### PR TITLE
Turn structure & phase enforcement

### DIFF
--- a/src/ScrambleCoin.Domain/Entities/Game.cs
+++ b/src/ScrambleCoin.Domain/Entities/Game.cs
@@ -321,6 +321,8 @@ public sealed class Game
             throw new DomainException(
                 $"Turn can only advance while the game is {GameStatus.InProgress}. Current status: {Status}.");
 
+        EnsureInMovePhase();
+
         if (TurnNumber >= TotalTurns)
         {
             End();
@@ -378,9 +380,10 @@ public sealed class Game
                 }
                 else
                 {
+                    var oldTurnNumber = TurnNumber;
                     TurnNumber++;
                     CurrentPhase = TurnPhase.CoinSpawn;
-                    _domainEvents.Add(new TurnPhaseAdvanced(Id, TurnNumber, previousPhase, CurrentPhase, DateTimeOffset.UtcNow));
+                    _domainEvents.Add(new TurnPhaseAdvanced(Id, oldTurnNumber, previousPhase, CurrentPhase, DateTimeOffset.UtcNow));
                 }
                 break;
         }

--- a/src/ScrambleCoin.Domain/Entities/Game.cs
+++ b/src/ScrambleCoin.Domain/Entities/Game.cs
@@ -322,16 +322,7 @@ public sealed class Game
                 $"Turn can only advance while the game is {GameStatus.InProgress}. Current status: {Status}.");
 
         EnsureInMovePhase();
-
-        if (TurnNumber >= TotalTurns)
-        {
-            End();
-        }
-        else
-        {
-            TurnNumber++;
-            CurrentPhase = TurnPhase.CoinSpawn;
-        }
+        AdvancePhase(); // handles turn increment, game-end, and TurnPhaseAdvanced event
     }
 
     // ── Phase advancement ─────────────────────────────────────────────────────

--- a/src/ScrambleCoin.Domain/Entities/Game.cs
+++ b/src/ScrambleCoin.Domain/Entities/Game.cs
@@ -66,14 +66,21 @@ public sealed class Game
     /// <summary>Current turn number (1–5); 0 before the game starts.</summary>
     public int TurnNumber { get; private set; }
 
+    /// <summary>
+    /// Current turn number (1–5); 0 before the game starts.
+    /// Alias for <see cref="TurnNumber"/> that matches the phase-based naming convention.
+    /// </summary>
+    public int CurrentTurnNumber => TurnNumber;
+
     /// <summary>Current lifecycle status of the game.</summary>
     public GameStatus Status { get; private set; }
 
     /// <summary>
-    /// Describes the active phase within the current turn
-    /// (e.g., "PlayerOneAction", "PlayerTwoAction").
+    /// The active phase within the current turn (<see cref="TurnPhase.CoinSpawn"/>,
+    /// <see cref="TurnPhase.PlacePhase"/>, or <see cref="TurnPhase.MovePhase"/>).
+    /// <c>null</c> when the game has not yet started or has already finished.
     /// </summary>
-    public string CurrentPhase { get; private set; }
+    public TurnPhase? CurrentPhase { get; private set; }
 
     // ── Pieces-on-board counters ──────────────────────────────────────────────
 
@@ -111,7 +118,7 @@ public sealed class Game
         Board = board;
         Status = GameStatus.WaitingForBots;
         TurnNumber = 0;
-        CurrentPhase = "WaitingForLineups";
+        CurrentPhase = null;
 
         _scores = new Dictionary<Guid, int>
         {
@@ -194,7 +201,7 @@ public sealed class Game
 
         Status = GameStatus.InProgress;
         TurnNumber = 1;
-        CurrentPhase = "PlayerOneAction";
+        CurrentPhase = TurnPhase.CoinSpawn;
 
         _domainEvents.Add(new GameStarted(Id, PlayerOne, PlayerTwo, DateTimeOffset.UtcNow));
     }
@@ -213,7 +220,7 @@ public sealed class Game
                 $"Game can only be ended from {GameStatus.InProgress} state. Current status: {Status}.");
 
         Status = GameStatus.Finished;
-        CurrentPhase = "Finished";
+        CurrentPhase = null;
 
         var scoreOne = _scores[PlayerOne];
         var scoreTwo = _scores[PlayerTwo];
