### PR TITLE
Piece domain model

### DIFF
--- a/src/ScrambleCoin.Domain/Entities/Piece.cs
+++ b/src/ScrambleCoin.Domain/Entities/Piece.cs
@@ -1,21 +1,111 @@
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Exceptions;
+using ScrambleCoin.Domain.ValueObjects;
+
 namespace ScrambleCoin.Domain.Entities;
 
 /// <summary>
-/// A player's piece that can occupy a tile.
+/// A player's piece that can be placed on the board and moved around.
 /// </summary>
 public sealed class Piece
 {
+    /// <summary>Unique identifier for this piece.</summary>
     public Guid Id { get; }
 
-    /// <summary>The name of the player who owns this piece.</summary>
-    public string Owner { get; }
+    /// <summary>Display name of the piece (e.g. "Knight", "Scout").</summary>
+    public string Name { get; }
 
-    public Piece(Guid id, string owner)
+    /// <summary>Identifier of the player who owns this piece.</summary>
+    public Guid PlayerId { get; }
+
+    /// <summary>
+    /// Current board position; <c>null</c> when the piece has not yet been placed.
+    /// </summary>
+    public Position? Position { get; private set; }
+
+    /// <summary>Determines which tiles are valid entry points when placing this piece.</summary>
+    public EntryPointType EntryPointType { get; }
+
+    /// <summary>Determines the directions in which this piece may move.</summary>
+    public MovementType MovementType { get; }
+
+    /// <summary>
+    /// Maximum number of tiles this piece may move in a single move action.
+    /// The player may choose any distance from 1 up to this value.
+    /// Must be at least 1.
+    /// </summary>
+    public int MaxDistance { get; }
+
+    /// <summary>
+    /// Number of move actions this piece must perform each turn.
+    /// When greater than 1 all moves must be used — partial use is not allowed.
+    /// Must be at least 1.
+    /// </summary>
+    public int MovesPerTurn { get; }
+
+    /// <summary>Returns <c>true</c> when the piece has been placed on the board.</summary>
+    public bool IsOnBoard => Position is not null;
+
+    /// <param name="id">Unique piece identifier.</param>
+    /// <param name="name">Display name — must not be null or whitespace.</param>
+    /// <param name="playerId">Owner player identifier.</param>
+    /// <param name="entryPointType">Where the piece may be placed when entering the board.</param>
+    /// <param name="movementType">Allowed movement directions.</param>
+    /// <param name="maxDistance">Maximum tiles per move action; must be ≥ 1.</param>
+    /// <param name="movesPerTurn">Move actions per turn; must be ≥ 1.</param>
+    public Piece(
+        Guid id,
+        string name,
+        Guid playerId,
+        EntryPointType entryPointType,
+        MovementType movementType,
+        int maxDistance,
+        int movesPerTurn)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        if (string.IsNullOrWhiteSpace(name))
+            throw new DomainException("Piece name must not be null or whitespace.");
+
+        if (maxDistance < 1)
+            throw new DomainException($"MaxDistance must be at least 1, but was {maxDistance}.");
+
+        if (movesPerTurn < 1)
+            throw new DomainException($"MovesPerTurn must be at least 1, but was {movesPerTurn}.");
+
         Id = id;
-        Owner = owner;
+        Name = name;
+        PlayerId = playerId;
+        EntryPointType = entryPointType;
+        MovementType = movementType;
+        MaxDistance = maxDistance;
+        MovesPerTurn = movesPerTurn;
     }
 
-    public Piece(string owner) : this(Guid.NewGuid(), owner) { }
+    /// <summary>
+    /// Convenience constructor that generates a new <see cref="Id"/>.
+    /// </summary>
+    public Piece(
+        string name,
+        Guid playerId,
+        EntryPointType entryPointType,
+        MovementType movementType,
+        int maxDistance,
+        int movesPerTurn)
+        : this(Guid.NewGuid(), name, playerId, entryPointType, movementType, maxDistance, movesPerTurn)
+    {
+    }
+
+    /// <summary>Places this piece at the given board position.</summary>
+    /// <exception cref="DomainException">Thrown when <paramref name="position"/> is null.</exception>
+    public void PlaceAt(Position position)
+    {
+        if (position is null)
+            throw new DomainException("Position must not be null.");
+        Position = position;
+    }
+
+    /// <summary>Removes this piece from the board; <see cref="Position"/> becomes <c>null</c>.</summary>
+    public void RemoveFromBoard()
+    {
+        Position = null;
+    }
 }

