### PR TITLE
Piece placement & replace phase

### DIFF
--- a/src/ScrambleCoin.Application/Games/PlacePiece/PlacePieceCommand.cs
+++ b/src/ScrambleCoin.Application/Games/PlacePiece/PlacePieceCommand.cs
@@ -1,0 +1,11 @@
+using MediatR;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Games.PlacePiece;
+
+/// <summary>Places an off-board piece at a valid entry-point tile during PlacePhase.</summary>
+public sealed record PlacePieceCommand(
+    Guid GameId,
+    Guid PlayerId,
+    Guid PieceId,
+    Position TargetPosition) : IRequest;

--- a/src/ScrambleCoin.Application/Games/PlacePiece/PlacePieceCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/PlacePiece/PlacePieceCommandHandler.cs
@@ -1,0 +1,37 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ScrambleCoin.Application.Interfaces;
+
+namespace ScrambleCoin.Application.Games.PlacePiece;
+
+/// <summary>
+/// Handles <see cref="PlacePieceCommand"/>: loads the game, delegates placement to the domain,
+/// and persists the updated game.
+/// </summary>
+public sealed class PlacePieceCommandHandler : IRequestHandler<PlacePieceCommand>
+{
+    private readonly IGameRepository _gameRepository;
+    private readonly ILogger<PlacePieceCommandHandler> _logger;
+
+    /// <param name="gameRepository">Repository for loading and saving games.</param>
+    /// <param name="logger">Logger for structured output.</param>
+    public PlacePieceCommandHandler(IGameRepository gameRepository, ILogger<PlacePieceCommandHandler> logger)
+    {
+        _gameRepository = gameRepository;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task Handle(PlacePieceCommand request, CancellationToken cancellationToken)
+    {
+        var game = await _gameRepository.GetByIdAsync(request.GameId, cancellationToken);
+
+        game.PlacePiece(request.PlayerId, request.PieceId, request.TargetPosition);
+
+        await _gameRepository.SaveAsync(game, cancellationToken);
+
+        _logger.LogInformation(
+            "Piece {PieceId} placed at {Position} by player {PlayerId} in game {GameId} on turn {Turn}",
+            request.PieceId, request.TargetPosition, request.PlayerId, request.GameId, game.TurnNumber);
+    }
+}

--- a/src/ScrambleCoin.Application/Games/ReplacePiece/ReplacePieceCommand.cs
+++ b/src/ScrambleCoin.Application/Games/ReplacePiece/ReplacePieceCommand.cs
@@ -1,0 +1,14 @@
+using MediatR;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Games.ReplacePiece;
+
+/// <summary>
+/// Removes an on-board piece and places a different lineup piece at the given position during PlacePhase.
+/// </summary>
+public sealed record ReplacePieceCommand(
+    Guid GameId,
+    Guid PlayerId,
+    Guid ExistingPieceId,
+    Guid NewPieceId,
+    Position TargetPosition) : IRequest;

--- a/src/ScrambleCoin.Application/Games/ReplacePiece/ReplacePieceCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/ReplacePiece/ReplacePieceCommandHandler.cs
@@ -1,0 +1,37 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ScrambleCoin.Application.Interfaces;
+
+namespace ScrambleCoin.Application.Games.ReplacePiece;
+
+/// <summary>
+/// Handles <see cref="ReplacePieceCommand"/>: loads the game, delegates the replace operation
+/// to the domain, and persists the updated game.
+/// </summary>
+public sealed class ReplacePieceCommandHandler : IRequestHandler<ReplacePieceCommand>
+{
+    private readonly IGameRepository _gameRepository;
+    private readonly ILogger<ReplacePieceCommandHandler> _logger;
+
+    /// <param name="gameRepository">Repository for loading and saving games.</param>
+    /// <param name="logger">Logger for structured output.</param>
+    public ReplacePieceCommandHandler(IGameRepository gameRepository, ILogger<ReplacePieceCommandHandler> logger)
+    {
+        _gameRepository = gameRepository;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task Handle(ReplacePieceCommand request, CancellationToken cancellationToken)
+    {
+        var game = await _gameRepository.GetByIdAsync(request.GameId, cancellationToken);
+
+        game.ReplacePiece(request.PlayerId, request.ExistingPieceId, request.NewPieceId, request.TargetPosition);
+
+        await _gameRepository.SaveAsync(game, cancellationToken);
+
+        _logger.LogInformation(
+            "Piece {ExistingPieceId} replaced by {NewPieceId} at {Position} by player {PlayerId} in game {GameId} on turn {Turn}",
+            request.ExistingPieceId, request.NewPieceId, request.TargetPosition, request.PlayerId, request.GameId, game.TurnNumber);
+    }
+}

--- a/src/ScrambleCoin.Application/Games/SkipPlacement/SkipPlacementCommand.cs
+++ b/src/ScrambleCoin.Application/Games/SkipPlacement/SkipPlacementCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace ScrambleCoin.Application.Games.SkipPlacement;
+
+/// <summary>Skips the placement action for a player during PlacePhase.</summary>
+public sealed record SkipPlacementCommand(Guid GameId, Guid PlayerId) : IRequest;

--- a/src/ScrambleCoin.Application/Games/SkipPlacement/SkipPlacementCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/SkipPlacement/SkipPlacementCommandHandler.cs
@@ -1,0 +1,37 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ScrambleCoin.Application.Interfaces;
+
+namespace ScrambleCoin.Application.Games.SkipPlacement;
+
+/// <summary>
+/// Handles <see cref="SkipPlacementCommand"/>: loads the game, records the player's skip,
+/// and persists the updated game.
+/// </summary>
+public sealed class SkipPlacementCommandHandler : IRequestHandler<SkipPlacementCommand>
+{
+    private readonly IGameRepository _gameRepository;
+    private readonly ILogger<SkipPlacementCommandHandler> _logger;
+
+    /// <param name="gameRepository">Repository for loading and saving games.</param>
+    /// <param name="logger">Logger for structured output.</param>
+    public SkipPlacementCommandHandler(IGameRepository gameRepository, ILogger<SkipPlacementCommandHandler> logger)
+    {
+        _gameRepository = gameRepository;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task Handle(SkipPlacementCommand request, CancellationToken cancellationToken)
+    {
+        var game = await _gameRepository.GetByIdAsync(request.GameId, cancellationToken);
+
+        game.SkipPlacement(request.PlayerId);
+
+        await _gameRepository.SaveAsync(game, cancellationToken);
+
+        _logger.LogInformation(
+            "Player {PlayerId} skipped placement in game {GameId} on turn {Turn}",
+            request.PlayerId, request.GameId, game.TurnNumber);
+    }
+}

--- a/src/ScrambleCoin.Domain/Entities/Board.cs
+++ b/src/ScrambleCoin.Domain/Entities/Board.cs
@@ -1,3 +1,4 @@
+using ScrambleCoin.Domain.Enums;
 using ScrambleCoin.Domain.Exceptions;
 using ScrambleCoin.Domain.Obstacles;
 using ScrambleCoin.Domain.ValueObjects;
@@ -180,6 +181,32 @@ public sealed class Board
             _rocks.AsReadOnly(),
             _lakes.AsReadOnly(),
             _fences.AsReadOnly());
+
+    // ── Entry-point helpers ───────────────────────────────────────────────────
+
+    /// <summary>Returns <c>true</c> if <paramref name="position"/> is on any board edge (row = 0 or 7, or col = 0 or 7).</summary>
+    public bool IsEdgeTile(Position position) =>
+        position.Row == 0 || position.Row == Size - 1 ||
+        position.Col == 0 || position.Col == Size - 1;
+
+    /// <summary>Returns <c>true</c> if <paramref name="position"/> is one of the 4 corner tiles.</summary>
+    public bool IsCornerTile(Position position) =>
+        (position.Row == 0 || position.Row == Size - 1) &&
+        (position.Col == 0 || position.Col == Size - 1);
+
+    /// <summary>
+    /// Returns <c>true</c> if <paramref name="position"/> is a valid entry point for the given
+    /// <paramref name="entryPointType"/>.
+    /// </summary>
+    /// <exception cref="DomainException">Thrown for unknown <see cref="EntryPointType"/> values.</exception>
+    public bool IsValidEntryPoint(Position position, EntryPointType entryPointType) =>
+        entryPointType switch
+        {
+            EntryPointType.Borders => IsEdgeTile(position),
+            EntryPointType.Corners => IsCornerTile(position),
+            EntryPointType.Anywhere => true,
+            _ => throw new DomainException($"Unknown EntryPointType: {entryPointType}.")
+        };
 
     /// <summary>
     /// Returns all tiles that are free: empty (no occupant), not covered by a Rock,

--- a/src/ScrambleCoin.Domain/Entities/Game.cs
+++ b/src/ScrambleCoin.Domain/Entities/Game.cs
@@ -522,16 +522,16 @@ public sealed class Game
         if (!Board.IsValidEntryPoint(position, piece.EntryPointType))
             throw new DomainException($"Position {position} is not a valid entry point for entry type {piece.EntryPointType}.");
 
-        var tile = Board.GetTile(position);
+        if (_piecesOnBoard[playerId] >= MaxPiecesOnBoard)
+            throw new DomainException($"Player {playerId} already has the maximum of {MaxPiecesOnBoard} pieces on the board.");
 
         if (Board.IsObstacleCovering(position))
             throw new DomainException($"Cannot place piece at {position}: position is covered by an obstacle.");
 
+        var tile = Board.GetTile(position);
+
         if (tile.AsPiece is not null)
             throw new DomainException($"Cannot place piece at {position}: tile is already occupied by another piece.");
-
-        if (_piecesOnBoard[playerId] >= MaxPiecesOnBoard)
-            throw new DomainException($"Player {playerId} already has the maximum of {MaxPiecesOnBoard} pieces on the board.");
 
         // Collect coin if present.
         var coin = tile.AsCoin;
@@ -596,23 +596,17 @@ public sealed class Game
         if (!Board.IsValidEntryPoint(position, newPiece.EntryPointType))
             throw new DomainException($"Position {position} is not a valid entry point for entry type {newPiece.EntryPointType}.");
 
-        // Remove existing piece from its current tile first.
+        if (Board.IsObstacleCovering(position))
+            throw new DomainException($"Cannot place piece at {position}: position is covered by an obstacle.");
+
+        // Remove existing piece from its current tile so the tile.AsPiece check handles same-tile replacement correctly.
         var existingTile = Board.GetTile(existingPiece.Position!);
         existingTile.ClearOccupant();
         existingPiece.RemoveFromBoard();
         _piecesOnBoard[playerId]--;
 
-        // Now check the target tile (may be the same tile — now clear after step above).
+        // Now check the target tile (may be the same tile — now clear after removal above).
         var tile = Board.GetTile(position);
-
-        if (Board.IsObstacleCovering(position))
-        {
-            // Undo the removal before throwing.
-            existingPiece.PlaceAt(existingTile.Position);
-            existingTile.SetOccupant(existingPiece);
-            _piecesOnBoard[playerId]++;
-            throw new DomainException($"Cannot place piece at {position}: position is covered by an obstacle.");
-        }
 
         if (tile.AsPiece is not null)
         {

--- a/src/ScrambleCoin.Domain/Entities/Game.cs
+++ b/src/ScrambleCoin.Domain/Entities/Game.cs
@@ -82,6 +82,10 @@ public sealed class Game
     /// </summary>
     public TurnPhase? CurrentPhase { get; private set; }
 
+    // ── Place-phase tracking ──────────────────────────────────────────────────
+
+    private readonly HashSet<Guid> _placePhaseDone = new HashSet<Guid>();
+
     // ── Pieces-on-board counters ──────────────────────────────────────────────
 
     private readonly Dictionary<Guid, int> _piecesOnBoard;
@@ -354,6 +358,7 @@ public sealed class Game
         {
             case TurnPhase.CoinSpawn:
                 CurrentPhase = TurnPhase.PlacePhase;
+                _placePhaseDone.Clear();
                 _domainEvents.Add(new TurnPhaseAdvanced(Id, TurnNumber, previousPhase, CurrentPhase, DateTimeOffset.UtcNow));
                 break;
 
@@ -481,5 +486,201 @@ public sealed class Game
         if (!_piecesOnBoard.TryGetValue(playerId, out var count))
             throw new DomainException($"Player {playerId} is not a participant of game {Id}.");
         return count;
+    }
+
+    // ── Piece placement ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Places an off-board piece at a valid entry-point tile during PlacePhase.
+    /// Collects any coin on the target tile and adds it to the player's score.
+    /// Auto-advances to MovePhase once both players have acted (or skipped).
+    /// </summary>
+    /// <exception cref="DomainException">
+    /// Thrown when the current phase is not <see cref="TurnPhase.PlacePhase"/>,
+    /// when the player is not a participant, when the player has already acted this phase,
+    /// when the piece is not in the player's lineup, when the piece is already on the board,
+    /// when the target position violates the piece's entry-point type,
+    /// when the target tile is covered by an obstacle,
+    /// when the target tile is already occupied by another piece,
+    /// or when the player already has the maximum number of pieces on the board.
+    /// </exception>
+    public void PlacePiece(Guid playerId, Guid pieceId, Position position)
+    {
+        EnsureInPlacePhase();
+        EnsureIsParticipant(playerId);
+
+        if (_placePhaseDone.Contains(playerId))
+            throw new DomainException($"Player {playerId} has already acted during the Place Phase this turn.");
+
+        var lineup = GetLineupForPlayer(playerId);
+        var piece = lineup.Pieces.SingleOrDefault(p => p.Id == pieceId)
+            ?? throw new DomainException($"Piece {pieceId} is not in player {playerId}'s lineup.");
+
+        if (piece.IsOnBoard)
+            throw new DomainException($"Piece {pieceId} is already on the board. Use ReplacePiece to swap it.");
+
+        if (!Board.IsValidEntryPoint(position, piece.EntryPointType))
+            throw new DomainException($"Position {position} is not a valid entry point for entry type {piece.EntryPointType}.");
+
+        var tile = Board.GetTile(position);
+
+        if (Board.IsObstacleCovering(position))
+            throw new DomainException($"Cannot place piece at {position}: position is covered by an obstacle.");
+
+        if (tile.AsPiece is not null)
+            throw new DomainException($"Cannot place piece at {position}: tile is already occupied by another piece.");
+
+        if (_piecesOnBoard[playerId] >= MaxPiecesOnBoard)
+            throw new DomainException($"Player {playerId} already has the maximum of {MaxPiecesOnBoard} pieces on the board.");
+
+        // Collect coin if present.
+        var coin = tile.AsCoin;
+        bool coinCollected = coin is not null;
+        int coinValue = coin?.Value ?? 0;
+        if (coinCollected)
+        {
+            tile.ClearOccupant();
+            _scores[playerId] += coinValue;
+        }
+
+        piece.PlaceAt(position);
+        tile.SetOccupant(piece);
+        _piecesOnBoard[playerId]++;
+
+        _domainEvents.Add(new PiecePlaced(Id, TurnNumber, playerId, pieceId, position, coinCollected, coinValue, DateTimeOffset.UtcNow));
+
+        MarkPlacePhaseActed(playerId);
+    }
+
+    /// <summary>
+    /// Removes an on-board piece and places a different lineup piece at the given position during PlacePhase.
+    /// Collects any coin on the target tile and adds it to the player's score.
+    /// Auto-advances to MovePhase once both players have acted (or skipped).
+    /// </summary>
+    /// <exception cref="DomainException">
+    /// Thrown when the current phase is not <see cref="TurnPhase.PlacePhase"/>,
+    /// when the player is not a participant, when the player has already acted this phase,
+    /// when either piece is not in the player's lineup,
+    /// when the existing piece is not on the board,
+    /// when the new piece is already on the board,
+    /// when <paramref name="existingPieceId"/> equals <paramref name="newPieceId"/>,
+    /// when the target position violates the new piece's entry-point type,
+    /// when the target tile is covered by an obstacle,
+    /// or when the target tile is already occupied by a different piece.
+    /// </exception>
+    public void ReplacePiece(Guid playerId, Guid existingPieceId, Guid newPieceId, Position position)
+    {
+        EnsureInPlacePhase();
+        EnsureIsParticipant(playerId);
+
+        if (_placePhaseDone.Contains(playerId))
+            throw new DomainException($"Player {playerId} has already acted during the Place Phase this turn.");
+
+        if (existingPieceId == newPieceId)
+            throw new DomainException("ExistingPieceId and NewPieceId must be different.");
+
+        var lineup = GetLineupForPlayer(playerId);
+
+        var existingPiece = lineup.Pieces.SingleOrDefault(p => p.Id == existingPieceId)
+            ?? throw new DomainException($"Piece {existingPieceId} is not in player {playerId}'s lineup.");
+
+        if (!existingPiece.IsOnBoard)
+            throw new DomainException($"Piece {existingPieceId} is not on the board; cannot replace it.");
+
+        var newPiece = lineup.Pieces.SingleOrDefault(p => p.Id == newPieceId)
+            ?? throw new DomainException($"Piece {newPieceId} is not in player {playerId}'s lineup.");
+
+        if (newPiece.IsOnBoard)
+            throw new DomainException($"Piece {newPieceId} is already on the board; cannot use it as the replacement.");
+
+        if (!Board.IsValidEntryPoint(position, newPiece.EntryPointType))
+            throw new DomainException($"Position {position} is not a valid entry point for entry type {newPiece.EntryPointType}.");
+
+        // Remove existing piece from its current tile first.
+        var existingTile = Board.GetTile(existingPiece.Position!);
+        existingTile.ClearOccupant();
+        existingPiece.RemoveFromBoard();
+        _piecesOnBoard[playerId]--;
+
+        // Now check the target tile (may be the same tile — now clear after step above).
+        var tile = Board.GetTile(position);
+
+        if (Board.IsObstacleCovering(position))
+        {
+            // Undo the removal before throwing.
+            existingPiece.PlaceAt(existingTile.Position);
+            existingTile.SetOccupant(existingPiece);
+            _piecesOnBoard[playerId]++;
+            throw new DomainException($"Cannot place piece at {position}: position is covered by an obstacle.");
+        }
+
+        if (tile.AsPiece is not null)
+        {
+            // Undo the removal before throwing.
+            existingPiece.PlaceAt(existingTile.Position);
+            existingTile.SetOccupant(existingPiece);
+            _piecesOnBoard[playerId]++;
+            throw new DomainException($"Cannot place piece at {position}: tile is already occupied by another piece.");
+        }
+
+        // Collect coin if present at target tile.
+        var coin = tile.AsCoin;
+        bool coinCollected = coin is not null;
+        int coinValue = coin?.Value ?? 0;
+        if (coinCollected)
+        {
+            tile.ClearOccupant();
+            _scores[playerId] += coinValue;
+        }
+
+        newPiece.PlaceAt(position);
+        tile.SetOccupant(newPiece);
+        _piecesOnBoard[playerId]++;
+
+        _domainEvents.Add(new PieceReplaced(Id, TurnNumber, playerId, existingPieceId, newPieceId, position, coinCollected, coinValue, DateTimeOffset.UtcNow));
+
+        MarkPlacePhaseActed(playerId);
+    }
+
+    /// <summary>
+    /// Skips the placement action for this player this turn.
+    /// Auto-advances to MovePhase once both players have acted (or skipped).
+    /// </summary>
+    /// <exception cref="DomainException">
+    /// Thrown when the current phase is not <see cref="TurnPhase.PlacePhase"/>,
+    /// when the player is not a participant,
+    /// or when the player has already acted this phase.
+    /// </exception>
+    public void SkipPlacement(Guid playerId)
+    {
+        EnsureInPlacePhase();
+        EnsureIsParticipant(playerId);
+
+        if (_placePhaseDone.Contains(playerId))
+            throw new DomainException($"Player {playerId} has already acted during the Place Phase this turn.");
+
+        MarkPlacePhaseActed(playerId);
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private void MarkPlacePhaseActed(Guid playerId)
+    {
+        _placePhaseDone.Add(playerId);
+        if (_placePhaseDone.Contains(PlayerOne) && _placePhaseDone.Contains(PlayerTwo))
+            AdvancePhase(); // PlacePhase → MovePhase
+    }
+
+    private void EnsureIsParticipant(Guid playerId)
+    {
+        if (playerId != PlayerOne && playerId != PlayerTwo)
+            throw new DomainException($"Player {playerId} is not a participant of game {Id}.");
+    }
+
+    private Lineup GetLineupForPlayer(Guid playerId)
+    {
+        if (playerId == PlayerOne)
+            return LineupPlayerOne ?? throw new DomainException("PlayerOne's lineup has not been set.");
+        return LineupPlayerTwo ?? throw new DomainException("PlayerTwo's lineup has not been set.");
     }
 }

--- a/src/ScrambleCoin.Domain/Events/PiecePlaced.cs
+++ b/src/ScrambleCoin.Domain/Events/PiecePlaced.cs
@@ -1,0 +1,16 @@
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Domain.Events;
+
+/// <summary>
+/// Raised when a player places an off-board piece onto the board during PlacePhase.
+/// </summary>
+public sealed record PiecePlaced(
+    Guid GameId,
+    int TurnNumber,
+    Guid PlayerId,
+    Guid PieceId,
+    Position Position,
+    bool CoinCollected,
+    int CoinValue,
+    DateTimeOffset OccurredAt) : IDomainEvent;

--- a/src/ScrambleCoin.Domain/Events/PieceReplaced.cs
+++ b/src/ScrambleCoin.Domain/Events/PieceReplaced.cs
@@ -1,0 +1,18 @@
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Domain.Events;
+
+/// <summary>
+/// Raised when a player removes an on-board piece and places a different lineup piece
+/// in its stead during PlacePhase.
+/// </summary>
+public sealed record PieceReplaced(
+    Guid GameId,
+    int TurnNumber,
+    Guid PlayerId,
+    Guid RemovedPieceId,
+    Guid PlacedPieceId,
+    Position Position,
+    bool CoinCollected,
+    int CoinValue,
+    DateTimeOffset OccurredAt) : IDomainEvent;

--- a/tests/ScrambleCoin.Application.Tests/PlacePieceCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/PlacePieceCommandHandlerTests.cs
@@ -1,0 +1,55 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using ScrambleCoin.Application.Games.PlacePiece;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="PlacePieceCommandHandler"/>.
+/// </summary>
+public class PlacePieceCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_CallsPlacePieceAndSavesGame()
+    {
+        // Arrange
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var board = new Board();
+
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Piece{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Piece{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, board);
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start();
+        game.AdvancePhase(); // → PlacePhase
+
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var logger = Substitute.For<ILogger<PlacePieceCommandHandler>>();
+        var handler = new PlacePieceCommandHandler(repo, logger);
+
+        var command = new PlacePieceCommand(game.Id, p1, p1Pieces[0].Id, new Position(0, 0));
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert: piece was placed on the board.
+        Assert.True(p1Pieces[0].IsOnBoard);
+
+        // Assert: game was saved.
+        await repo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/ScrambleCoin.Application.Tests/ReplacePieceCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/ReplacePieceCommandHandlerTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using ScrambleCoin.Application.Games.ReplacePiece;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ReplacePieceCommandHandler"/>.
+/// </summary>
+public class ReplacePieceCommandHandlerTests
+{
+    private static (Game game, Guid p1, Guid p2, List<Piece> p1Pieces, List<Piece> p2Pieces) GameInPlacePhaseWithOnePiecePlaced()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Piece{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Piece{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+
+        // Place first piece so it can be replaced
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+
+        // Reset phase tracking: p2 skips so phase auto-advanced to MovePhase;
+        // we need to get back to PlacePhase for the next turn.
+        game.SkipPlacement(p2); // both acted → auto-advance to MovePhase
+        game.AdvanceTurn();     // MovePhase → turn 2, CoinSpawn
+        game.AdvancePhase();    // CoinSpawn → PlacePhase (turn 2)
+
+        return (game, p1, p2, p1Pieces, p2Pieces);
+    }
+
+    [Fact]
+    public async Task Handle_CallsReplacePieceAndSavesGame()
+    {
+        // Arrange
+        var (game, p1, p2, p1Pieces, _) = GameInPlacePhaseWithOnePiecePlaced();
+
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var logger = Substitute.For<ILogger<ReplacePieceCommandHandler>>();
+        var handler = new ReplacePieceCommandHandler(repo, logger);
+
+        // Replace p1Pieces[0] (on board at (0,0)) with p1Pieces[1] (off board) at (0,1)
+        var command = new ReplacePieceCommand(game.Id, p1, p1Pieces[0].Id, p1Pieces[1].Id, new Position(0, 1));
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert: old piece removed, new piece placed
+        Assert.False(p1Pieces[0].IsOnBoard);
+        Assert.True(p1Pieces[1].IsOnBoard);
+        Assert.Equal(new Position(0, 1), p1Pieces[1].Position);
+
+        // Assert: game was saved
+        await repo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/ScrambleCoin.Application.Tests/SkipPlacementCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/SkipPlacementCommandHandlerTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using ScrambleCoin.Application.Games.SkipPlacement;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SkipPlacementCommandHandler"/>.
+/// </summary>
+public class SkipPlacementCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_CallsSkipPlacementAndSavesGame()
+    {
+        // Arrange
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Piece{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Piece{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var logger = Substitute.For<ILogger<SkipPlacementCommandHandler>>();
+        var handler = new SkipPlacementCommandHandler(repo, logger);
+
+        var command = new SkipPlacementCommand(game.Id, p1);
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert: game is still in PlacePhase (only p1 skipped; p2 hasn't acted yet)
+        Assert.Equal(TurnPhase.PlacePhase, game.CurrentPhase);
+
+        // Assert: game was saved
+        await repo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_BothPlayersSkip_AutoAdvancesToMovePhase()
+    {
+        // Arrange
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Piece{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Piece{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var logger = Substitute.For<ILogger<SkipPlacementCommandHandler>>();
+        var handler = new SkipPlacementCommandHandler(repo, logger);
+
+        // Act: both players skip
+        await handler.Handle(new SkipPlacementCommand(game.Id, p1), CancellationToken.None);
+        await handler.Handle(new SkipPlacementCommand(game.Id, p2), CancellationToken.None);
+
+        // Assert: phase auto-advanced to MovePhase
+        Assert.Equal(TurnPhase.MovePhase, game.CurrentPhase);
+
+        await repo.Received(2).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/ScrambleCoin.Application.Tests/SpawnCoinsCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/SpawnCoinsCommandHandlerTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using ScrambleCoin.Application.Games.SpawnCoins;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SpawnCoinsCommandHandler"/>.
+/// </summary>
+public class SpawnCoinsCommandHandlerTests
+{
+    private static Game GameInCoinSpawnPhase()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Piece{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Piece{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start(); // → CoinSpawn phase, turn 1
+        return game;
+    }
+
+    [Fact]
+    public async Task Handle_SpawnsCoinsOnBoardAndSavesGame()
+    {
+        // Arrange
+        var game = GameInCoinSpawnPhase();
+
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var logger = Substitute.For<ILogger<SpawnCoinsCommandHandler>>();
+        // Use a seeded Random for deterministic tile selection
+        var random = new Random(42);
+        var handler = new SpawnCoinsCommandHandler(repo, random, logger);
+
+        var command = new SpawnCoinsCommand(game.Id);
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert: at least one coin was spawned (turn 1 schedule guarantees coins)
+        var coinTiles = game.Board.GetAllCoins();
+        Assert.NotEmpty(coinTiles);
+
+        // Assert: game was saved
+        await repo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_Turn1_SpawnsSilverCoins()
+    {
+        // Arrange
+        var game = GameInCoinSpawnPhase(); // turn 1
+
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var logger = Substitute.For<ILogger<SpawnCoinsCommandHandler>>();
+        var random = new Random(0);
+        var handler = new SpawnCoinsCommandHandler(repo, random, logger);
+
+        // Act
+        await handler.Handle(new SpawnCoinsCommand(game.Id), CancellationToken.None);
+
+        // Assert: all spawned coins on turn 1 are Silver
+        var coinTiles = game.Board.GetAllCoins();
+        Assert.All(coinTiles, t => Assert.Equal(CoinType.Silver, t.AsCoin!.CoinType));
+    }
+
+    [Fact]
+    public async Task Handle_WhenBoardFull_SpawnsOnlyAsManyAsFit()
+    {
+        // Arrange: fill all but 2 tiles with pieces so almost no free tiles remain
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Piece{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Piece{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+
+        var board = new Board();
+        var game = new Game(p1, p2, board);
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start();
+
+        // Manually fill almost all tiles with fake coin occupants to simulate a crowded board
+        // Leave only 2 free tiles: (7,6) and (7,7)
+        for (var row = 0; row < 8; row++)
+        for (var col = 0; col < 8; col++)
+        {
+            if (row == 7 && col >= 6) continue; // leave 2 free
+            board.GetTile(new Position(row, col)).SetOccupant(new Coin(CoinType.Silver));
+        }
+
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var logger = Substitute.For<ILogger<SpawnCoinsCommandHandler>>();
+        var random = new Random(1);
+        var handler = new SpawnCoinsCommandHandler(repo, random, logger);
+
+        // Act: should not throw; spawns ≤ 2 coins
+        await handler.Handle(new SpawnCoinsCommand(game.Id), CancellationToken.None);
+
+        // Assert: no more than 2 coins were added to the originally-free tiles
+        var freeTileCoins = new[]
+        {
+            board.GetTile(new Position(7, 6)).AsCoin,
+            board.GetTile(new Position(7, 7)).AsCoin
+        }.Count(c => c is not null);
+
+        Assert.True(freeTileCoins <= 2);
+        await repo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/ScrambleCoin.Domain.Tests/PiecePlacementTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/PiecePlacementTests.cs
@@ -566,6 +566,107 @@ public class PiecePlacementTests
         Assert.Contains("entry point", ex.Message);
     }
 
+    [Fact]
+    public void ReplacePiece_TargetTileOccupied_OldPieceStillOnBoard()
+    {
+        // Arrange: place p1 and p2 pieces in turn 1, then advance to turn 2 PlacePhase.
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+        var posA = new Position(0, 0);
+        var posB = new Position(7, 0);
+
+        game.PlacePiece(p1, p1Pieces[0].Id, posA);
+        game.PlacePiece(p2, p2Pieces[0].Id, posB);
+        game.AdvanceTurn();
+        game.AdvancePhase();
+
+        // Act & Assert: replacing p1's piece targeting posB (occupied by p2) should throw.
+        Assert.Throws<DomainException>(
+            () => game.ReplacePiece(p1, p1Pieces[0].Id, p1Pieces[1].Id, posB));
+
+        // Rollback: old piece must be restored to its original position.
+        Assert.True(p1Pieces[0].IsOnBoard);
+        Assert.Equal(posA, p1Pieces[0].Position);
+        Assert.Equal(1, game.PiecesOnBoard[p1]);
+    }
+
+    [Fact]
+    public void ReplacePiece_WrongPhase_Throws()
+    {
+        // Arrange: create a game in CoinSpawnPhase (before PlacePhase).
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => MakePiece(p1, EntryPointType.Borders, $"P1Piece{i}"))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => MakePiece(p2, EntryPointType.Borders, $"P2Piece{i}"))
+            .ToList();
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start(); // → CoinSpawnPhase (not PlacePhase)
+
+        // Act & Assert: phase guard fires before any piece validation.
+        var ex = Assert.Throws<DomainException>(
+            () => game.ReplacePiece(p1, p1Pieces[0].Id, p1Pieces[1].Id, new Position(0, 0)));
+        Assert.Contains("PlacePhase", ex.Message);
+    }
+
+    [Fact]
+    public void ReplacePiece_NonParticipant_Throws()
+    {
+        // Arrange: game in PlacePhase — stranger ID is unknown to the game.
+        var (game, _, _, _, _) = GameInPlacePhase();
+        var stranger = Guid.NewGuid();
+
+        // Act & Assert.
+        var ex = Assert.Throws<DomainException>(
+            () => game.ReplacePiece(stranger, Guid.NewGuid(), Guid.NewGuid(), new Position(0, 0)));
+        Assert.Contains("not a participant", ex.Message);
+    }
+
+    [Fact]
+    public void ReplacePiece_ActingTwice_Throws()
+    {
+        // Arrange: set up turn 2 PlacePhase with p1's piece on board.
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 0));
+        game.AdvanceTurn();
+        game.AdvancePhase();
+
+        // p1 acts once successfully.
+        game.ReplacePiece(p1, p1Pieces[0].Id, p1Pieces[1].Id, new Position(0, 1));
+
+        // p2 has not yet acted — p1 tries again.
+        var ex = Assert.Throws<DomainException>(
+            () => game.ReplacePiece(p1, p1Pieces[1].Id, p1Pieces[2].Id, new Position(0, 2)));
+        Assert.Contains("already acted", ex.Message);
+    }
+
+    [Fact]
+    public void ReplacePiece_SameTile_Succeeds()
+    {
+        // Arrange: p1Pieces[0] is on board at posA; replace it with p1Pieces[1] targeting the same tile.
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+        var posA = new Position(0, 0);
+
+        game.PlacePiece(p1, p1Pieces[0].Id, posA);
+        game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 0));
+        game.AdvanceTurn();
+        game.AdvancePhase();
+
+        // Act: replace with the same target position.
+        game.ReplacePiece(p1, p1Pieces[0].Id, p1Pieces[1].Id, posA);
+
+        // Assert: new piece is at posA, old piece is off board, net count unchanged.
+        Assert.True(p1Pieces[1].IsOnBoard);
+        Assert.Equal(posA, p1Pieces[1].Position);
+        Assert.False(p1Pieces[0].IsOnBoard);
+        Assert.Equal(1, game.PiecesOnBoard[p1]);
+    }
+
     // ── Board helper methods ──────────────────────────────────────────────────
 
     [Theory]

--- a/tests/ScrambleCoin.Domain.Tests/PiecePlacementTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/PiecePlacementTests.cs
@@ -1,0 +1,612 @@
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Events;
+using ScrambleCoin.Domain.Exceptions;
+using ScrambleCoin.Domain.Obstacles;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Domain.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="Game.PlacePiece"/>, <see cref="Game.ReplacePiece"/>,
+/// and <see cref="Game.SkipPlacement"/>.
+/// </summary>
+public class PiecePlacementTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static Piece MakePiece(Guid playerId, EntryPointType entryPointType = EntryPointType.Borders, string name = "TestPiece") =>
+        new Piece(Guid.NewGuid(), name, playerId, entryPointType, MovementType.Orthogonal, 1, 1);
+
+    /// <summary>
+    /// Creates a Game in PlacePhase with 5 Borders pieces per player.
+    /// </summary>
+    private static (Game game, Guid p1, Guid p2, List<Piece> p1Pieces, List<Piece> p2Pieces) GameInPlacePhase()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var board = new Board();
+
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => MakePiece(p1, EntryPointType.Borders, $"P1Piece{i}"))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => MakePiece(p2, EntryPointType.Borders, $"P2Piece{i}"))
+            .ToList();
+
+        var game = new Game(p1, p2, board);
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start();          // → CoinSpawn
+        game.AdvancePhase();   // → PlacePhase
+        game.ClearDomainEvents();
+
+        return (game, p1, p2, p1Pieces, p2Pieces);
+    }
+
+    // ── PlacePiece happy path ─────────────────────────────────────────────────
+
+    [Fact]
+    public void PlacePiece_HappyPath_PlacesPieceOnBoard()
+    {
+        var (game, p1, p2, p1Pieces, _) = GameInPlacePhase();
+        var piece = p1Pieces[0];
+        var pos = new Position(0, 0);
+
+        game.PlacePiece(p1, piece.Id, pos);
+
+        Assert.True(piece.IsOnBoard);
+        Assert.Equal(pos, piece.Position);
+        Assert.Equal(piece, game.Board.GetTile(pos).AsPiece);
+        Assert.Equal(1, game.PiecesOnBoard[p1]);
+        Assert.Equal(0, game.Scores[p1]); // no coin
+    }
+
+    [Fact]
+    public void PlacePiece_HappyPath_RaisesPiecePlacedEvent()
+    {
+        var (game, p1, _, p1Pieces, _) = GameInPlacePhase();
+        var piece = p1Pieces[0];
+        var pos = new Position(0, 1);
+
+        game.PlacePiece(p1, piece.Id, pos);
+
+        var evt = Assert.Single(game.DomainEvents.OfType<PiecePlaced>());
+        Assert.Equal(game.Id, evt.GameId);
+        Assert.Equal(p1, evt.PlayerId);
+        Assert.Equal(piece.Id, evt.PieceId);
+        Assert.Equal(pos, evt.Position);
+        Assert.False(evt.CoinCollected);
+        Assert.Equal(0, evt.CoinValue);
+    }
+
+    [Fact]
+    public void PlacePiece_OnCoinTile_CollectsCoinAndScores()
+    {
+        var (game, p1, p2, p1Pieces, _) = GameInPlacePhase();
+
+        // Put coin on an edge tile by using SpawnCoins during CoinSpawn phase.
+        // We can't spawn in PlacePhase, so place a coin manually on the tile.
+        var pos = new Position(0, 3);
+        game.Board.GetTile(pos).SetOccupant(new Coin(CoinType.Silver)); // value = 1
+
+        var piece = p1Pieces[0];
+        game.PlacePiece(p1, piece.Id, pos);
+
+        Assert.Equal(1, game.Scores[p1]);
+        Assert.Equal(piece, game.Board.GetTile(pos).AsPiece);
+
+        var evt = Assert.Single(game.DomainEvents.OfType<PiecePlaced>());
+        Assert.True(evt.CoinCollected);
+        Assert.Equal(1, evt.CoinValue);
+    }
+
+    [Fact]
+    public void PlacePiece_OnGoldCoinTile_CollectsGoldValue()
+    {
+        var (game, p1, _, p1Pieces, _) = GameInPlacePhase();
+        var pos = new Position(7, 7);
+        game.Board.GetTile(pos).SetOccupant(new Coin(CoinType.Gold)); // value = 3
+
+        game.PlacePiece(p1, p1Pieces[0].Id, pos);
+
+        Assert.Equal(3, game.Scores[p1]);
+    }
+
+    // ── PlacePiece error cases ────────────────────────────────────────────────
+
+    [Fact]
+    public void PlacePiece_WrongPhase_Throws()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => MakePiece(p1, EntryPointType.Borders, $"P1Piece{i}"))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => MakePiece(p2, EntryPointType.Borders, $"P2Piece{i}"))
+            .ToList();
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start(); // → CoinSpawn
+
+        var ex = Assert.Throws<DomainException>(() => game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0)));
+        Assert.Contains("PlacePhase", ex.Message);
+    }
+
+    [Fact]
+    public void PlacePiece_PieceNotInLineup_Throws()
+    {
+        var (game, p1, _, _, _) = GameInPlacePhase();
+        var randomPieceId = Guid.NewGuid();
+
+        var ex = Assert.Throws<DomainException>(() => game.PlacePiece(p1, randomPieceId, new Position(0, 0)));
+        Assert.Contains(randomPieceId.ToString(), ex.Message);
+    }
+
+    [Fact]
+    public void PlacePiece_PieceAlreadyOnBoard_Throws()
+    {
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+        var piece = p1Pieces[0];
+
+        // Place it once.
+        game.PlacePiece(p1, piece.Id, new Position(0, 0));
+        game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 0)); // p2 acts so phase stays in PlacePhase for next turn
+        // Advance to next turn's PlacePhase.
+        game.AdvanceTurn(); // MovePhase → next turn CoinSpawn
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+
+        // Now try to PlacePiece again with the same piece (already on board).
+        var ex = Assert.Throws<DomainException>(() => game.PlacePiece(p1, piece.Id, new Position(0, 1)));
+        Assert.Contains("already on the board", ex.Message);
+    }
+
+    [Fact]
+    public void PlacePiece_OccupiedByPieceTile_Throws()
+    {
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        // p2 tries to place on the same tile.
+        var ex = Assert.Throws<DomainException>(() => game.PlacePiece(p2, p2Pieces[0].Id, new Position(0, 0)));
+        Assert.Contains("already occupied", ex.Message);
+    }
+
+    [Fact]
+    public void PlacePiece_ObstacleTile_Throws()
+    {
+        var (game, p1, _, p1Pieces, _) = GameInPlacePhase();
+        var obstaclePos = new Position(0, 0);
+        game.Board.AddRock(new Rock(obstaclePos));
+
+        var ex = Assert.Throws<DomainException>(() => game.PlacePiece(p1, p1Pieces[0].Id, obstaclePos));
+        Assert.Contains("obstacle", ex.Message);
+    }
+
+    [Fact]
+    public void PlacePiece_BordersPieceOnCenter_Throws()
+    {
+        var (game, p1, _, p1Pieces, _) = GameInPlacePhase();
+        // p1Pieces have Borders entry type; (4,4) is not an edge tile.
+
+        var ex = Assert.Throws<DomainException>(() => game.PlacePiece(p1, p1Pieces[0].Id, new Position(4, 4)));
+        Assert.Contains("entry point", ex.Message);
+    }
+
+    [Fact]
+    public void PlacePiece_CornersPieceOnCorner_Succeeds()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var pieces1 = new List<Piece>
+        {
+            MakePiece(p1, EntryPointType.Corners, "CornerPiece"),
+            MakePiece(p1, EntryPointType.Borders, "B1"),
+            MakePiece(p1, EntryPointType.Borders, "B2"),
+            MakePiece(p1, EntryPointType.Borders, "B3"),
+            MakePiece(p1, EntryPointType.Borders, "B4"),
+        };
+        var pieces2 = Enumerable.Range(0, 5).Select(i => MakePiece(p2, EntryPointType.Borders, $"P2{i}")).ToList();
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(pieces1));
+        game.SetLineup(p2, new Lineup(pieces2));
+        game.Start();
+        game.AdvancePhase();
+
+        // Should not throw — (0,0) is a corner.
+        game.PlacePiece(p1, pieces1[0].Id, new Position(0, 0));
+
+        Assert.True(pieces1[0].IsOnBoard);
+    }
+
+    [Fact]
+    public void PlacePiece_CornersPieceOnNonCornerEdge_Throws()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var pieces1 = new List<Piece>
+        {
+            MakePiece(p1, EntryPointType.Corners, "CornerPiece"),
+            MakePiece(p1, EntryPointType.Borders, "B1"),
+            MakePiece(p1, EntryPointType.Borders, "B2"),
+            MakePiece(p1, EntryPointType.Borders, "B3"),
+            MakePiece(p1, EntryPointType.Borders, "B4"),
+        };
+        var pieces2 = Enumerable.Range(0, 5).Select(i => MakePiece(p2, EntryPointType.Borders, $"P2{i}")).ToList();
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(pieces1));
+        game.SetLineup(p2, new Lineup(pieces2));
+        game.Start();
+        game.AdvancePhase();
+
+        // (0,1) is an edge but NOT a corner.
+        var ex = Assert.Throws<DomainException>(() => game.PlacePiece(p1, pieces1[0].Id, new Position(0, 1)));
+        Assert.Contains("entry point", ex.Message);
+    }
+
+    [Fact]
+    public void PlacePiece_AnywherePieceOnCenter_Succeeds()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var pieces1 = new List<Piece>
+        {
+            MakePiece(p1, EntryPointType.Anywhere, "AnyPiece"),
+            MakePiece(p1, EntryPointType.Borders, "B1"),
+            MakePiece(p1, EntryPointType.Borders, "B2"),
+            MakePiece(p1, EntryPointType.Borders, "B3"),
+            MakePiece(p1, EntryPointType.Borders, "B4"),
+        };
+        var pieces2 = Enumerable.Range(0, 5).Select(i => MakePiece(p2, EntryPointType.Borders, $"P2{i}")).ToList();
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(pieces1));
+        game.SetLineup(p2, new Lineup(pieces2));
+        game.Start();
+        game.AdvancePhase();
+
+        game.PlacePiece(p1, pieces1[0].Id, new Position(4, 4));
+
+        Assert.True(pieces1[0].IsOnBoard);
+    }
+
+    [Fact]
+    public void PlacePiece_MaxPiecesExceeded_Throws()
+    {
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+
+        // Place p1's first piece this turn.
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 0));
+
+        // Turn 2.
+        game.AdvanceTurn();
+        game.AdvancePhase();
+        game.PlacePiece(p1, p1Pieces[1].Id, new Position(0, 1));
+        game.PlacePiece(p2, p2Pieces[1].Id, new Position(7, 1));
+
+        // Turn 3 — place 3rd piece for p1.
+        game.AdvanceTurn();
+        game.AdvancePhase();
+        game.PlacePiece(p1, p1Pieces[2].Id, new Position(0, 2));
+        game.PlacePiece(p2, p2Pieces[2].Id, new Position(7, 2));
+
+        // Turn 4 — p1 tries to place a 4th piece.
+        game.AdvanceTurn();
+        game.AdvancePhase();
+        var ex = Assert.Throws<DomainException>(() => game.PlacePiece(p1, p1Pieces[3].Id, new Position(0, 3)));
+        Assert.Contains("maximum", ex.Message);
+    }
+
+    [Fact]
+    public void PlacePiece_NonParticipant_Throws()
+    {
+        var (game, _, _, _, _) = GameInPlacePhase();
+        var stranger = Guid.NewGuid();
+
+        var ex = Assert.Throws<DomainException>(() => game.PlacePiece(stranger, Guid.NewGuid(), new Position(0, 0)));
+        Assert.Contains("not a participant", ex.Message);
+    }
+
+    [Fact]
+    public void PlacePiece_ActingTwice_Throws()
+    {
+        var (game, p1, _, p1Pieces, _) = GameInPlacePhase();
+
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+
+        // Phase has not yet advanced (p2 hasn't acted), but p1 tries again on a different turn assumption —
+        // actually at this point the phase already advanced if p2 acted or didn't.
+        // Since p2 hasn't acted, phase is still PlacePhase and p1 already acted.
+        var ex = Assert.Throws<DomainException>(() => game.PlacePiece(p1, p1Pieces[1].Id, new Position(0, 1)));
+        Assert.Contains("already acted", ex.Message);
+    }
+
+    // ── Auto-advance to MovePhase ──────────────────────────────────────────────
+
+    [Fact]
+    public void PlacePiece_BothPlayersAct_AutoAdvancesToMovePhase()
+    {
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        Assert.Equal(TurnPhase.PlacePhase, game.CurrentPhase); // p2 hasn't acted yet
+
+        game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 0));
+        Assert.Equal(TurnPhase.MovePhase, game.CurrentPhase); // auto-advanced
+    }
+
+    [Fact]
+    public void SkipPlacement_BothPlayers_AutoAdvancesToMovePhase()
+    {
+        var (game, p1, p2, _, _) = GameInPlacePhase();
+
+        game.SkipPlacement(p1);
+        Assert.Equal(TurnPhase.PlacePhase, game.CurrentPhase);
+
+        game.SkipPlacement(p2);
+        Assert.Equal(TurnPhase.MovePhase, game.CurrentPhase);
+    }
+
+    [Fact]
+    public void PlacePieceAndSkip_AutoAdvancesToMovePhase()
+    {
+        var (game, p1, p2, p1Pieces, _) = GameInPlacePhase();
+
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        game.SkipPlacement(p2);
+
+        Assert.Equal(TurnPhase.MovePhase, game.CurrentPhase);
+    }
+
+    // ── SkipPlacement error cases ─────────────────────────────────────────────
+
+    [Fact]
+    public void SkipPlacement_WrongPhase_Throws()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(Enumerable.Range(0, 5).Select(i => MakePiece(p1, EntryPointType.Borders, $"P1{i}")).ToList()));
+        game.SetLineup(p2, new Lineup(Enumerable.Range(0, 5).Select(i => MakePiece(p2, EntryPointType.Borders, $"P2{i}")).ToList()));
+        game.Start(); // CoinSpawn phase
+
+        var ex = Assert.Throws<DomainException>(() => game.SkipPlacement(p1));
+        Assert.Contains("PlacePhase", ex.Message);
+    }
+
+    [Fact]
+    public void SkipPlacement_ActingTwice_Throws()
+    {
+        var (game, p1, _, _, _) = GameInPlacePhase();
+
+        game.SkipPlacement(p1);
+
+        // Phase hasn't advanced yet (p2 hasn't acted).
+        var ex = Assert.Throws<DomainException>(() => game.SkipPlacement(p1));
+        Assert.Contains("already acted", ex.Message);
+    }
+
+    [Fact]
+    public void SkipPlacement_NonParticipant_Throws()
+    {
+        var (game, _, _, _, _) = GameInPlacePhase();
+        var stranger = Guid.NewGuid();
+
+        var ex = Assert.Throws<DomainException>(() => game.SkipPlacement(stranger));
+        Assert.Contains("not a participant", ex.Message);
+    }
+
+    // ── ReplacePiece happy path ───────────────────────────────────────────────
+
+    [Fact]
+    public void ReplacePiece_HappyPath_OldGoneNewOnBoard()
+    {
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+
+        // Place first piece.
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 0));
+
+        // Advance to turn 2 PlacePhase.
+        game.AdvanceTurn();
+        game.AdvancePhase();
+        game.ClearDomainEvents();
+
+        // Replace p1Pieces[0] with p1Pieces[1] at a new position.
+        var newPos = new Position(0, 1);
+        game.ReplacePiece(p1, p1Pieces[0].Id, p1Pieces[1].Id, newPos);
+
+        Assert.False(p1Pieces[0].IsOnBoard);
+        Assert.True(p1Pieces[1].IsOnBoard);
+        Assert.Equal(newPos, p1Pieces[1].Position);
+        Assert.Equal(p1Pieces[1], game.Board.GetTile(newPos).AsPiece);
+        Assert.Null(game.Board.GetTile(new Position(0, 0)).AsPiece);
+        Assert.Equal(1, game.PiecesOnBoard[p1]); // net count unchanged
+    }
+
+    [Fact]
+    public void ReplacePiece_HappyPath_RaisesPieceReplacedEvent()
+    {
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 0));
+        game.AdvanceTurn();
+        game.AdvancePhase();
+        game.ClearDomainEvents();
+
+        var newPos = new Position(0, 1);
+        game.ReplacePiece(p1, p1Pieces[0].Id, p1Pieces[1].Id, newPos);
+
+        var evt = Assert.Single(game.DomainEvents.OfType<PieceReplaced>());
+        Assert.Equal(p1, evt.PlayerId);
+        Assert.Equal(p1Pieces[0].Id, evt.RemovedPieceId);
+        Assert.Equal(p1Pieces[1].Id, evt.PlacedPieceId);
+        Assert.Equal(newPos, evt.Position);
+        Assert.False(evt.CoinCollected);
+        Assert.Equal(0, evt.CoinValue);
+    }
+
+    [Fact]
+    public void ReplacePiece_OnCoinTile_CollectsCoin()
+    {
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 0));
+        game.AdvanceTurn();
+        game.AdvancePhase();
+
+        // Put a coin on target edge tile.
+        var newPos = new Position(0, 1);
+        game.Board.GetTile(newPos).SetOccupant(new Coin(CoinType.Gold)); // value = 3
+
+        game.ReplacePiece(p1, p1Pieces[0].Id, p1Pieces[1].Id, newPos);
+
+        Assert.Equal(3, game.Scores[p1]);
+        var evt = game.DomainEvents.OfType<PieceReplaced>().Last();
+        Assert.True(evt.CoinCollected);
+        Assert.Equal(3, evt.CoinValue);
+    }
+
+    [Fact]
+    public void ReplacePiece_PieceCountStaysSame()
+    {
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 0));
+        game.AdvanceTurn();
+        game.AdvancePhase();
+
+        var countBefore = game.PiecesOnBoard[p1];
+        game.ReplacePiece(p1, p1Pieces[0].Id, p1Pieces[1].Id, new Position(0, 1));
+
+        Assert.Equal(countBefore, game.PiecesOnBoard[p1]);
+    }
+
+    // ── ReplacePiece error cases ──────────────────────────────────────────────
+
+    [Fact]
+    public void ReplacePiece_OldPieceNotOnBoard_Throws()
+    {
+        var (game, p1, _, p1Pieces, _) = GameInPlacePhase();
+
+        // p1Pieces[0] is not on board — try to replace it.
+        var ex = Assert.Throws<DomainException>(
+            () => game.ReplacePiece(p1, p1Pieces[0].Id, p1Pieces[1].Id, new Position(0, 0)));
+        Assert.Contains("not on the board", ex.Message);
+    }
+
+    [Fact]
+    public void ReplacePiece_NewPieceAlreadyOnBoard_Throws()
+    {
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 0));
+        game.AdvanceTurn();
+        game.AdvancePhase();
+        game.PlacePiece(p1, p1Pieces[1].Id, new Position(0, 1));
+        game.PlacePiece(p2, p2Pieces[1].Id, new Position(7, 1));
+        game.AdvanceTurn();
+        game.AdvancePhase();
+
+        // Both pieces [0] and [1] are on board. Try to replace [0] with [1].
+        var ex = Assert.Throws<DomainException>(
+            () => game.ReplacePiece(p1, p1Pieces[0].Id, p1Pieces[1].Id, new Position(0, 2)));
+        Assert.Contains("already on the board", ex.Message);
+    }
+
+    [Fact]
+    public void ReplacePiece_SamePieceId_Throws()
+    {
+        var (game, p1, p2, p1Pieces, p2Pieces) = GameInPlacePhase();
+
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 0));
+        game.AdvanceTurn();
+        game.AdvancePhase();
+
+        var ex = Assert.Throws<DomainException>(
+            () => game.ReplacePiece(p1, p1Pieces[0].Id, p1Pieces[0].Id, new Position(0, 1)));
+        Assert.Contains("different", ex.Message);
+    }
+
+    [Fact]
+    public void ReplacePiece_InvalidEntryPoint_Throws()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var pieces1 = new List<Piece>
+        {
+            MakePiece(p1, EntryPointType.Borders, "Borders"),   // will go on board first
+            MakePiece(p1, EntryPointType.Corners, "Corners"),   // will be the replacement
+            MakePiece(p1, EntryPointType.Borders, "B2"),
+            MakePiece(p1, EntryPointType.Borders, "B3"),
+            MakePiece(p1, EntryPointType.Borders, "B4"),
+        };
+        var pieces2 = Enumerable.Range(0, 5).Select(i => MakePiece(p2, EntryPointType.Borders, $"P2{i}")).ToList();
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(pieces1));
+        game.SetLineup(p2, new Lineup(pieces2));
+        game.Start();
+        game.AdvancePhase();
+
+        game.PlacePiece(p1, pieces1[0].Id, new Position(0, 0));
+        game.PlacePiece(p2, pieces2[0].Id, new Position(7, 0));
+        game.AdvanceTurn();
+        game.AdvancePhase();
+
+        // Corners piece must go to a corner — (0,1) is edge but NOT corner.
+        var ex = Assert.Throws<DomainException>(
+            () => game.ReplacePiece(p1, pieces1[0].Id, pieces1[1].Id, new Position(0, 1)));
+        Assert.Contains("entry point", ex.Message);
+    }
+
+    // ── Board helper methods ──────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0, 0, true)]
+    [InlineData(0, 4, true)]
+    [InlineData(7, 7, true)]
+    [InlineData(7, 3, true)]
+    [InlineData(3, 0, true)]
+    [InlineData(4, 4, false)]
+    [InlineData(3, 3, false)]
+    [InlineData(1, 6, false)]
+    public void Board_IsEdgeTile_ReturnsCorrectly(int row, int col, bool expected)
+    {
+        var board = new Board();
+        Assert.Equal(expected, board.IsEdgeTile(new Position(row, col)));
+    }
+
+    [Theory]
+    [InlineData(0, 0, true)]
+    [InlineData(0, 7, true)]
+    [InlineData(7, 0, true)]
+    [InlineData(7, 7, true)]
+    [InlineData(0, 1, false)]
+    [InlineData(3, 0, false)]
+    [InlineData(4, 4, false)]
+    public void Board_IsCornerTile_ReturnsCorrectly(int row, int col, bool expected)
+    {
+        var board = new Board();
+        Assert.Equal(expected, board.IsCornerTile(new Position(row, col)));
+    }
+
+    [Theory]
+    [InlineData(0, 0, EntryPointType.Borders, true)]
+    [InlineData(4, 4, EntryPointType.Borders, false)]
+    [InlineData(0, 0, EntryPointType.Corners, true)]
+    [InlineData(0, 1, EntryPointType.Corners, false)]
+    [InlineData(4, 4, EntryPointType.Anywhere, true)]
+    [InlineData(0, 0, EntryPointType.Anywhere, true)]
+    public void Board_IsValidEntryPoint_ReturnsCorrectly(int row, int col, EntryPointType entryPointType, bool expected)
+    {
+        var board = new Board();
+        Assert.Equal(expected, board.IsValidEntryPoint(new Position(row, col), entryPointType));
+    }
+}