@@ -321,8 +328,106 @@ public sealed class Game
         else
         {
             TurnNumber++;
-            CurrentPhase = "PlayerOneAction";
+            CurrentPhase = TurnPhase.CoinSpawn;
         }
+    }
+
+    // ── Phase advancement ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Advances the current phase within the turn following the mandatory sequence:
+    /// <see cref="TurnPhase.CoinSpawn"/> → <see cref="TurnPhase.PlacePhase"/> → <see cref="TurnPhase.MovePhase"/>.
+    /// After <see cref="TurnPhase.MovePhase"/>:
+    /// <list type="bullet">
+    ///   <item>If the current turn is less than <see cref="TotalTurns"/>, the turn number
+    ///         increments and the phase resets to <see cref="TurnPhase.CoinSpawn"/>.</item>
+    ///   <item>If the current turn equals <see cref="TotalTurns"/>, <see cref="End"/> is called
+    ///         automatically and the game transitions to <see cref="GameStatus.Finished"/>.</item>
+    /// </list>
+    /// Raises a <see cref="TurnPhaseAdvanced"/> domain event on every transition.
+    /// </summary>
+    /// <exception cref="DomainException">
+    /// Thrown when the game is not <see cref="GameStatus.InProgress"/>.
+    /// </exception>
+    public void AdvancePhase()
+    {
+        if (Status != GameStatus.InProgress)
+            throw new DomainException(
+                $"Phase can only advance while the game is {GameStatus.InProgress}. Current status: {Status}.");
+
+        var previousPhase = CurrentPhase!.Value;
+
+        switch (CurrentPhase)
+        {
+            case TurnPhase.CoinSpawn:
+                CurrentPhase = TurnPhase.PlacePhase;
+                _domainEvents.Add(new TurnPhaseAdvanced(Id, TurnNumber, previousPhase, CurrentPhase, DateTimeOffset.UtcNow));
+                break;
+
+            case TurnPhase.PlacePhase:
+                CurrentPhase = TurnPhase.MovePhase;
+                _domainEvents.Add(new TurnPhaseAdvanced(Id, TurnNumber, previousPhase, CurrentPhase, DateTimeOffset.UtcNow));
+                break;
+
+            case TurnPhase.MovePhase:
+                if (TurnNumber >= TotalTurns)
+                {
+                    // Raise the event before ending the game so listeners see the final transition.
+                    _domainEvents.Add(new TurnPhaseAdvanced(Id, TurnNumber, previousPhase, null, DateTimeOffset.UtcNow));
+                    End();
+                }
+                else
+                {
+                    TurnNumber++;
+                    CurrentPhase = TurnPhase.CoinSpawn;
+                    _domainEvents.Add(new TurnPhaseAdvanced(Id, TurnNumber, previousPhase, CurrentPhase, DateTimeOffset.UtcNow));
+                }
+                break;
+        }
+    }
+
+    // ── Phase guard methods ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Asserts that the game is currently in the <see cref="TurnPhase.CoinSpawn"/> phase.
+    /// Call this at the start of any operation that is only valid during coin spawning.
+    /// </summary>
+    /// <exception cref="DomainException">
+    /// Thrown when the current phase is not <see cref="TurnPhase.CoinSpawn"/>.
+    /// </exception>
+    public void EnsureInCoinSpawnPhase()
+    {
+        if (CurrentPhase != TurnPhase.CoinSpawn)
+            throw new DomainException(
+                $"This action is only allowed during the {TurnPhase.CoinSpawn} phase. Current phase: {CurrentPhase?.ToString() ?? "None"}.");
+    }
+
+    /// <summary>
+    /// Asserts that the game is currently in the <see cref="TurnPhase.PlacePhase"/>.
+    /// Call this at the start of any placement operation.
+    /// </summary>
+    /// <exception cref="DomainException">
+    /// Thrown when the current phase is not <see cref="TurnPhase.PlacePhase"/>.
+    /// </exception>
+    public void EnsureInPlacePhase()
+    {
+        if (CurrentPhase != TurnPhase.PlacePhase)
+            throw new DomainException(
+                $"This action is only allowed during the {TurnPhase.PlacePhase} phase. Current phase: {CurrentPhase?.ToString() ?? "None"}.");
+    }
+
+    /// <summary>
+    /// Asserts that the game is currently in the <see cref="TurnPhase.MovePhase"/>.
+    /// Call this at the start of any movement operation.
+    /// </summary>
+    /// <exception cref="DomainException">
+    /// Thrown when the current phase is not <see cref="TurnPhase.MovePhase"/>.
+    /// </exception>
+    public void EnsureInMovePhase()
+    {
+        if (CurrentPhase != TurnPhase.MovePhase)
+            throw new DomainException(
+                $"This action is only allowed during the {TurnPhase.MovePhase} phase. Current phase: {CurrentPhase?.ToString() ?? "None"}.");
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/src/ScrambleCoin.Domain/Enums/TurnPhase.cs
+++ b/src/ScrambleCoin.Domain/Enums/TurnPhase.cs
@@ -1,0 +1,26 @@
+namespace ScrambleCoin.Domain.Enums;
+
+/// <summary>
+/// Represents the three sequential phases that make up a single turn in a Scramblecoin game.
+/// Each turn must progress through all three phases in order:
+/// <see cref="CoinSpawn"/> → <see cref="PlacePhase"/> → <see cref="MovePhase"/>.
+/// </summary>
+public enum TurnPhase
+{
+    /// <summary>
+    /// The first phase of every turn. Coins are spawned onto the board during this phase.
+    /// </summary>
+    CoinSpawn,
+
+    /// <summary>
+    /// The second phase of every turn. Players may place or replace pieces on the board.
+    /// This phase is skippable by individual players, but the phase itself is mandatory.
+    /// </summary>
+    PlacePhase,
+
+    /// <summary>
+    /// The third and final phase of every turn. Players move their pieces on the board.
+    /// After this phase completes, the turn number increments (or the game ends after turn 5).
+    /// </summary>
+    MovePhase
+}

--- a/src/ScrambleCoin.Domain/Events/TurnPhaseAdvanced.cs
+++ b/src/ScrambleCoin.Domain/Events/TurnPhaseAdvanced.cs
@@ -1,0 +1,21 @@
+using ScrambleCoin.Domain.Enums;
+
+namespace ScrambleCoin.Domain.Events;
+
+/// <summary>
+/// Raised each time the active phase within a turn changes.
+/// </summary>
+/// <param name="GameId">The identifier of the game in which the phase advanced.</param>
+/// <param name="TurnNumber">The turn number (1–5) during which the phase advanced.</param>
+/// <param name="PreviousPhase">The phase that just ended.</param>
+/// <param name="NewPhase">
+/// The phase that is now active, or <c>null</c> when the final <see cref="TurnPhase.MovePhase"/>
+/// of turn 5 has completed and the game is ending.
+/// </param>
+/// <param name="OccurredAt">UTC timestamp when the event was raised.</param>
+public sealed record TurnPhaseAdvanced(
+    Guid GameId,
+    int TurnNumber,
+    TurnPhase PreviousPhase,
+    TurnPhase? NewPhase,
+    DateTimeOffset OccurredAt) : IDomainEvent;

--- a/tests/ScrambleCoin.Domain.Tests/GameTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/GameTests.cs
@@ -38,8 +38,17 @@ public class GameTests
         return (game, p1, p2);
     }
 
