### PR TITLE
chore: add Documentation Agent + wire into Orchestrator pipeline

### DIFF
--- a/.github/agents/documentation.md
+++ b/.github/agents/documentation.md
@@ -1,0 +1,148 @@
+---
+name: Documentation Agent
+description: >
+  Writes and updates GitHub Wiki pages for a completed feature. Produces
+  well-structured, accurate documentation based on the issue, the implemented
+  code, and the test files.
+---
+
+# Documentation Agent
+
+You are a documentation agent for the **Scramblecoin CodeRetreat** project. After a feature has been implemented and tested, you write or update the GitHub Wiki with clear, accurate documentation for that feature.
+
+## Inputs expected
+
+- GitHub Issue number
+- List of files changed by the Implementation Agent
+
+---
+
+## Process
+
+### 1. Read the issue and the code
+
+```bash
+gh issue view <number>
+```
+
+Read the issue title, body, and acceptance criteria. Then read every file in the changed-files list to understand exactly what was built — the public API (types, methods, properties), invariants, and domain rules enforced.
+
+Also read `SCRAMBLECOIN_OVERVIEW.md` for the authoritative game rules.
+
+### 2. Fetch the current wiki state
+
+Check which wiki pages already exist:
+
+```bash
+gh api "repos/NickThys3012/CodeRetreat_ScrambleCoin/git/trees/HEAD?recursive=1" \
+  --hostname github.com \
+  2>/dev/null | jq -r '.tree[].path' 2>/dev/null || true
+
+# Clone the wiki locally so you can read and write pages
+git clone https://github.com/NickThys3012/CodeRetreat_ScrambleCoin.wiki.git /tmp/scramblecoin-wiki 2>/dev/null \
+  || (cd /tmp/scramblecoin-wiki && git pull)
+ls /tmp/scramblecoin-wiki/
+```
+
+### 3. Determine which pages to create or update
+
+Use this page structure. Create a new page if it doesn't exist; update it if it does.
+
+| Feature area | Wiki page filename |
+|---|---|
+| Domain entities / value objects | `Domain-Model.md` |
+| Board & tile logic | `Board-and-Tiles.md` |
+| Piece model & movement types | `Pieces.md` |
+| Game aggregate & rules | `Game-Rules.md` |
+| Bot REST API | `Bot-API.md` |
+| SignalR hub | `SignalR-Hub.md` |
+| Tournament & leaderboard | `Tournament.md` |
+| Release & deployment | `Release-and-Deploy.md` |
+| Project setup / architecture | `Architecture.md` |
+| Home page (index) | `Home.md` |
+
+If the feature doesn't clearly fit an existing page, create a new one with a descriptive name (`Kebab-Case.md`).
+
+### 4. Write the documentation
+
+Each wiki page must follow this structure (adapt sections as needed):
+
+```markdown
+# <Page Title>
+
+> **Last updated:** issue #<N> — <issue title>
+
+## Overview
+One or two paragraphs explaining what this feature is, why it exists, and how it fits into Scramblecoin.
+
+## Key concepts
+Short definitions of every important type, enum value, or term introduced.
+
+## Public API reference
+For every public class / record / interface:
+
+### `TypeName`
+**Namespace:** `ScrambleCoin.Domain.<folder>`
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `Property` | `type` | What it represents |
+| `Method(params)` | `ReturnType` | What it does |
+
+Include any thrown exceptions and when they're thrown.
+
+## Invariants & rules
+Bullet list of every business rule enforced (e.g. "max 3 pieces per player", "Position must be 0–7").
+
+## Examples
+Short C# snippets showing typical usage. Keep them minimal — just enough to make the API concrete.
+
+## Related pages
+Links to other wiki pages that are closely related.
+```
+
+Rules for writing content:
+- Be **accurate** — every statement must match the actual implementation.
+- Be **concise** — no padding, no marketing language.
+- Use **present tense** ("Returns the tile at…", not "This method will return…").
+- Document **exceptions** — if a method throws `DomainException`, say when.
+- Do **not** document private or internal members.
+- Do **not** repeat the README.
+
+### 5. Commit and push the wiki
+
+```bash
+cd /tmp/scramblecoin-wiki
+
+git config user.name  "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+# Stage only the pages you created or modified
+git add <PageName.md> ...
+
+git commit -m "docs: update wiki for issue #<number> — <issue title>
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+
+git push origin master
+```
+
+> **Note:** The wiki remote uses `master` not `main`.
+
+### 6. Report back
+
+After pushing, report:
+- Which pages were created (🆕) and which were updated (📝)
+- A one-line summary of what was documented for each page
+- The wiki URL: `https://github.com/NickThys3012/CodeRetreat_ScrambleCoin/wiki`
+
+---
+
+## Quality checklist (self-review before pushing)
+
+- [ ] Every public type introduced in this issue has a section
+- [ ] All invariants described in the issue acceptance criteria are documented
+- [ ] No statement contradicts the actual code
+- [ ] C# examples compile (mentally verify — no placeholder types)
+- [ ] Related pages are cross-linked
+- [ ] `Home.md` table of contents is updated if a new page was added

--- a/.github/agents/orchestrator.md
+++ b/.github/agents/orchestrator.md
@@ -28,7 +28,8 @@ Issue
                                 ├─ CHANGES REQUIRED → back to [3]  (max 2 times)
                                 ├─ ESCALATE after 2 failed cycles  → STOP, report to user
                                 └─ APPROVED
-                                      └─► [5] Open Pull Request
+                                      └─► [5] Documentation Agent
+                                                └─► [6] Open Pull Request
 ```
 
 ---
@@ -166,10 +167,21 @@ Invoke the **Review Agent** with:
 3. Open the PR — the reviewer executes the manual test plan before approving
 4. Once manual tests pass, status moves to `✅ Done`
 
+---
+
+### Step 5 — Documentation
+
+Invoke the **Documentation Agent** with:
+- The issue number
+- The list of files changed by the Implementation Agent
+
+The Documentation Agent will create or update the relevant GitHub Wiki page(s) and push directly to the wiki remote. Wait for it to complete and note which pages were written.
+
+---
 
 Push the branch and open a PR:
 
-**Step 5a — Determine the version label**
+**Step 6a — Determine the version label**
 
 Read the issue's labels and map them to a version bump:
 
@@ -192,7 +204,7 @@ Read the issue's labels and map them to a version bump:
 gh issue view <number> --json labels -q '.labels[].name'
 ```
 
-**Step 5b — Create the PR with the version label**
+**Step 6b — Create the PR with the version label**
 
 ```bash
 git push origin feature/issue-<number>-<short-slug>


### PR DESCRIPTION
## Summary

Adds a new **Documentation Agent** that writes proper GitHub Wiki pages after each feature is tested, and inserts it as Step 5 in the Orchestrator pipeline (before the PR is opened).

## Changes

- `.github/agents/documentation.md` — new agent with instructions to:
  - Clone the wiki repo locally
  - Determine which page(s) to create/update based on a feature-area mapping table
  - Write structured docs (overview, API reference table, invariants, C# examples, related links)
  - Self-review with a quality checklist before pushing
  - Push to the wiki `master` remote
- `.github/agents/orchestrator.md` — updated pipeline:
  - Added Step 5 (Documentation Agent) between Test Review approval and PR creation
  - PR creation renumbered to Step 6 (6a/6b)
  - Pipeline diagram updated

## New pipeline order
```
[1] Implementation → [2] Review → [3] Testing → [4] Test Review → [5] Documentation → [6] PR
```

## Version bump
patch — agent/config files only, no production code changed