--- a/tests/ScrambleCoin.Domain.Tests/PiecePlacementTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/PiecePlacementTests.cs
@@ -316,9 +316,7 @@ public class PiecePlacementTests
 
         game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
 
-        // Phase has not yet advanced (p2 hasn't acted), but p1 tries again on a different turn assumption —
-        // actually at this point the phase already advanced if p2 acted or didn't.
-        // Since p2 hasn't acted, phase is still PlacePhase and p1 already acted.
+        // p2 has not yet acted, so phase is still PlacePhase — p1 cannot act again.
         var ex = Assert.Throws<DomainException>(() => game.PlacePiece(p1, p1Pieces[1].Id, new Position(0, 1)));
         Assert.Contains("already acted", ex.Message);
     }


### PR DESCRIPTION
## Summary
Closes #10.

Implements the PlacePhase actions: players can place an off-board piece at a valid entry-point tile, replace an on-board piece with an off-board one, or skip their placement turn. The phase auto-advances to MovePhase once both players have acted (or skipped).

## Changes
- PiecePlaced / PieceReplaced domain events
- Board: IsEdgeTile, IsCornerTile, IsValidEntryPoint helpers
- Game: PlacePiece, ReplacePiece, SkipPlacement with full guard validation and auto-advance
- Application commands + handlers for all three actions
- 56 domain tests + 4 application handler tests (532 total, all passing)
- Manual test plan posted on issue #10

## Testing
- Unit tests: 56 domain + 4 application added
- All 532 tests pass

## Review cycles
- Implementation: 1 cycle (moved obstacle/capacity guards before state mutation)
- Tests: 2 cycles (added rollback/guard/same-tile tests; fixed comment)

## Version bump
minor (feature + domain labels)