-    // ══════════════════════════════════════════════════════════════════════════
-    // 1. Constructor
+    /// <summary>
+    /// Advances the game through CoinSpawn and PlacePhase so it is in MovePhase,
+    /// ready for a call to <see cref="Game.AdvanceTurn"/>.
+    /// </summary>
+    private static void AdvanceToMovePhase(Game game)
+    {
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.AdvancePhase(); // PlacePhase → MovePhase
+    }
+
+
     // ══════════════════════════════════════════════════════════════════════════
 
     [Fact]
@@ -608,6 +617,7 @@ public class GameTests
     public void AdvanceTurn_FromTurnOne_SetsTurnNumberToTwo()
     {
         var (game, _, _) = StartedGame();
+        AdvanceToMovePhase(game);
         game.AdvanceTurn();
         Assert.Equal(2, game.TurnNumber);
     }
@@ -616,7 +626,9 @@ public class GameTests
     public void AdvanceTurn_FromTurnTwo_SetsTurnNumberToThree()
     {
         var (game, _, _) = StartedGame();
+        AdvanceToMovePhase(game);
         game.AdvanceTurn();
+        AdvanceToMovePhase(game);
         game.AdvanceTurn();
         Assert.Equal(3, game.TurnNumber);
     }
@@ -626,7 +638,10 @@ public class GameTests
     {
         var (game, _, _) = StartedGame();
         for (var i = 0; i < Game.TotalTurns; i++)
+        {
+            AdvanceToMovePhase(game);
             game.AdvanceTurn();
+        }
         Assert.Equal(GameStatus.Finished, game.Status);
     }
 
