### PR TITLE
Set up GitHub Actions CI/CD (build+test on PR, deploy to Azure App Service on merge)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,7 +53,7 @@ jobs:
           --output ${{ env.PUBLISH_DIR }}
 
       - name: Install EF Core CLI tools
-        run: dotnet tool install --global dotnet-ef
+        run: dotnet tool install --global dotnet-ef --version 9.*
 
       - name: Run EF Core migrations
         env:
@@ -62,6 +62,7 @@ jobs:
           dotnet ef database update
           --project src/ScrambleCoin.Infrastructure
           --startup-project src/ScrambleCoin.Web
+          --configuration Release
           --no-build
 
       - name: Deploy to Azure App Service

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,72 @@
+name: CD — Deploy to Azure App Service
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-test-deploy:
+    name: build-test-deploy
+    runs-on: ubuntu-latest
+
+    env:
+      DOTNET_NOLOGO: true
+      PUBLISH_DIR: ./publish
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build (Release)
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Run tests
+        run: >
+          dotnet test
+          --no-build
+          --configuration Release
+          --logger "trx;LogFileName=results.trx"
+          --results-directory ./TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-cd
+          path: ./TestResults/**/*.trx
+          retention-days: 14
+
+      - name: Publish web app
+        run: >
+          dotnet publish src/ScrambleCoin.Web/ScrambleCoin.Web.csproj
+          --no-build
+          --configuration Release
+          --output ${{ env.PUBLISH_DIR }}
+
+      - name: Install EF Core CLI tools
+        run: dotnet tool install --global dotnet-ef
+
+      - name: Run EF Core migrations
+        env:
+          ConnectionStrings__DefaultConnection: ${{ secrets.AZURE_SQL_CONNECTION_STRING }}
+        run: >
+          dotnet ef database update
+          --project src/ScrambleCoin.Infrastructure
+          --startup-project src/ScrambleCoin.Web
+          --no-build
+
+      - name: Deploy to Azure App Service
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: app-scramblecoin
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: ${{ env.PUBLISH_DIR }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Build (Release)
         run: dotnet build --no-restore --configuration Release
 
+      - name: Install Playwright browsers
+        run: pwsh tests/ScrambleCoin.E2E.Tests/bin/Release/net9.0/playwright.ps1 install --with-deps chromium
+
       - name: Run tests
         run: >
           dotnet test

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,8 @@ jobs:
           --configuration Release
           --logger "trx;LogFileName=results.trx"
           --results-directory ./TestResults
+          --collect:"XPlat Code Coverage"
+          --settings coverlet.runsettings
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,21 @@ jobs:
           --configuration Release
           --logger "trx;LogFileName=results.trx"
           --results-directory ./TestResults
+          --collect:"XPlat Code Coverage"
+          --settings coverlet.runsettings
+
+      - name: Generate coverage report
+        if: always()
+        run: |
+          dotnet tool install --global dotnet-reportgenerator-globaltool
+          reportgenerator \
+            -reports:"./TestResults/**/coverage.cobertura.xml" \
+            -targetdir:"./CoverageReport" \
+            -reporttypes:"HtmlInline_AzurePipelines;Cobertura;MarkdownSummaryGithub"
+
+      - name: Write coverage summary to job
+        if: always()
+        run: cat ./CoverageReport/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload test results
         if: always()
@@ -42,4 +57,12 @@ jobs:
         with:
           name: test-results
           path: ./TestResults/**/*.trx
+          retention-days: 14
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: ./CoverageReport/
           retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --configuration Release
 
+      - name: Install Playwright browsers
+        run: pwsh tests/ScrambleCoin.E2E.Tests/bin/Release/net9.0/playwright.ps1 install --with-deps chromium
+
       - name: Run tests
         run: >
           dotnet test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI — Build & Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    name: build-and-test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Run tests
+        run: >
+          dotnet test
+          --no-build
+          --configuration Release
+          --logger "trx;LogFileName=results.trx"
+          --results-directory ./TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: ./TestResults/**/*.trx
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
           --results-directory ./TestResults
           --collect:"XPlat Code Coverage"
           --settings coverlet.runsettings
+          --
+          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Threshold=85
+          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ThresholdType=line
+          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ThresholdStat=total
 
       - name: Generate coverage report
         if: always()

--- a/README.md
+++ b/README.md
@@ -178,6 +178,56 @@ dotnet run --project src/ScrambleCoin.Web
 
 ---
 
+## 🤖 GitHub Actions
+
+Two workflows run automatically on every PR and every merge to `main`.
+
+### Workflows
+
+| Workflow | File | Trigger | What it does |
+|---|---|---|---|
+| **CI — Build & Test** | `.github/workflows/ci.yml` | Pull request → `main` | Restores, builds (Release), runs all tests, uploads TRX results as artifact. Fails the PR if any test fails. |
+| **CD — Deploy** | `.github/workflows/cd.yml` | Push to `main` | Restores, builds (Release), runs all tests, publishes the web app, runs EF Core migrations against Azure SQL, deploys to Azure App Service. |
+
+> ⚠️ The CD pipeline will **not deploy** if any test fails — the test step runs before publish and deploy.
+
+---
+
+### Required GitHub Secrets
+
+Before the CD workflow can run you must add two repository secrets
+(**Settings → Secrets and variables → Actions → New repository secret**):
+
+| Secret name | Description |
+|---|---|
+| `AZURE_WEBAPP_PUBLISH_PROFILE` | The XML publish profile downloaded from Azure Portal (see below). |
+| `AZURE_SQL_CONNECTION_STRING` | Full ADO.NET connection string for the Azure SQL database, used by `dotnet ef database update`. |
+
+#### How to get the publish profile
+
+1. Open the [Azure Portal](https://portal.azure.com) and navigate to **App Services → app-scramblecoin**.
+2. Click **Get publish profile** in the top toolbar.
+3. A `.PublishSettings` XML file is downloaded — copy its **entire contents**.
+4. Paste the contents as the value of the `AZURE_WEBAPP_PUBLISH_PROFILE` secret in GitHub.
+
+#### Example `AZURE_SQL_CONNECTION_STRING` format
+
+```
+Server=tcp:sql-scramblecoin.database.windows.net,1433;Initial Catalog=sqldb-scramblecoin;Persist Security Info=False;User ID=<admin>;Password=<password>;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;
+```
+
+---
+
+### Branch protection (required status check)
+
+To block PR merges when tests fail, add `build-and-test` as a required status check:
+
+1. **Settings → Branches → Add branch protection rule** for `main`.
+2. Enable **Require status checks to pass before merging**.
+3. Search for and add `build-and-test`.
+
+---
+
 ## ☁️ Azure Deployment
 
 ### Prerequisites

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -5,6 +5,10 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
+          <!-- Enforce 85% line coverage across all source projects -->
+          <Threshold>85</Threshold>
+          <ThresholdType>line</ThresholdType>
+          <ThresholdStat>total</ThresholdStat>
           <!-- Exclude test projects, migrations, and program entry points -->
           <Exclude>[*.Tests]*,[*.E2E.Tests]*</Exclude>
           <ExcludeByFile>**/Migrations/**/*.cs,**/Program.cs</ExcludeByFile>

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <!-- Exclude test projects, migrations, and program entry points -->
+          <Exclude>[*.Tests]*,[*.E2E.Tests]*</Exclude>
+          <ExcludeByFile>**/Migrations/**/*.cs,**/Program.cs</ExcludeByFile>
+          <SingleHit>false</SingleHit>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/tests/ScrambleCoin.Web.Tests/CiCdWorkflowTests.cs
+++ b/tests/ScrambleCoin.Web.Tests/CiCdWorkflowTests.cs
@@ -1,0 +1,236 @@
+namespace ScrambleCoin.Web.Tests;
+
+/// <summary>
+/// Static-analysis tests for the GitHub Actions workflow YAML files introduced in Issue #4.
+/// These tests verify structural requirements of ci.yml and cd.yml without executing the
+/// workflows themselves — ensuring that required job names, SDK versions, steps, secrets,
+/// and deployment targets are present and correctly configured.
+/// </summary>
+public class CiCdWorkflowTests
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Walks up from the test-output directory until a <c>.github</c> folder is found,
+    /// then returns the path to <c>.github/workflows</c>.
+    /// </summary>
+    private static string FindWorkflowsDir()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".github")))
+            dir = dir.Parent;
+
+        if (dir is null)
+            throw new InvalidOperationException(
+                "Could not locate the .github directory by walking up from the test output directory.");
+
+        return Path.Combine(dir.FullName, ".github", "workflows");
+    }
+
+    private static string ReadWorkflow(string fileName)
+    {
+        var path = Path.Combine(FindWorkflowsDir(), fileName);
+        Assert.True(File.Exists(path), $"Workflow file not found: {path}");
+        return File.ReadAllText(path);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ci.yml — Pull Request checks
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// <summary>Test 1 — The CI workflow is triggered by pull requests targeting main.</summary>
+    [Fact]
+    public void CiWorkflow_TriggersOnPullRequestToMain()
+    {
+        var yaml = ReadWorkflow("ci.yml");
+
+        Assert.Contains("pull_request", yaml, StringComparison.Ordinal);
+        Assert.Contains("branches:", yaml, StringComparison.Ordinal);
+        Assert.Contains("main", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>Test 2 — The CI workflow uses .NET 9 SDK.</summary>
+    [Fact]
+    public void CiWorkflow_UsesNET9Sdk()
+    {
+        var yaml = ReadWorkflow("ci.yml");
+
+        Assert.Contains("dotnet-version: '9.0.x'", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>Test 3 — The CI workflow runs <c>dotnet test</c>.</summary>
+    [Fact]
+    public void CiWorkflow_RunsDotnetTest()
+    {
+        var yaml = ReadWorkflow("ci.yml");
+
+        Assert.Contains("dotnet test", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Test 4 — The CI job is named <c>build-and-test</c>, matching the required status-check
+    /// name that must be configured in the branch protection rule for <c>main</c>.
+    /// </summary>
+    [Fact]
+    public void CiWorkflow_JobNameIsBuildAndTest()
+    {
+        var yaml = ReadWorkflow("ci.yml");
+
+        Assert.Contains("build-and-test", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>Test 5 — The CI workflow uploads test results as a workflow artifact.</summary>
+    [Fact]
+    public void CiWorkflow_UploadsTestResultsArtifact()
+    {
+        var yaml = ReadWorkflow("ci.yml");
+
+        Assert.Contains("upload-artifact", yaml, StringComparison.Ordinal);
+        Assert.Contains("TestResults", yaml, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Test 6 — The CI workflow builds and tests in Release configuration.</summary>
+    [Fact]
+    public void CiWorkflow_BuildsInReleaseConfiguration()
+    {
+        var yaml = ReadWorkflow("ci.yml");
+
+        Assert.Contains("--configuration Release", yaml, StringComparison.Ordinal);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // cd.yml — Deploy on merge to main
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// <summary>Test 7 — The CD workflow is triggered by pushes to main.</summary>
+    [Fact]
+    public void CdWorkflow_TriggersOnPushToMain()
+    {
+        var yaml = ReadWorkflow("cd.yml");
+
+        Assert.Contains("push:", yaml, StringComparison.Ordinal);
+        Assert.Contains("branches:", yaml, StringComparison.Ordinal);
+        Assert.Contains("main", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>Test 8 — The CD workflow uses .NET 9 SDK.</summary>
+    [Fact]
+    public void CdWorkflow_UsesNET9Sdk()
+    {
+        var yaml = ReadWorkflow("cd.yml");
+
+        Assert.Contains("dotnet-version: '9.0.x'", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>Test 9 — The CD workflow runs <c>dotnet test</c> before deploying.</summary>
+    [Fact]
+    public void CdWorkflow_RunsDotnetTest()
+    {
+        var yaml = ReadWorkflow("cd.yml");
+
+        Assert.Contains("dotnet test", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>Test 10 — The CD workflow publishes the ScrambleCoin.Web project.</summary>
+    [Fact]
+    public void CdWorkflow_PublishesWebApp()
+    {
+        var yaml = ReadWorkflow("cd.yml");
+
+        Assert.Contains("dotnet publish", yaml, StringComparison.Ordinal);
+        Assert.Contains("ScrambleCoin.Web", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>Test 11 — The CD workflow installs the EF Core global CLI tool.</summary>
+    [Fact]
+    public void CdWorkflow_InstallsEfCoreTool()
+    {
+        var yaml = ReadWorkflow("cd.yml");
+
+        Assert.Contains("dotnet tool install", yaml, StringComparison.Ordinal);
+        Assert.Contains("dotnet-ef", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Test 12 — The EF Core CLI tool is pinned to a version-9 release
+    /// (<c>--version 9.*</c>) so minor/patch updates are accepted automatically
+    /// while a future major upgrade remains a deliberate choice.
+    /// </summary>
+    [Fact]
+    public void CdWorkflow_EfToolPinnedToVersion9()
+    {
+        var yaml = ReadWorkflow("cd.yml");
+
+        Assert.Contains("--version 9.", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>Test 13 — The CD workflow runs EF Core database migrations.</summary>
+    [Fact]
+    public void CdWorkflow_RunsMigrations()
+    {
+        var yaml = ReadWorkflow("cd.yml");
+
+        Assert.Contains("dotnet ef database update", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Test 14 — The EF Core migration step uses Release configuration, ensuring it
+    /// resolves the same startup project build output as the publish step.
+    /// </summary>
+    [Fact]
+    public void CdWorkflow_MigrationsUseReleaseConfiguration()
+    {
+        var yaml = ReadWorkflow("cd.yml");
+
+        // Verify both tokens appear in the file — the migration step carries
+        // --configuration Release alongside the dotnet ef database update command.
+        var migrationIndex = yaml.IndexOf("dotnet ef database update", StringComparison.Ordinal);
+        Assert.True(migrationIndex >= 0, "'dotnet ef database update' not found in cd.yml.");
+
+        // Look for '--configuration Release' anywhere after the migration command
+        // (multi-line YAML scalar: the flag appears on a subsequent line of the same step).
+        var releaseIndex = yaml.IndexOf("--configuration Release", migrationIndex, StringComparison.Ordinal);
+        Assert.True(
+            releaseIndex >= 0,
+            "'--configuration Release' was not found after 'dotnet ef database update' in cd.yml.");
+    }
+
+    /// <summary>
+    /// Test 15 — The CD workflow deploys to Azure App Service using the
+    /// <c>azure/webapps-deploy</c> action targeting the <c>app-scramblecoin</c> app.
+    /// </summary>
+    [Fact]
+    public void CdWorkflow_DeploysToAzureWebApp()
+    {
+        var yaml = ReadWorkflow("cd.yml");
+
+        Assert.Contains("azure/webapps-deploy", yaml, StringComparison.Ordinal);
+        Assert.Contains("app-scramblecoin", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Test 16 — The CD workflow reads the Azure App Service publish profile from the
+    /// <c>AZURE_WEBAPP_PUBLISH_PROFILE</c> repository secret, ensuring deployment
+    /// credentials are never hard-coded.
+    /// </summary>
+    [Fact]
+    public void CdWorkflow_UsesPublishProfileSecret()
+    {
+        var yaml = ReadWorkflow("cd.yml");
+
+        Assert.Contains("AZURE_WEBAPP_PUBLISH_PROFILE", yaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Test 17 — The CD workflow injects the SQL Server connection string from the
+    /// <c>AZURE_SQL_CONNECTION_STRING</c> repository secret so that EF Core migrations
+    /// target the production database without exposing credentials in the workflow file.
+    /// </summary>
+    [Fact]
+    public void CdWorkflow_UsesSqlConnectionStringSecret()
+    {
+        var yaml = ReadWorkflow("cd.yml");
+
+        Assert.Contains("AZURE_SQL_CONNECTION_STRING", yaml, StringComparison.Ordinal);
+    }
+}

--- a/tests/ScrambleCoin.Web.Tests/InfrastructureTemplateTests.cs
+++ b/tests/ScrambleCoin.Web.Tests/InfrastructureTemplateTests.cs
@@ -100,7 +100,8 @@ public class InfrastructureTemplateTests
     {
         var content = File.ReadAllText(BicepFilePath);
 
-        Assert.Contains("DOTNETCORE|9.0", content, StringComparison.Ordinal);
+        Assert.Contains("netFrameworkVersion", content, StringComparison.Ordinal);
+        Assert.Contains("v9.0", content, StringComparison.Ordinal);
     }
 
     // ── Security: @secure() decorator & no hardcoded password ────────────────


### PR DESCRIPTION
## Summary
Closes #4.

## Changes
- `.github/workflows/ci.yml`: CI workflow — triggers on PR to `main`; checkout → .NET 9 → restore → build Release → test → upload TRX artifact. Job name `build-and-test` for required status check.
- `.github/workflows/cd.yml`: CD workflow — triggers on push to `main`; build → test → publish → EF migrations (dotnet-ef pinned to 9.*) → deploy to `app-scramblecoin` via publish profile.
- `README.md`: GitHub Actions section documenting both workflows, required secrets, publish profile instructions, and branch protection setup.
- `tests/ScrambleCoin.Web.Tests/CiCdWorkflowTests.cs`: 17 static-analysis tests covering both workflow files.
- `tests/ScrambleCoin.Web.Tests/InfrastructureTemplateTests.cs`: Updated `BicepFile_UsesDotNet9Runtime` for Windows stack (`netFrameworkVersion` instead of `DOTNETCORE|9.0`).

## Testing
- Static analysis tests: 17 added (CiCdWorkflowTests.cs)
- Total: 42 tests in Web.Tests, 0 failures ✅

## Manual test plan
See: https://github.com/NickThys3012/CodeRetreat_ScrambleCoin/issues/4#issuecomment-4321875547

> ⚠️ Prerequisites before running the manual plan: set `AZURE_WEBAPP_PUBLISH_PROFILE` and `AZURE_SQL_CONNECTION_STRING` secrets in repo Settings, and ensure Azure resources are deployed.

## Review cycles
- Implementation: 1 cycle (pinned dotnet-ef to 9.*, added --configuration Release to migration step)
- Tests: 0 cycles