--- a/src/ScrambleCoin.Domain/Enums/EntryPointType.cs
+++ b/src/ScrambleCoin.Domain/Enums/EntryPointType.cs
@@ -1,0 +1,16 @@
+namespace ScrambleCoin.Domain.Enums;
+
+/// <summary>
+/// Determines which tiles a piece may use when entering the board.
+/// </summary>
+public enum EntryPointType
+{
+    /// <summary>The piece may be placed on any edge tile of the board.</summary>
+    Borders,
+
+    /// <summary>The piece may only be placed on one of the 4 corner tiles.</summary>
+    Corners,
+
+    /// <summary>The piece may be placed on any free tile on the board.</summary>
+    Anywhere
+}

--- a/src/ScrambleCoin.Domain/Enums/MovementType.cs
+++ b/src/ScrambleCoin.Domain/Enums/MovementType.cs
@@ -1,0 +1,16 @@
+namespace ScrambleCoin.Domain.Enums;
+
+/// <summary>
+/// Determines the directions in which a piece may move.
+/// </summary>
+public enum MovementType
+{
+    /// <summary>The piece may move up, down, left, or right (cardinal directions).</summary>
+    Orthogonal,
+
+    /// <summary>The piece may move along the four diagonal directions.</summary>
+    Diagonal,
+
+    /// <summary>The piece may move in any direction (orthogonal or diagonal).</summary>
+    AnyDirection
+}