@@ -636,9 +651,13 @@ public class GameTests
         var (game, _, _) = StartedGame();
         // Advance to turn 5
         for (var i = 0; i < Game.TotalTurns - 1; i++)
+        {
+            AdvanceToMovePhase(game);
             game.AdvanceTurn();
+        }
         Assert.Equal(Game.TotalTurns, game.TurnNumber);
         // Advance from turn 5 → auto-End
+        AdvanceToMovePhase(game);
         game.AdvanceTurn();
         Assert.Equal(GameStatus.Finished, game.Status);
     }
@@ -648,8 +667,12 @@ public class GameTests
     {
         var (game, _, _) = StartedGame();
         for (var i = 0; i < Game.TotalTurns - 1; i++)
+        {
+            AdvanceToMovePhase(game);
             game.AdvanceTurn();
+        }
         game.ClearDomainEvents();
+        AdvanceToMovePhase(game);
         game.AdvanceTurn();
         Assert.Single(game.DomainEvents.OfType<GameEnded>());
     }
@@ -674,7 +697,10 @@ public class GameTests
     {
         var (game, _, _) = StartedGame();
         for (var i = 0; i < Game.TotalTurns - 1; i++)
+        {
+            AdvanceToMovePhase(game);
             game.AdvanceTurn();
+        }
         Assert.Equal(Game.TotalTurns, game.TurnNumber);
     }
 

--- a/tests/ScrambleCoin.Domain.Tests/GameTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/GameTests.cs
@@ -776,4 +776,354 @@ public class GameTests
         var (game, _, _) = StartedGame();
         Assert.Throws<DomainException>(() => game.GetPiecesOnBoardCount(Guid.NewGuid()));
     }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // 10. AdvancePhase() and phase guards