--- a/src/ScrambleCoin.Domain/ValueObjects/Lineup.cs
+++ b/src/ScrambleCoin.Domain/ValueObjects/Lineup.cs
@@ -1,0 +1,83 @@
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Exceptions;
+
+namespace ScrambleCoin.Domain.ValueObjects;
+
+/// <summary>
+/// An immutable, ordered selection of exactly 5 <see cref="Piece"/> instances chosen by a player
+/// before the game starts.
+/// </summary>
+/// <remarks>
+/// Equality is order-dependent: two <see cref="Lineup"/> instances are equal only when they contain
+/// the same piece Ids in the same order. This mirrors the fact that position within the lineup
+/// may be meaningful to the player (e.g. preferred deployment order).
+/// </remarks>
+public sealed class Lineup : IEquatable<Lineup>
+{
+    /// <summary>The required number of pieces in a lineup.</summary>
+    public const int RequiredPieceCount = 5;
+
+    /// <summary>The ordered list of pieces in this lineup.</summary>
+    public IReadOnlyList<Piece> Pieces { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="Lineup"/> from the given collection of pieces.
+    /// </summary>
+    /// <param name="pieces">
+    /// Must contain exactly <see cref="RequiredPieceCount"/> non-null pieces with unique Ids.
+    /// </param>
+    /// <exception cref="DomainException">
+    /// Thrown when the collection does not meet the invariants above.
+    /// </exception>
+    public Lineup(IEnumerable<Piece> pieces)
+    {
+        if (pieces is null)
+            throw new DomainException("Pieces collection must not be null.");
+
+        var list = pieces.ToList();
+
+        if (list.Count != RequiredPieceCount)
+            throw new DomainException(
+                $"A lineup must contain exactly {RequiredPieceCount} pieces, but {list.Count} were provided.");
+
+        for (var i = 0; i < list.Count; i++)
+        {
+            if (list[i] is null)
+                throw new DomainException($"Piece at index {i} must not be null.");
+        }
+
+        var ids = list.Select(p => p.Id).ToList();
+        var duplicates = ids.GroupBy(id => id).Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+        if (duplicates.Count > 0)
+            throw new DomainException(
+                $"A lineup must not contain duplicate pieces. Duplicate Id(s): {string.Join(", ", duplicates)}.");
+
+        Pieces = list.AsReadOnly();
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>Equality is order-dependent and based on piece Ids.</remarks>
+    public bool Equals(Lineup? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Pieces.Select(p => p.Id).SequenceEqual(other.Pieces.Select(p => p.Id));
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is Lineup l && Equals(l);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var piece in Pieces)
+            hash.Add(piece.Id);
+        return hash.ToHashCode();
+    }
+
+    public static bool operator ==(Lineup? left, Lineup? right) =>
+        left is null ? right is null : left.Equals(right);
+
+    public static bool operator !=(Lineup? left, Lineup? right) => !(left == right);
+}

--- a/tests/ScrambleCoin.Domain.Tests/BoardTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/BoardTests.cs
@@ -2,6 +2,7 @@ using ScrambleCoin.Domain.Entities;
 using ScrambleCoin.Domain.Enums;
 using ScrambleCoin.Domain.Exceptions;
 using ScrambleCoin.Domain.Obstacles;
+using ScrambleCoin.Domain.Tests.Helpers;
 using ScrambleCoin.Domain.ValueObjects;
 
 namespace ScrambleCoin.Domain.Tests;
@@ -273,7 +274,7 @@ public class BoardTests
     {
         var board = new Board();
         var tile = board.GetTile(new Position(1, 1));
-        tile.SetOccupant(new Piece("Alice"));
+        tile.SetOccupant(PieceFactory.Any("Alice"));
         Assert.Empty(board.GetAllCoins());
     }
 
@@ -282,7 +283,7 @@ public class BoardTests
     {
         var board = new Board();
         board.GetTile(new Position(0, 0)).SetOccupant(new Coin(CoinType.Gold));
-        board.GetTile(new Position(1, 1)).SetOccupant(new Piece("Bob"));
+        board.GetTile(new Position(1, 1)).SetOccupant(PieceFactory.Any("Bob"));
         var coins = board.GetAllCoins();
         Assert.Single(coins);
         Assert.NotNull(coins[0].AsCoin);
@@ -319,7 +320,7 @@ public class BoardTests
     public void GetAllOccupiedTiles_WithPiece_ShouldReturnTile()
     {
         var board = new Board();
-        board.GetTile(new Position(0, 0)).SetOccupant(new Piece("Alice"));
+        board.GetTile(new Position(0, 0)).SetOccupant(PieceFactory.Any("Alice"));
         Assert.Single(board.GetAllOccupiedTiles());
     }
 
@@ -328,7 +329,7 @@ public class BoardTests
     {
         var board = new Board();
         board.GetTile(new Position(0, 0)).SetOccupant(new Coin(CoinType.Silver));
-        board.GetTile(new Position(1, 1)).SetOccupant(new Piece("Alice"));
+        board.GetTile(new Position(1, 1)).SetOccupant(PieceFactory.Any("Alice"));
         board.GetTile(new Position(2, 2)).SetOccupant(new Coin(CoinType.Gold));
         Assert.Equal(3, board.GetAllOccupiedTiles().Count);
     }

--- a/tests/ScrambleCoin.Domain.Tests/Helpers/PieceFactory.cs
+++ b/tests/ScrambleCoin.Domain.Tests/Helpers/PieceFactory.cs
@@ -1,0 +1,25 @@
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+
+namespace ScrambleCoin.Domain.Tests.Helpers;
+
+/// <summary>
+/// Test helper that creates <see cref="Piece"/> instances with sensible defaults,
+/// replacing the removed <c>Piece(string name)</c> convenience constructor.
+/// </summary>
+internal static class PieceFactory
+{
+    /// <summary>
+    /// Creates a fully valid <see cref="Piece"/> with sensible test defaults.
+    /// </summary>
+    /// <param name="name">Display name for the piece. Defaults to "TestPiece".</param>
+    internal static Piece Any(string name = "TestPiece") =>
+        new Piece(
+            id: Guid.NewGuid(),
+            name: name,
+            playerId: Guid.NewGuid(),
+            entryPointType: EntryPointType.Borders,
+            movementType: MovementType.Orthogonal,
+            maxDistance: 3,
+            movesPerTurn: 1);
+}

--- a/tests/ScrambleCoin.Domain.Tests/LineupTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/LineupTests.cs
@@ -1,0 +1,303 @@
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Exceptions;
+using ScrambleCoin.Domain.Tests.Helpers;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Domain.Tests;
+
+public class LineupTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>Creates N distinct valid pieces, each owned by a different player.</summary>
+    private static List<Piece> MakePieces(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => PieceFactory.Any($"Piece{i}"))
+            .ToList();
+
+    // ── Valid construction ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithExactlyFiveUniquePieces_Succeeds()
+    {
+        var pieces = MakePieces(5);
+
+        var lineup = new Lineup(pieces);
+
+        Assert.NotNull(lineup);
+    }
+
+    [Fact]
+    public void Constructor_WithExactlyFivePieces_PiecesHasFiveItems()
+    {
+        var pieces = MakePieces(5);
+
+        var lineup = new Lineup(pieces);
+
+        Assert.Equal(5, lineup.Pieces.Count);
+    }
+
+    [Fact]
+    public void Constructor_PreservesOrderOfPieces()
+    {
+        var pieces = MakePieces(5);
+
+        var lineup = new Lineup(pieces);
+
+        for (var i = 0; i < 5; i++)
+            Assert.Equal(pieces[i].Id, lineup.Pieces[i].Id);
+    }
+
+    // ── Null collection ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithNullCollection_ThrowsDomainException()
+    {
+        Assert.Throws<DomainException>(() => new Lineup(null!));
+    }
+
+    // ── Wrong piece count ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithFourPieces_ThrowsDomainException()
+    {
+        var pieces = MakePieces(4);
+
+        Assert.Throws<DomainException>(() => new Lineup(pieces));
+    }
+
+    [Fact]
+    public void Constructor_WithSixPieces_ThrowsDomainException()
+    {
+        var pieces = MakePieces(6);
+
+        Assert.Throws<DomainException>(() => new Lineup(pieces));
+    }
+
+    [Fact]
+    public void Constructor_WithZeroPieces_ThrowsDomainException()
+    {
+        Assert.Throws<DomainException>(() => new Lineup(Enumerable.Empty<Piece>()));
+    }
+
+    // ── Null pieces in the collection ─────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithFirstPieceNull_ThrowsDomainException()
+    {
+        var pieces = MakePieces(5);
+        pieces[0] = null!;
+
+        Assert.Throws<DomainException>(() => new Lineup(pieces));
+    }
+
+    [Fact]
+    public void Constructor_WithMiddlePieceNull_ThrowsDomainException()
+    {
+        var pieces = MakePieces(5);
+        pieces[2] = null!;
+
+        Assert.Throws<DomainException>(() => new Lineup(pieces));
+    }
+
+    [Fact]
+    public void Constructor_WithLastPieceNull_ThrowsDomainException()
+    {
+        var pieces = MakePieces(5);
+        pieces[4] = null!;
+
+        Assert.Throws<DomainException>(() => new Lineup(pieces));
+    }
+
+    // ── Duplicate piece IDs ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithDuplicatePieceIds_ThrowsDomainException()
+    {
+        var pieces = MakePieces(4);
+        // Add the first piece again — same Id, same reference
+        pieces.Add(pieces[0]);
+
+        Assert.Throws<DomainException>(() => new Lineup(pieces));
+    }
+
+    [Fact]
+    public void Constructor_WithAllSamePiece_ThrowsDomainException()
+    {
+        var single = PieceFactory.Any("Duplicate");
+        var pieces = Enumerable.Repeat(single, 5).ToList();
+
+        Assert.Throws<DomainException>(() => new Lineup(pieces));
+    }
+
+    // ── Equals (order-dependent, ID-based) ───────────────────────────────────
+
+    [Fact]
+    public void Equals_SameFivePiecesInSameOrder_ReturnsTrue()
+    {
+        var pieces = MakePieces(5);
+        var lineup1 = new Lineup(pieces);
+        var lineup2 = new Lineup(pieces);
+
+        Assert.True(lineup1.Equals(lineup2));
+    }
+
+    [Fact]
+    public void Equals_SameFivePiecesInDifferentOrder_ReturnsFalse()
+    {
+        var pieces = MakePieces(5);
+        var lineup1 = new Lineup(pieces);
+
+        // Reverse the list to guarantee a different order
+        var reordered = pieces.AsEnumerable().Reverse().ToList();
+        var lineup2 = new Lineup(reordered);
+
+        Assert.False(lineup1.Equals(lineup2));
+    }
+
+    [Fact]
+    public void Equals_WithNull_ReturnsFalse()
+    {
+        var lineup = new Lineup(MakePieces(5));
+
+        Assert.False(lineup.Equals(null));
+    }
+
+    [Fact]
+    public void Equals_WithSelf_ReturnsTrue()
+    {
+        var lineup = new Lineup(MakePieces(5));
+
+        Assert.True(lineup.Equals(lineup));
+    }
+
+    [Fact]
+    public void EqualsObject_WithEqualLineup_ReturnsTrue()
+    {
+        var pieces = MakePieces(5);
+        var lineup1 = new Lineup(pieces);
+        var lineup2 = new Lineup(pieces);
+
+        Assert.True(lineup1.Equals((object)lineup2));
+    }
+
+    [Fact]
+    public void EqualsObject_WithNonLineupObject_ReturnsFalse()
+    {
+        var lineup = new Lineup(MakePieces(5));
+
+        Assert.False(lineup.Equals("not a lineup"));
+    }
+
+    // ── Equality operators ────────────────────────────────────────────────────
+
+    [Fact]
+    public void EqualityOperator_ForEqualLineups_ReturnsTrue()
+    {
+        var pieces = MakePieces(5);
+        var lineup1 = new Lineup(pieces);
+        var lineup2 = new Lineup(pieces);
+
+        Assert.True(lineup1 == lineup2);
+    }
+
+    [Fact]
+    public void EqualityOperator_ForDifferentLineups_ReturnsFalse()
+    {
+        var pieces = MakePieces(5);
+        var lineup1 = new Lineup(pieces);
+        var lineup2 = new Lineup(pieces.AsEnumerable().Reverse().ToList());
+
+        Assert.False(lineup1 == lineup2);
+    }
+
+    [Fact]
+    public void InequalityOperator_ForDifferentLineups_ReturnsTrue()
+    {
+        var pieces = MakePieces(5);
+        var lineup1 = new Lineup(pieces);
+        var lineup2 = new Lineup(pieces.AsEnumerable().Reverse().ToList());
+
+        Assert.True(lineup1 != lineup2);
+    }
+
+    [Fact]
+    public void InequalityOperator_ForEqualLineups_ReturnsFalse()
+    {
+        var pieces = MakePieces(5);
+        var lineup1 = new Lineup(pieces);
+        var lineup2 = new Lineup(pieces);
+
+        Assert.False(lineup1 != lineup2);
+    }
+
+    [Fact]
+    public void EqualityOperator_BothNull_ReturnsTrue()
+    {
+        Lineup? left = null;
+        Lineup? right = null;
+
+        Assert.True(left == right);
+    }
+
+    [Fact]
+    public void EqualityOperator_LeftNull_ReturnsFalse()
+    {
+        Lineup? left = null;
+        var right = new Lineup(MakePieces(5));
+
+        Assert.False(left == right);
+    }
+
+    [Fact]
+    public void EqualityOperator_RightNull_ReturnsFalse()
+    {
+        var left = new Lineup(MakePieces(5));
+        Lineup? right = null;
+
+        Assert.False(left == right);
+    }
+
+    // ── GetHashCode ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetHashCode_ForEqualLineups_IsConsistent()
+    {
+        var pieces = MakePieces(5);
+        var lineup1 = new Lineup(pieces);
+        var lineup2 = new Lineup(pieces);
+
+        Assert.Equal(lineup1.GetHashCode(), lineup2.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_CalledTwiceOnSameInstance_ReturnsSameValue()
+    {
+        var lineup = new Lineup(MakePieces(5));
+
+        Assert.Equal(lineup.GetHashCode(), lineup.GetHashCode());
+    }
+
+    // ── Pieces is read-only ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Pieces_PropertyType_IsIReadOnlyList()
+    {
+        var lineup = new Lineup(MakePieces(5));
+
+        Assert.IsAssignableFrom<IReadOnlyList<Piece>>(lineup.Pieces);
+    }
+
+    [Fact]
+    public void Pieces_IsNotDirectlyCastableToList_SoCannotBeModifiedByCallers()
+    {
+        var lineup = new Lineup(MakePieces(5));
+
+        // AsReadOnly() returns a ReadOnlyCollection<T>, not a List<T>.
+        // Mutating operations (Add, Remove) throw NotSupportedException at runtime,
+        // and the type is not directly castable to List<Piece>.
+        var castSucceeded = lineup.Pieces is List<Piece>;
+        Assert.False(castSucceeded);
+    }
+}

--- a/tests/ScrambleCoin.Domain.Tests/PieceTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/PieceTests.cs
@@ -1,0 +1,338 @@
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Exceptions;
+using ScrambleCoin.Domain.Tests.Helpers;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Domain.Tests;
+
+public class PieceTests
+{
+    // ── Construction (explicit-Id constructor) ────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithExplicitId_StoresIdCorrectly()
+    {
+        var id = Guid.NewGuid();
+        var playerId = Guid.NewGuid();
+        var piece = new Piece(id, "Mickey Mouse", playerId,
+            EntryPointType.Borders, MovementType.Orthogonal, 3, 1);
+
+        Assert.Equal(id, piece.Id);
+    }
+
+    [Fact]
+    public void Constructor_StoresNameCorrectly()
+    {
+        var piece = new Piece(Guid.NewGuid(), "Mickey Mouse", Guid.NewGuid(),
+            EntryPointType.Borders, MovementType.Orthogonal, 3, 1);
+
+        Assert.Equal("Mickey Mouse", piece.Name);
+    }
+
+    [Fact]
+    public void Constructor_StoresPlayerIdCorrectly()
+    {
+        var playerId = Guid.NewGuid();
+        var piece = new Piece(Guid.NewGuid(), "Mickey Mouse", playerId,
+            EntryPointType.Borders, MovementType.Orthogonal, 3, 1);
+
+        Assert.Equal(playerId, piece.PlayerId);
+    }
+
+    [Fact]
+    public void Constructor_StoresEntryPointTypeCorrectly()
+    {
+        var piece = new Piece(Guid.NewGuid(), "Donald Duck", Guid.NewGuid(),
+            EntryPointType.Corners, MovementType.Orthogonal, 3, 1);
+
+        Assert.Equal(EntryPointType.Corners, piece.EntryPointType);
+    }
+
+    [Fact]
+    public void Constructor_StoresMovementTypeCorrectly()
+    {
+        var piece = new Piece(Guid.NewGuid(), "Donald Duck", Guid.NewGuid(),
+            EntryPointType.Corners, MovementType.Diagonal, 3, 1);
+
+        Assert.Equal(MovementType.Diagonal, piece.MovementType);
+    }
+
+    [Fact]
+    public void Constructor_StoresMaxDistanceCorrectly()
+    {
+        var piece = new Piece(Guid.NewGuid(), "Mickey Mouse", Guid.NewGuid(),
+            EntryPointType.Borders, MovementType.Orthogonal, 3, 1);
+
+        Assert.Equal(3, piece.MaxDistance);
+    }
+
+    [Fact]
+    public void Constructor_StoresMovesPerTurnCorrectly()
+    {
+        var piece = new Piece(Guid.NewGuid(), "Mickey Mouse", Guid.NewGuid(),
+            EntryPointType.Borders, MovementType.Orthogonal, 3, 1);
+
+        Assert.Equal(1, piece.MovesPerTurn);
+    }
+
+    // ── Auto-generated Id constructor ─────────────────────────────────────────
+
+    [Fact]
+    public void AutoIdConstructor_GivesEachPieceAUniqueId()
+    {
+        var playerId = Guid.NewGuid();
+        var piece1 = new Piece("Piece A", playerId, EntryPointType.Borders, MovementType.Orthogonal, 3, 1);
+        var piece2 = new Piece("Piece B", playerId, EntryPointType.Borders, MovementType.Orthogonal, 3, 1);
+
+        Assert.NotEqual(piece1.Id, piece2.Id);
+    }
+
+    [Fact]
+    public void AutoIdConstructor_GeneratesNonEmptyId()
+    {
+        var piece = new Piece("Piece A", Guid.NewGuid(), EntryPointType.Borders, MovementType.Orthogonal, 3, 1);
+
+        Assert.NotEqual(Guid.Empty, piece.Id);
+    }
+
+    // ── Validation: name ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithNullName_ThrowsDomainException()
+    {
+        var ex = Assert.Throws<DomainException>(() =>
+            new Piece(Guid.NewGuid(), null!, Guid.NewGuid(),
+                EntryPointType.Borders, MovementType.Orthogonal, 3, 1));
+
+        Assert.False(string.IsNullOrWhiteSpace(ex.Message));
+    }
+
+    [Fact]
+    public void Constructor_WithWhitespaceName_ThrowsDomainException()
+    {
+        Assert.Throws<DomainException>(() =>
+            new Piece(Guid.NewGuid(), "   ", Guid.NewGuid(),
+                EntryPointType.Borders, MovementType.Orthogonal, 3, 1));
+    }
+
+    [Fact]
+    public void Constructor_WithEmptyName_ThrowsDomainException()
+    {
+        Assert.Throws<DomainException>(() =>
+            new Piece(Guid.NewGuid(), string.Empty, Guid.NewGuid(),
+                EntryPointType.Borders, MovementType.Orthogonal, 3, 1));
+    }
+
+    // ── Validation: maxDistance ───────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithMaxDistanceZero_ThrowsDomainException()
+    {
+        Assert.Throws<DomainException>(() =>
+            new Piece(Guid.NewGuid(), "Mickey Mouse", Guid.NewGuid(),
+                EntryPointType.Borders, MovementType.Orthogonal, maxDistance: 0, movesPerTurn: 1));
+    }
+
+    [Fact]
+    public void Constructor_WithMaxDistanceNegative_ThrowsDomainException()
+    {
+        Assert.Throws<DomainException>(() =>
+            new Piece(Guid.NewGuid(), "Mickey Mouse", Guid.NewGuid(),
+                EntryPointType.Borders, MovementType.Orthogonal, maxDistance: -1, movesPerTurn: 1));
+    }
+
+    [Fact]
+    public void Constructor_WithMaxDistanceOne_Succeeds()
+    {
+        var piece = new Piece(Guid.NewGuid(), "Anna", Guid.NewGuid(),
+            EntryPointType.Borders, MovementType.Orthogonal, maxDistance: 1, movesPerTurn: 1);
+
+        Assert.Equal(1, piece.MaxDistance);
+    }
+
+    // ── Validation: movesPerTurn ──────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithMovesPerTurnZero_ThrowsDomainException()
+    {
+        Assert.Throws<DomainException>(() =>
+            new Piece(Guid.NewGuid(), "Mickey Mouse", Guid.NewGuid(),
+                EntryPointType.Borders, MovementType.Orthogonal, maxDistance: 3, movesPerTurn: 0));
+    }
+
+    [Fact]
+    public void Constructor_WithMovesPerTurnNegative_ThrowsDomainException()
+    {
+        Assert.Throws<DomainException>(() =>
+            new Piece(Guid.NewGuid(), "Mickey Mouse", Guid.NewGuid(),
+                EntryPointType.Borders, MovementType.Orthogonal, maxDistance: 3, movesPerTurn: -1));
+    }
+
+    // ── MovesPerTurn > 1 (Anna-style piece) ───────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithMovesPerTurnGreaterThanOne_StoresValueCorrectly()
+    {
+        var piece = new Piece(Guid.NewGuid(), "Anna", Guid.NewGuid(),
+            EntryPointType.Borders, MovementType.Orthogonal, maxDistance: 1, movesPerTurn: 3);
+
+        Assert.Equal(3, piece.MovesPerTurn);
+    }
+
+    [Fact]
+    public void Constructor_AnnaStylePiece_HasMaxDistanceOne()
+    {
+        var piece = new Piece(Guid.NewGuid(), "Anna", Guid.NewGuid(),
+            EntryPointType.Borders, MovementType.Orthogonal, maxDistance: 1, movesPerTurn: 3);
+
+        Assert.Equal(1, piece.MaxDistance);
+    }
+
+    // ── EntryPointType values ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithEntryPointTypeBorders_CanBeReadBack()
+    {
+        var piece = new Piece(Guid.NewGuid(), "TestPiece", Guid.NewGuid(),
+            EntryPointType.Borders, MovementType.Orthogonal, 3, 1);
+
+        Assert.Equal(EntryPointType.Borders, piece.EntryPointType);
+    }
+
+    [Fact]
+    public void Constructor_WithEntryPointTypeCorners_CanBeReadBack()
+    {
+        var piece = new Piece(Guid.NewGuid(), "Donald Duck", Guid.NewGuid(),
+            EntryPointType.Corners, MovementType.Orthogonal, 3, 1);
+
+        Assert.Equal(EntryPointType.Corners, piece.EntryPointType);
+    }
+
+    [Fact]
+    public void Constructor_WithEntryPointTypeAnywhere_CanBeReadBack()
+    {
+        var piece = new Piece(Guid.NewGuid(), "Tinker Bell", Guid.NewGuid(),
+            EntryPointType.Anywhere, MovementType.Orthogonal, 3, 1);
+
+        Assert.Equal(EntryPointType.Anywhere, piece.EntryPointType);
+    }
+
+    // ── MovementType values ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithMovementTypeOrthogonal_CanBeReadBack()
+    {
+        var piece = new Piece(Guid.NewGuid(), "TestPiece", Guid.NewGuid(),
+            EntryPointType.Borders, MovementType.Orthogonal, 3, 1);
+
+        Assert.Equal(MovementType.Orthogonal, piece.MovementType);
+    }
+
+    [Fact]
+    public void Constructor_WithMovementTypeDiagonal_CanBeReadBack()
+    {
+        var piece = new Piece(Guid.NewGuid(), "Goofy", Guid.NewGuid(),
+            EntryPointType.Borders, MovementType.Diagonal, 3, 1);
+
+        Assert.Equal(MovementType.Diagonal, piece.MovementType);
+    }
+
+    [Fact]
+    public void Constructor_WithMovementTypeAnyDirection_CanBeReadBack()
+    {
+        var piece = new Piece(Guid.NewGuid(), "Donald Duck", Guid.NewGuid(),
+            EntryPointType.Corners, MovementType.AnyDirection, 3, 1);
+
+        Assert.Equal(MovementType.AnyDirection, piece.MovementType);
+    }
+
+    // ── IsOnBoard ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Position_BeforePlaceAt_IsNull()
+    {
+        var piece = PieceFactory.Any();
+
+        Assert.Null(piece.Position);
+    }
+
+    [Fact]
+    public void IsOnBoard_BeforePlaceAt_IsFalse()
+    {
+        var piece = PieceFactory.Any();
+
+        Assert.False(piece.IsOnBoard);
+    }
+
+    [Fact]
+    public void IsOnBoard_AfterPlaceAt_IsTrue()
+    {
+        var piece = PieceFactory.Any();
+        piece.PlaceAt(new Position(3, 4));
+
+        Assert.True(piece.IsOnBoard);
+    }
+
+    [Fact]
+    public void IsOnBoard_AfterRemoveFromBoard_IsFalse()
+    {
+        var piece = PieceFactory.Any();
+        piece.PlaceAt(new Position(3, 4));
+        piece.RemoveFromBoard();
+
+        Assert.False(piece.IsOnBoard);
+    }
+
+    // ── PlaceAt ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PlaceAt_SetsPositionCorrectly()
+    {
+        var piece = PieceFactory.Any();
+        var position = new Position(2, 5);
+        piece.PlaceAt(position);
+
+        Assert.Equal(position, piece.Position);
+    }
+
+    [Fact]
+    public void PlaceAt_WithNullPosition_ThrowsDomainException()
+    {
+        var piece = PieceFactory.Any();
+
+        Assert.Throws<DomainException>(() => piece.PlaceAt(null!));
+    }
+
+    [Fact]
+    public void PlaceAt_CalledTwice_UpdatesPositionToLatest()
+    {
+        var piece = PieceFactory.Any();
+        piece.PlaceAt(new Position(0, 0));
+        piece.PlaceAt(new Position(7, 7));
+
+        Assert.Equal(new Position(7, 7), piece.Position);
+    }
+
+    // ── RemoveFromBoard ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void RemoveFromBoard_SetsPositionToNull()
+    {
+        var piece = PieceFactory.Any();
+        piece.PlaceAt(new Position(4, 4));
+        piece.RemoveFromBoard();
+
+        Assert.Null(piece.Position);
+    }
+
+    [Fact]
+    public void RemoveFromBoard_WhenNotOnBoard_DoesNotThrow()
+    {
+        var piece = PieceFactory.Any();
+
+        // should be a no-op without throwing
+        var ex = Record.Exception(() => piece.RemoveFromBoard());
+        Assert.Null(ex);
+    }
+}

--- a/tests/ScrambleCoin.Domain.Tests/TileTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/TileTests.cs
@@ -1,5 +1,6 @@
 using ScrambleCoin.Domain.Entities;
 using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Tests.Helpers;
 using ScrambleCoin.Domain.ValueObjects;
 
 namespace ScrambleCoin.Domain.Tests;
@@ -58,7 +59,7 @@ public class TileTests
     public void SetOccupant_WithPiece_AsPiece_ShouldReturnPiece()
     {
         var tile = MakeTile();
-        var piece = new Piece("Alice");
+        var piece = PieceFactory.Any("Alice");
         tile.SetOccupant(piece);
         Assert.Equal(piece, tile.AsPiece);
     }
@@ -67,7 +68,7 @@ public class TileTests
     public void SetOccupant_WithPiece_AsCoin_ShouldBeNull()
     {
         var tile = MakeTile();
-        tile.SetOccupant(new Piece("Alice"));
+        tile.SetOccupant(PieceFactory.Any("Alice"));
         Assert.Null(tile.AsCoin);
     }
 


### PR DESCRIPTION
## Summary
Closes #6.

## Changes
- `src/ScrambleCoin.Domain/Entities/Piece.cs`: Replaced stub with full implementation — `Id`, `Name`, `PlayerId`, `Position` (nullable), `EntryPointType`, `MovementType`, `MaxDistance`, `MovesPerTurn`, `IsOnBoard`, `PlaceAt()`, `RemoveFromBoard()`
- `src/ScrambleCoin.Domain/Enums/EntryPointType.cs`: New enum — `Borders`, `Corners`, `Anywhere`
- `src/ScrambleCoin.Domain/Enums/MovementType.cs`: New enum — `Orthogonal`, `Diagonal`, `AnyDirection`
- `src/ScrambleCoin.Domain/ValueObjects/Lineup.cs`: New value object — immutable ordered collection of exactly 5 pieces with full equality semantics
- `tests/ScrambleCoin.Domain.Tests/Helpers/PieceFactory.cs`: Test helper replacing removed convenience constructor
- `tests/ScrambleCoin.Domain.Tests/PieceTests.cs`: 38 unit tests covering construction, validation, IsOnBoard lifecycle, PlaceAt/RemoveFromBoard
- `tests/ScrambleCoin.Domain.Tests/LineupTests.cs`: 25 unit tests covering invariants, equality, and operators
- `tests/ScrambleCoin.Domain.Tests/BoardTests.cs`: Updated to use PieceFactory.Any() after removal of single-arg Piece constructor
- `tests/ScrambleCoin.Domain.Tests/TileTests.cs`: Updated to use PieceFactory.Any() after removal of single-arg Piece constructor

## Testing
- Unit tests: 63 added (PieceTests: 38, LineupTests: 25)
- Integration tests: 0 added
- E2E tests: 0 added

All 320 tests pass ✅

Manual test plan posted and execution confirmed on Issue #6.

## Review cycles
- Implementation: 1 cycle (DomainException consistency + test helper extraction)
- Tests: 1 cycle (comment fix + null Position assertion + manual test confirmation)

## Version bump
Issue has `feature` label → `minor` version bump applied.