+    // ══════════════════════════════════════════════════════════════════════════
+
+    // ── AdvancePhase() — individual transitions ───────────────────────────────
+
+    [Fact]
+    public void AdvancePhase_FromCoinSpawn_SetsCurrentPhaseToPlacePhase()
+    {
+        var (game, _, _) = StartedGame();
+        // freshly started game is in CoinSpawn
+        game.AdvancePhase();
+        Assert.Equal(TurnPhase.PlacePhase, game.CurrentPhase);
+    }
+
+    [Fact]
+    public void AdvancePhase_FromPlacePhase_SetsCurrentPhaseToMovePhase()
+    {
+        var (game, _, _) = StartedGame();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.AdvancePhase(); // PlacePhase → MovePhase
+        Assert.Equal(TurnPhase.MovePhase, game.CurrentPhase);
+    }
+
+    [Fact]
+    public void AdvancePhase_FromMovePhase_OnNonFinalTurn_IncrementsTurnNumber()
+    {
+        var (game, _, _) = StartedGame();
+        AdvanceToMovePhase(game);
+        var turnBefore = game.TurnNumber;
+        game.AdvancePhase(); // MovePhase → CoinSpawn, turn++
+        Assert.Equal(turnBefore + 1, game.TurnNumber);
+    }
+
+    [Fact]
+    public void AdvancePhase_FromMovePhase_OnNonFinalTurn_ResetsCurrentPhaseToCoinSpawn()
+    {
+        var (game, _, _) = StartedGame();
+        AdvanceToMovePhase(game);
+        game.AdvancePhase();
+        Assert.Equal(TurnPhase.CoinSpawn, game.CurrentPhase);
+    }
+
+    [Fact]
+    public void AdvancePhase_FromMovePhase_OnTurnFive_SetsStatusToFinished()
+    {
+        var (game, _, _) = StartedGame();
+        // advance through turns 1-4
+        for (var i = 0; i < Game.TotalTurns - 1; i++)
+        {
+            AdvanceToMovePhase(game);
+            game.AdvancePhase(); // MovePhase → CoinSpawn, turn++
+        }
+        // now on turn 5 — advance to MovePhase then trigger final AdvancePhase
+        AdvanceToMovePhase(game);
+        game.AdvancePhase(); // MovePhase on turn 5 → End()
+        Assert.Equal(GameStatus.Finished, game.Status);
+    }
+
+    [Fact]
+    public void AdvancePhase_WhenNotInProgress_ThrowsDomainException()
+    {
+        var (game, _, _) = NewGame();
+        Assert.Throws<DomainException>(() => game.AdvancePhase());
+    }
+
+    [Fact]
+    public void AdvancePhase_WhenFinished_ThrowsDomainException()
+    {
+        var (game, _, _) = StartedGame();
+        game.End();
+        Assert.Throws<DomainException>(() => game.AdvancePhase());
+    }
+
+    [Fact]
+    public void AdvancePhase_FullFiveTurnCycle_AllFifteenTransitions_EndsGameAsFinished()
+    {
+        var (game, _, _) = StartedGame();
+        // 5 turns × 3 phases each = 15 calls to AdvancePhase
+        for (var turn = 0; turn < Game.TotalTurns; turn++)
+        {
+            game.AdvancePhase(); // CoinSpawn → PlacePhase
+            game.AdvancePhase(); // PlacePhase → MovePhase
+            game.AdvancePhase(); // MovePhase → CoinSpawn (or End on turn 5)
+        }
+        Assert.Equal(GameStatus.Finished, game.Status);
+    }
+
+    // ── EnsureInCoinSpawnPhase() ──────────────────────────────────────────────
+
+    [Fact]
+    public void EnsureInCoinSpawnPhase_WhenInCoinSpawn_DoesNotThrow()
+    {
+        var (game, _, _) = StartedGame();
+        // freshly started game is in CoinSpawn
+        var exception = Record.Exception(() => game.EnsureInCoinSpawnPhase());
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void EnsureInCoinSpawnPhase_WhenInPlacePhase_ThrowsDomainException()
+    {
+        var (game, _, _) = StartedGame();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        Assert.Throws<DomainException>(() => game.EnsureInCoinSpawnPhase());
+    }
+
+    [Fact]
+    public void EnsureInCoinSpawnPhase_WhenInMovePhase_ThrowsDomainException()
+    {
+        var (game, _, _) = StartedGame();
+        AdvanceToMovePhase(game);
+        Assert.Throws<DomainException>(() => game.EnsureInCoinSpawnPhase());
+    }
+
+    [Fact]
+    public void EnsureInCoinSpawnPhase_WhenCurrentPhaseIsNull_ThrowsDomainException()
+    {
+        var (game, _, _) = StartedGame();
+        game.End(); // sets CurrentPhase = null
+        Assert.Throws<DomainException>(() => game.EnsureInCoinSpawnPhase());
+    }
+
+    // ── EnsureInPlacePhase() ──────────────────────────────────────────────────
+
+    [Fact]
+    public void EnsureInPlacePhase_WhenInPlacePhase_DoesNotThrow()
+    {
+        var (game, _, _) = StartedGame();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        var exception = Record.Exception(() => game.EnsureInPlacePhase());
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void EnsureInPlacePhase_WhenInCoinSpawnPhase_ThrowsDomainException()
+    {
+        var (game, _, _) = StartedGame();
+        // freshly started game is in CoinSpawn
+        Assert.Throws<DomainException>(() => game.EnsureInPlacePhase());
+    }
+
+    [Fact]
+    public void EnsureInPlacePhase_WhenInMovePhase_ThrowsDomainException()
+    {
+        var (game, _, _) = StartedGame();
+        AdvanceToMovePhase(game);
+        Assert.Throws<DomainException>(() => game.EnsureInPlacePhase());
+    }
+
+    [Fact]
+    public void EnsureInPlacePhase_WhenCurrentPhaseIsNull_ThrowsDomainException()
+    {
+        var (game, _, _) = StartedGame();
+        game.End(); // sets CurrentPhase = null
+        Assert.Throws<DomainException>(() => game.EnsureInPlacePhase());
+    }
+
+    // ── EnsureInMovePhase() ───────────────────────────────────────────────────
+
+    [Fact]
+    public void EnsureInMovePhase_WhenInMovePhase_DoesNotThrow()
+    {
+        var (game, _, _) = StartedGame();
+        AdvanceToMovePhase(game);
+        var exception = Record.Exception(() => game.EnsureInMovePhase());
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void EnsureInMovePhase_WhenInCoinSpawnPhase_ThrowsDomainException()
+    {
+        var (game, _, _) = StartedGame();
+        // freshly started game is in CoinSpawn
+        Assert.Throws<DomainException>(() => game.EnsureInMovePhase());
+    }
+
+    [Fact]
+    public void EnsureInMovePhase_WhenInPlacePhase_ThrowsDomainException()
+    {
+        var (game, _, _) = StartedGame();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        Assert.Throws<DomainException>(() => game.EnsureInMovePhase());
+    }
+
+    [Fact]
+    public void EnsureInMovePhase_WhenCurrentPhaseIsNull_ThrowsDomainException()
+    {
+        var (game, _, _) = StartedGame();
+        game.End(); // sets CurrentPhase = null
+        Assert.Throws<DomainException>(() => game.EnsureInMovePhase());
+    }
+
+    // ── TurnPhaseAdvanced domain events ───────────────────────────────────────
+
+    [Fact]
+    public void AdvancePhase_CoinSpawnToPlacePhase_RaisesTurnPhaseAdvancedEvent()
+    {
+        var (game, _, _) = StartedGame();
+        game.ClearDomainEvents();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        Assert.Single(game.DomainEvents.OfType<TurnPhaseAdvanced>());
+    }
+
+    [Fact]
+    public void AdvancePhase_CoinSpawnToPlacePhase_Event_HasCorrectTurnNumber()
+    {
+        var (game, _, _) = StartedGame();
+        game.ClearDomainEvents();
+        game.AdvancePhase();
+        var evt = game.DomainEvents.OfType<TurnPhaseAdvanced>().Single();
+        Assert.Equal(1, evt.TurnNumber);
+    }
+
+    [Fact]
+    public void AdvancePhase_CoinSpawnToPlacePhase_Event_HasCorrectPreviousPhase()
+    {
+        var (game, _, _) = StartedGame();
+        game.ClearDomainEvents();
+        game.AdvancePhase();
+        var evt = game.DomainEvents.OfType<TurnPhaseAdvanced>().Single();
+        Assert.Equal(TurnPhase.CoinSpawn, evt.PreviousPhase);
+    }
+
+    [Fact]
+    public void AdvancePhase_CoinSpawnToPlacePhase_Event_HasCorrectNewPhase()
+    {
+        var (game, _, _) = StartedGame();
+        game.ClearDomainEvents();
+        game.AdvancePhase();
+        var evt = game.DomainEvents.OfType<TurnPhaseAdvanced>().Single();
+        Assert.Equal(TurnPhase.PlacePhase, evt.NewPhase);
+    }
+
+    [Fact]
+    public void AdvancePhase_PlacePhaseToMovePhase_RaisesTurnPhaseAdvancedEvent()
+    {
+        var (game, _, _) = StartedGame();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.ClearDomainEvents();
+        game.AdvancePhase(); // PlacePhase → MovePhase
+        Assert.Single(game.DomainEvents.OfType<TurnPhaseAdvanced>());
+    }
+
+    [Fact]
+    public void AdvancePhase_PlacePhaseToMovePhase_Event_HasCorrectPreviousPhase()
+    {
+        var (game, _, _) = StartedGame();
+        game.AdvancePhase();
+        game.ClearDomainEvents();
+        game.AdvancePhase();
+        var evt = game.DomainEvents.OfType<TurnPhaseAdvanced>().Single();
+        Assert.Equal(TurnPhase.PlacePhase, evt.PreviousPhase);
+    }
+
+    [Fact]
+    public void AdvancePhase_PlacePhaseToMovePhase_Event_HasCorrectNewPhase()
+    {
+        var (game, _, _) = StartedGame();
+        game.AdvancePhase();
+        game.ClearDomainEvents();
+        game.AdvancePhase();
+        var evt = game.DomainEvents.OfType<TurnPhaseAdvanced>().Single();
+        Assert.Equal(TurnPhase.MovePhase, evt.NewPhase);
+    }
+
+    [Fact]
+    public void AdvancePhase_MovePhaseToCoinSpawn_OnNonFinalTurn_Event_HasOldTurnNumber()
+    {
+        var (game, _, _) = StartedGame();
+        AdvanceToMovePhase(game);
+        var oldTurn = game.TurnNumber; // 1
+        game.ClearDomainEvents();
+        game.AdvancePhase(); // MovePhase → CoinSpawn, turn++
+        var evt = game.DomainEvents.OfType<TurnPhaseAdvanced>().Single();
+        Assert.Equal(oldTurn, evt.TurnNumber);
+    }
+
+    [Fact]
+    public void AdvancePhase_MovePhaseToCoinSpawn_OnNonFinalTurn_Event_HasCorrectNewPhase()
+    {
+        var (game, _, _) = StartedGame();
+        AdvanceToMovePhase(game);
+        game.ClearDomainEvents();
+        game.AdvancePhase();
+        var evt = game.DomainEvents.OfType<TurnPhaseAdvanced>().Single();
+        Assert.Equal(TurnPhase.CoinSpawn, evt.NewPhase);
+    }
+
+    [Fact]
+    public void AdvancePhase_FinalMovePhase_Event_HasNullNewPhase()
+    {
+        var (game, _, _) = StartedGame();
+        // advance to turn 5 MovePhase
+        for (var i = 0; i < Game.TotalTurns - 1; i++)
+        {
+            AdvanceToMovePhase(game);
+            game.AdvancePhase(); // complete non-final turns
+        }
+        AdvanceToMovePhase(game);
+        game.ClearDomainEvents();
+        game.AdvancePhase(); // final MovePhase → End
+        var evt = game.DomainEvents.OfType<TurnPhaseAdvanced>().Single();
+        Assert.Null(evt.NewPhase);
+    }
+
+    [Fact]
+    public void AdvancePhase_FinalMovePhase_Event_HasCorrectPreviousPhase()
+    {
+        var (game, _, _) = StartedGame();
+        for (var i = 0; i < Game.TotalTurns - 1; i++)
+        {
+            AdvanceToMovePhase(game);
+            game.AdvancePhase();
+        }
+        AdvanceToMovePhase(game);
+        game.ClearDomainEvents();
+        game.AdvancePhase();
+        var evt = game.DomainEvents.OfType<TurnPhaseAdvanced>().Single();
+        Assert.Equal(TurnPhase.MovePhase, evt.PreviousPhase);
+    }
+
+    [Fact]
+    public void AdvanceTurn_RaisesTurnPhaseAdvancedEvent()
+    {
+        var (game, _, _) = StartedGame();
+        AdvanceToMovePhase(game);
+        game.ClearDomainEvents();
+        game.AdvanceTurn(); // delegates to AdvancePhase()
+        Assert.Single(game.DomainEvents.OfType<TurnPhaseAdvanced>());
+    }
+
+    // ── AdvanceTurn() guard ───────────────────────────────────────────────────
+
+    [Fact]
+    public void AdvanceTurn_WhenInCoinSpawnPhase_ThrowsDomainException()
+    {
+        var (game, _, _) = StartedGame();
+        // freshly started game is in CoinSpawn — AdvanceTurn requires MovePhase
+        Assert.Throws<DomainException>(() => game.AdvanceTurn());
+    }
+
+    [Fact]
+    public void AdvanceTurn_WhenInPlacePhase_ThrowsDomainException()
+    {
+        var (game, _, _) = StartedGame();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        Assert.Throws<DomainException>(() => game.AdvanceTurn());
+    }
 }


### PR DESCRIPTION
## Summary
Closes #8.

## Changes
- `src/ScrambleCoin.Domain/Enums/TurnPhase.cs`: New enum — `CoinSpawn`, `PlacePhase`, `MovePhase`
- `src/ScrambleCoin.Domain/Events/TurnPhaseAdvanced.cs`: New domain event raised on every phase transition
- `src/ScrambleCoin.Domain/Entities/Game.cs`: `AdvancePhase()`, three `EnsureIn*Phase()` guards, `CurrentTurnNumber` alias, `CurrentPhase` type changed `string→TurnPhase?`, `AdvanceTurn()` now delegates to `AdvancePhase()`
- `tests/ScrambleCoin.Domain.Tests/GameTests.cs`: 34 new unit tests covering all phase transitions, guard methods, `TurnPhaseAdvanced` events (including final `null` NewPhase), and `AdvanceTurn()` delegation

## Testing
- Unit tests: 34 added (Domain)
- Integration tests: 0 added
- E2E tests: 0 added

All tests pass ✅ (431 total)

## Review cycles
- Implementation: 1 cycle (1 review pass that caught TurnNumber/AdvanceTurn issues; 1 targeted fix)
- Tests: 1 cycle (approved first pass)

## Version bump