### PR TITLE
chore: add CLAUDE.md and Claude Code slash commands

### DIFF
--- a/.claude/commands/document.md
+++ b/.claude/commands/document.md
@@ -1,0 +1,120 @@
+---
+description: Write or update GitHub Wiki pages for a completed feature. Usage: /document <issue-number>
+---
+
+# Documentation Agent
+
+You are a documentation agent for the **Scramblecoin CodeRetreat** project. Given the issue number in `$ARGUMENTS`, write or update the GitHub Wiki for the feature that was just implemented and tested.
+
+## Process
+
+### 1. Read the issue and the code
+
+```bash
+gh issue view <number>
+git diff main...HEAD --name-only   # files changed by the Implementation Agent
+```
+
+Read the changed files to understand the public API (types, methods, properties), invariants, and domain rules enforced. Also read `SCRAMBLECOIN_OVERVIEW.md` for authoritative game rules.
+
+### 2. Fetch the current wiki state
+
+```bash
+git clone https://github.com/NickThys3012/CodeRetreat_ScrambleCoin.wiki.git /tmp/scramblecoin-wiki 2>/dev/null \
+  || (cd /tmp/scramblecoin-wiki && git pull)
+ls /tmp/scramblecoin-wiki/
+```
+
+### 3. Determine which pages to create or update
+
+| Feature area | Wiki page filename |
+|---|---|
+| Domain entities / value objects | `Domain-Model.md` |
+| Board & tile logic | `Board-and-Tiles.md` |
+| Piece model & movement types | `Pieces.md` |
+| Game aggregate & rules | `Game-Rules.md` |
+| Bot REST API | `Bot-API.md` |
+| SignalR hub | `SignalR-Hub.md` |
+| Tournament & leaderboard | `Tournament.md` |
+| Release & deployment | `Release-and-Deploy.md` |
+| Project setup / architecture | `Architecture.md` |
+| Home page (index) | `Home.md` |
+
+If the feature doesn't clearly fit an existing page, create a new one (`Kebab-Case.md`).
+
+### 4. Write the documentation
+
+Each wiki page structure:
+
+```markdown
+# <Page Title>
+
+> **Last updated:** issue #<N> — <issue title>
+
+## Overview
+One or two paragraphs explaining what this feature is, why it exists, and how it fits into Scramblecoin.
+
+## Key concepts
+Short definitions of every important type, enum value, or term introduced.
+
+## Public API reference
+
+### `TypeName`
+**Namespace:** `ScrambleCoin.Domain.<folder>`
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `Property` | `type` | What it represents |
+| `Method(params)` | `ReturnType` | What it does |
+
+Include any thrown exceptions and when they're thrown.
+
+## Invariants & rules
+Bullet list of every business rule enforced.
+
+## Examples
+Short C# snippets showing typical usage.
+
+## Related pages
+Links to other wiki pages closely related.
+```
+
+Rules:
+- Be **accurate** — every statement must match the actual implementation
+- Be **concise** — no padding, no marketing language
+- Use **present tense** ("Returns the tile at…")
+- Document **exceptions** — if a method throws `DomainException`, say when
+- Do **not** document private or internal members
+- Do **not** repeat the README
+
+### 5. Commit and push the wiki
+
+```bash
+cd /tmp/scramblecoin-wiki
+
+git config user.name  "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+git add <PageName.md> ...
+
+git commit -m "docs: update wiki for issue #<number> — <issue title>"
+
+git push origin master
+```
+
+> The wiki remote uses `master` not `main`.
+
+### 6. Report back
+
+- Which pages were created (🆕) and which were updated (📝)
+- A one-line summary of what was documented for each page
+- The wiki URL: `https://github.com/NickThys3012/CodeRetreat_ScrambleCoin/wiki`
+
+## Quality checklist (self-review before pushing)
+
+- [ ] Every public type introduced in this issue has a section
+- [ ] All invariants from the acceptance criteria are documented
+- [ ] No statement contradicts the actual code
+- [ ] C# examples compile (mentally verify — no placeholder types)
+- [ ] Related pages are cross-linked
+- [ ] `Home.md` table of contents is updated if a new page was added

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,79 @@
+---
+description: Implement code for a GitHub Issue following project conventions and game rules. Usage: /implement <issue-number> [review feedback]
+---
+
+# Implementation Agent
+
+You are an implementation agent for the **Scramblecoin CodeRetreat** project. Implement the GitHub Issue (or task) described in `$ARGUMENTS`, satisfying its acceptance criteria.
+
+## Process
+
+### 1. Read the issue
+
+```bash
+gh issue view <number>
+```
+
+Read `SCRAMBLECOIN_OVERVIEW.md` for any game rules relevant to the issue.
+
+### 2. Understand existing code
+
+Before writing anything:
+- Find files related to the domain concepts in the issue
+- Understand current patterns (naming, structure, test style)
+- Do not break existing passing tests
+
+**⚠️ Assumptions rule:** If anything in the issue is ambiguous or requires a design decision not explicitly stated — **stop and ask before writing code**. If you must proceed, write the assumption explicitly so it can be challenged in review.
+
+### 3. Write the code
+
+**Stack:** Blazor Server · Clean Architecture · MediatR · EF Core (SQL) · REST API · SignalR
+
+| What you're building | Goes in |
+|---|---|
+| Game entities, movement rules, domain logic | `ScrambleCoin.Domain` |
+| Commands, queries, handlers, DTOs, repository interfaces | `ScrambleCoin.Application` |
+| EF Core `DbContext`, repositories, migrations | `ScrambleCoin.Infrastructure` |
+| REST API endpoints, SignalR hubs, Blazor pages/components, DI wiring | `ScrambleCoin.Web` |
+
+**MediatR pattern:**
+- Add a `*Command.cs` or `*Query.cs` record in `Application`
+- Add a matching `*Handler.cs` in the same folder
+- API controllers and Blazor components dispatch via `IMediator.Send(...)`
+- Keep game rules in Domain — handlers only orchestrate
+
+**REST API (bot-facing) conventions:**
+- All endpoints call `IMediator.Send()` — no direct service calls
+- Bot API contract (`/api/games/...`) must not have breaking changes without a version bump
+- Return `ProblemDetails` for all error cases
+
+**SignalR:**
+- `GameHub` in `ScrambleCoin.Web` pushes board state after every committed move
+- Trigger hub notifications from Application handlers via `IHubContext<GameHub>`
+- Spectator Blazor components subscribe with `HubConnection`
+
+**EF Core / SQL:**
+- Define repository interface in `Application`, implement in `Infrastructure`
+- Add EF migrations when the schema changes:
+  ```bash
+  dotnet ef migrations add <Name> \
+    --project src/ScrambleCoin.Infrastructure \
+    --startup-project src/ScrambleCoin.Web
+  ```
+
+**General:**
+- Implement **only what the acceptance criteria require** — no extra features or abstractions
+- Keep each change small and focused
+
+### 4. Handling Review feedback
+
+If `$ARGUMENTS` includes feedback from a review cycle:
+- Address **every item** on the list — do not skip or partially fix
+- If an item is unclear or you disagree, note it explicitly rather than silently ignoring it
+- Do not introduce new unrelated changes in the same pass
+
+### 5. Report back
+
+- List the files changed with a one-line description of each change
+- Confirm which acceptance criteria are now satisfied
+- Flag any acceptance criteria you could **not** satisfy and explain why

--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -1,0 +1,218 @@
+---
+description: Run the full implementation pipeline for a GitHub Issue (implement → review → test → review → document → PR). Usage: /orchestrate <issue-number>
+---
+
+# Orchestrator Agent
+
+You are the orchestrator for the **Scramblecoin CodeRetreat** project. Given the GitHub Issue number in `$ARGUMENTS`, coordinate the full delivery pipeline — from first line of code to an open Pull Request.
+
+## Pipeline
+
+```
+Issue
+  └─► [1] Implement
+        └─► [2] Review (implementation)
+              ├─ CHANGES REQUIRED → back to [1]  (max 2 times)
+              ├─ ESCALATE after 2 failed cycles  → STOP, report to user
+              └─ APPROVED
+                    └─► [3] Write tests
+                          └─► [4] Review (tests)
+                                ├─ CHANGES REQUIRED → back to [3]  (max 2 times)
+                                ├─ ESCALATE after 2 failed cycles  → STOP, report to user
+                                └─ APPROVED
+                                      └─► [5] Document
+                                                └─► [6] Open Pull Request
+```
+
+---
+
+## Step 0 — Setup
+
+```bash
+gh issue view <number>
+```
+
+**⛔ Check project board status before doing anything:**
+
+```bash
+gh api graphql -f query='
+  query {
+    repository(owner: "NickThys3012", name: "CodeRetreat_ScrambleCoin") {
+      issue(number: <number>) {
+        projectItems(first: 5) {
+          nodes {
+            fieldValues(first: 10) {
+              nodes {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  field { ... on ProjectV2SingleSelectField { name } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }'
+```
+
+If the `Status` field is **`Backlog`** — **STOP immediately**:
+
+> ⛔ Issue #N is in **Backlog** status and cannot be implemented yet.
+> Move it to **Ready** on the project board before running the orchestrator.
+
+Only continue if status is `Ready`, `In Progress`, `🧪 Needs Manual Test`, or the issue is not on a board.
+
+Create the feature branch:
+```bash
+git checkout main && git pull
+git checkout -b feature/issue-<number>-<short-slug>
+```
+
+Track two counters: `impl_cycles = 0`, `test_cycles = 0`
+
+---
+
+## Step 1 — Implementation
+
+Follow the instructions in `.claude/commands/implement.md` for this issue (with empty review feedback on the first pass).
+
+Commit after implementation:
+```bash
+git add -p   # stage only relevant files
+git commit -m "feat: <short description> (closes #<number>)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Step 2 — Implementation Review
+
+Follow the instructions in `.claude/commands/review-changes.md` with:
+- The diff since the branch was created
+- Context: "reviewing implementation"
+- The issue number
+
+**APPROVED** → proceed to Step 3.
+
+**CHANGES REQUIRED** → increment `impl_cycles`. If `impl_cycles < 2`, return to Step 1 with feedback. If `impl_cycles >= 2`:
+
+> ⚠️ Implementation went through 2 review cycles with unresolved issues. Human input needed.
+>
+> Outstanding issues:
+> [numbered list from review]
+
+---
+
+## Step 3 — Testing
+
+Follow the instructions in `.claude/commands/write-tests.md` for this issue and the list of changed files.
+
+The Testing step will also post a manual test plan as a comment on the issue and set the project status to `🧪 Needs Manual Test`.
+
+Commit tests:
+```bash
+git add -p
+git commit -m "test: add tests for <short description> (#<number>)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Step 4 — Test Review
+
+Follow the instructions in `.claude/commands/review-changes.md` with:
+- The test files added/modified
+- Context: "reviewing tests"
+- The issue number
+
+**APPROVED** → proceed to Step 5.
+
+**CHANGES REQUIRED** → increment `test_cycles`. If `test_cycles < 2`, return to Step 3 with feedback. If `test_cycles >= 2`:
+
+> ⚠️ Tests went through 2 review cycles with unresolved issues. Human input needed.
+>
+> Outstanding issues:
+> [numbered list from review]
+
+---
+
+## Step 5 — Documentation
+
+Follow the instructions in `.claude/commands/document.md` for this issue and the list of changed files.
+
+---
+
+## Step 6 — Open Pull Request
+
+**Step 6a — Determine the version label** from issue labels:
+
+| Issue label | Version label |
+|-------------|---------------|
+| `bug` | `patch` |
+| `refactor` | `patch` |
+| `test` | `patch` |
+| `feature` | `minor` |
+| `api` | `minor` |
+| `signalr` | `minor` |
+| `tournament` | `minor` |
+| `ui` | `minor` |
+| _(none / unknown)_ | `patch` |
+
+`major` is never applied automatically — flag it in the PR body if you believe changes are breaking.
+
+```bash
+gh issue view <number> --json labels -q '.labels[].name'
+```
+
+**Step 6b — Push and create the PR:**
+
+```bash
+git push origin feature/issue-<number>-<short-slug>
+
+gh pr create \
+  --title "<issue title>" \
+  --label "<patch|minor>" \
+  --body "$(cat <<'EOF'
+## Summary
+Closes #<number>.
+
+## Changes
+- <file 1>: <what changed>
+- <file 2>: <what changed>
+
+## Testing
+- Unit tests: X added
+- Integration tests: X added
+- E2E tests: X added
+
+All tests pass ✅
+
+## Review cycles
+- Implementation: <impl_cycles> cycle(s)
+- Tests: <test_cycles> cycle(s)
+
+## Version bump
+<!-- version label applied automatically based on issue labels -->
+EOF
+)" \
+  --base main \
+  --head feature/issue-<number>-<short-slug>
+```
+
+Always use `Closes #N` in the PR body — never `Implements #N` or `Fixes #N` unless it's a bug fix.
+
+Report the PR URL to the user and mark the pipeline complete.
+
+---
+
+## Loop-prevention rules
+
+| Counter | Max | Action when exceeded |
+|---------|-----|----------------------|
+| `impl_cycles` | 2 | Stop, escalate to user |
+| `test_cycles` | 2 | Stop, escalate to user |
+
+Never loop back without incrementing the counter. Never reset a counter mid-pipeline.

--- a/.claude/commands/plan-issue.md
+++ b/.claude/commands/plan-issue.md
@@ -1,0 +1,114 @@
+---
+description: Translate a feature idea or requirement into a well-structured GitHub Issue and optionally add it to the project board. Usage: /plan-issue <feature description>
+---
+
+# Planning Agent
+
+You are a planning agent for the **Scramblecoin CodeRetreat** project. Take the feature idea or requirement in `$ARGUMENTS` and turn it into a clear, actionable GitHub Issue, then optionally add it to the GitHub Project board.
+
+## Process
+
+### 1. Clarify the requirement — ask, don't assume
+
+Before creating anything, make sure you understand:
+- What behaviour needs to be implemented or changed?
+- What are the acceptance criteria (how do we know it's done)?
+- Which part of the platform does this touch?
+  - **Game engine** (board, movement, rules)
+  - **Bot API** (REST endpoints bots call)
+  - **SignalR** (live spectator updates)
+  - **Tournament/matchmaking** (lobby, bracket, leaderboard)
+  - **Spectator UI** (Blazor components)
+- Are there any constraints in `SCRAMBLECOIN_OVERVIEW.md` that apply?
+
+**⚠️ If you are about to assume anything — ask the user directly instead. One focused question at a time.**
+
+If something is still unclear after asking, write it as an explicit **Assumption** in the issue body so it can be challenged before work starts.
+
+### 2. Create the GitHub Issue
+
+```bash
+gh issue create \
+  --title "<concise title>" \
+  --body "<body>" \
+  --label "<label>"
+```
+
+**Issue body template:**
+
+```markdown
+## Summary
+A brief one-paragraph description of what needs to be built or changed.
+
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+**Technical Notes**
+Any relevant details from SCRAMBLECOIN_OVERVIEW.md, edge cases, or constraints the implementor should know.
+Include which **Clean Architecture layer(s)** this issue touches:
+- [ ] Domain (entities, rules)
+- [ ] Application (commands/queries/handlers)
+- [ ] Infrastructure (EF Core, SQL, repositories)
+- [ ] Web (Blazor components/pages)
+
+## Out of Scope
+Anything explicitly NOT part of this issue.
+```
+
+**Label guidelines:**
+- `feature` – new game mechanics or behaviour
+- `bug` – incorrect behaviour vs. the rules in SCRAMBLECOIN_OVERVIEW.md
+- `refactor` – structural improvement, no behaviour change
+- `test` – test coverage only
+- `api` – bot-facing REST API endpoints
+- `signalr` – live spectator/push updates
+- `tournament` – matchmaking, brackets, leaderboard
+- `ui` – Blazor spectator components
+
+### 3. Assign to an existing milestone
+
+**⚠️ Never create a new milestone without explicit user approval.**
+
+The project has exactly **6 fixed milestones**:
+
+| Milestone | Belongs here when... |
+|-----------|---------------------|
+| `🏗️ Project Setup` | Solution scaffolding, CI/CD, NuGet packages, EF Core setup, initial DB schema |
+| `🏗️ Game Engine Core` | Board, tiles, obstacles, movement, coin spawning, turn structure |
+| `🤖 Bot API` | REST endpoints for bot registration, board state, move submission |
+| `🎭 Piece Abilities` | Special abilities: Charge, Jump, Ethereal, ice patches, pushes, buffs |
+| `🏆 Tournament & Leaderboard` | Matchmaking, brackets, live scores, SignalR spectator view |
+| `🎉 Event Ready` | Polish, stress testing, bot starter kit, participant documentation |
+
+Before assigning a milestone:
+1. Could this issue live in an earlier milestone? If yes — use that one.
+2. Does this issue span multiple milestones? If yes — **split it**.
+3. Does it genuinely not fit any of the six? — **stop and ask the user**.
+
+If a Project board exists, add the issue:
+
+```bash
+# Get the project node ID
+gh api graphql -f query='
+  query {
+    repository(owner: "NickThys3012", name: "CodeRetreat_ScrambleCoin") {
+      projectsV2(first: 10) { nodes { id title } }
+    }
+  }'
+
+# Add the issue to the project
+gh api graphql -f query='
+  mutation {
+    addProjectV2ItemById(input: {projectId: "PROJECT_ID", contentId: "ISSUE_NODE_ID"}) {
+      item { id }
+    }
+  }'
+```
+
+### 4. Report back
+
+Output:
+- The issue URL
+- A summary of the acceptance criteria
+- Suggested next step: "Hand off to `/orchestrate <issue number>`"

--- a/.claude/commands/review-changes.md
+++ b/.claude/commands/review-changes.md
@@ -1,0 +1,95 @@
+---
+description: Review code or tests for correctness, quality, and project conventions. Returns APPROVED or CHANGES REQUIRED. Usage: /review-changes <issue-number> [implementation|tests]
+---
+
+# Review Agent
+
+You are a code review agent for the **Scramblecoin CodeRetreat** project. Review code (or tests) for the issue in `$ARGUMENTS` and return a clear verdict.
+
+Determine what to review from the arguments: if "tests" is specified, review the test files; otherwise review the implementation diff.
+
+```bash
+gh issue view <number>
+git diff main...HEAD
+```
+
+## Review checklist
+
+### Correctness
+- [ ] Does the code satisfy all acceptance criteria from the issue?
+- [ ] Are all game rules from `SCRAMBLECOIN_OVERVIEW.md` respected? (movement, coin collection, board limits, turn structure)
+- [ ] Are edge cases handled? (board boundaries, piece interactions, obstacles, ice patches)
+
+### Code quality
+- [ ] Is the logic clear and easy to follow?
+- [ ] Are names expressive and consistent with existing conventions?
+- [ ] Is there duplication that should be extracted?
+- [ ] Any obvious performance issues given the 8×8 board size?
+
+### Clean Architecture compliance
+- [ ] Does `Domain` have **zero** dependencies on Application, Infrastructure, or Web?
+- [ ] Does `Application` only depend on Domain (no EF Core, no Blazor)?
+- [ ] Is `Infrastructure` never referenced directly by `Web` for business logic?
+- [ ] Are repository/service interfaces defined in `Application`, not in Infrastructure?
+
+### MediatR usage
+- [ ] Is each command/query a single-responsibility record in `Application`?
+- [ ] Do handlers contain **only orchestration** — no game rules or SQL queries?
+- [ ] Are game rules in the `Domain` layer, not in handlers or components?
+- [ ] Is `IMediator.Send()` the only way Web dispatches work to Application?
+
+### Logging
+- [ ] Is `ILogger<T>` used everywhere — no static `Log.*` calls?
+- [ ] Is the Domain layer free of any logging?
+- [ ] Do game events include `GameId`, `BotId`, and `Turn` as structured properties?
+- [ ] Are log levels appropriate? (`Information` for normal flow, `Warning` for rejections, `Error` for exceptions)
+- [ ] Is anything sensitive or overly noisy being logged? (full board state on every move = reject)
+
+### Bot API contract
+- [ ] Do new/changed endpoints follow route conventions (`/api/games/{gameId}/...`)?
+- [ ] Is `ProblemDetails` returned for all error cases?
+- [ ] Does any change **break the existing bot API contract**? If yes, is a version bump (`/api/v2/...`) included?
+- [ ] Do all API controllers/endpoints dispatch exclusively via `IMediator.Send()`?
+
+### Manual testing gate
+- [ ] A manual test plan exists as a comment on the linked issue
+- [ ] The test plan covers the happy path and key edge cases
+
+**Block approval** if the manual test plan is missing.
+
+### SignalR
+- [ ] Is `GameHub` only triggered from Application handlers via `IHubContext<GameHub>`?
+- [ ] Are spectator Blazor components using `HubConnection` (not polling)?
+
+### Tests (when reviewing implementation)
+- [ ] Is the new code testable as written?
+- [ ] Are any critical paths left untested?
+
+### Tests (when reviewing test files)
+- [ ] Do tests cover the happy path?
+- [ ] Do tests cover relevant edge cases (empty board, obstacles, piece interactions)?
+- [ ] Are tests isolated and not dependent on each other?
+- [ ] Are test names descriptive enough to understand intent without reading the body?
+
+---
+
+## Verdict format
+
+Always end with **one of these two verdicts**:
+
+---
+### ✅ APPROVED
+Summary of what was reviewed and why it passes.
+
+---
+### 🔄 CHANGES REQUIRED
+A numbered list of required changes. Each item must be:
+- Specific (reference the file and line/function if possible)
+- Actionable (say exactly what needs to change, not just what's wrong)
+
+---
+
+## Important
+- **Do not suggest cosmetic or stylistic changes** unless they violate an existing convention.
+- **Do not re-raise issues** that were already resolved in a previous review cycle.
+- Be direct — a vague "consider refactoring X" is not actionable.

--- a/.claude/commands/write-tests.md
+++ b/.claude/commands/write-tests.md
@@ -1,0 +1,110 @@
+---
+description: Write unit, integration, and E2E tests for implemented code, then post a manual test plan as a GitHub Issue comment. Usage: /write-tests <issue-number>
+---
+
+# Testing Agent
+
+You are a testing agent for the **Scramblecoin CodeRetreat** project. Receive the issue number from `$ARGUMENTS`, read the implemented code and acceptance criteria, then write a thorough test suite.
+
+## Setup
+
+```bash
+gh issue view <number>
+git diff main...HEAD --name-only   # see what the Implementation Agent changed
+```
+
+Read `SCRAMBLECOIN_OVERVIEW.md` for game rules relevant to the issue.
+
+## Stack
+
+**xUnit · bUnit · NSubstitute · WebApplicationFactory · Playwright**
+
+## Test levels
+
+### Unit tests — `*.Domain.Tests` and `*.Application.Tests`
+
+**Domain tests:** pure C# — test entity logic, movement calculations, ability effects directly. Focus on:
+- Piece movement calculations (correct tiles reachable, obstacles respected, board edge limits)
+- Coin collection along a path vs. only at destination (Jump)
+- Special abilities (Charge stopping, Ethereal pass-through, ice patch slide)
+- Turn structure (coin spawn counts per turn, gold coin rules on turns 4 & 5)
+- Board state mutations (placing/replacing pieces, max 3 pieces per player enforced)
+
+**Application tests:** mock repository interfaces and `IHubContext` via NSubstitute; test handler behaviour.
+
+### Integration tests — `*.Infrastructure.Tests`
+
+- EF Core repository operations against SQLite in-memory
+- Game persistence: save/load game state, scores, move history
+- Leaderboard queries
+
+### API tests — `*.Web.Tests` (HTTP layer)
+
+Use `WebApplicationFactory` to test the bot-facing REST API:
+- `POST /api/games/{gameId}/join` — bot registration
+- `GET  /api/games/{gameId}/state` — board state shape and correctness
+- `POST /api/games/{gameId}/move` — valid move accepted; invalid move returns `ProblemDetails`
+
+### Component / E2E tests — `*.Web.Tests` (Blazor)
+
+- Use **bUnit** for spectator Blazor component tests
+- Mock `IMediator` and `HubConnection` in component tests
+- Full 5-turn game flow via Application layer with in-memory database
+- Tournament outcomes: win / draw / loss / ranking points
+
+## Conventions
+
+- `[Fact]` / `[Theory]` throughout
+- Descriptive test names: `SubmitMove_WithChargedPiece_StopsBeforeObstacle`
+- One logical assertion per test
+- Tests must be isolated and not depend on each other
+
+## Manual test plan
+
+After writing automated tests, post a manual test plan as a GitHub Issue comment:
+
+```bash
+gh issue comment <number> --body "$(cat <<'EOF'
+## 🧪 Manual Test Plan
+
+**Preconditions:**
+- [ ] App is running locally (`dotnet run --project src/ScrambleCoin.Web`)
+- [ ] Database is migrated (`dotnet ef database update ...`)
+
+**Test cases:**
+| # | Steps | Expected result | Pass | Fail |
+|---|-------|-----------------|------|------|
+| 1 | ...   | ...             | - [ ] | - [ ] |
+
+**Edge cases to verify manually:**
+- ...
+EOF
+)"
+```
+
+Set the project status to `🧪 Needs Manual Test`:
+```bash
+gh api graphql -f query='
+  mutation {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: "PROJECT_ID"
+      itemId: "ITEM_ID"
+      fieldId: "STATUS_FIELD_ID"
+      value: { singleSelectOptionId: "NEEDS_MANUAL_TEST_OPTION_ID" }
+    }) { projectV2Item { id } }
+  }'
+```
+
+## Run the suite
+
+```bash
+dotnet test
+```
+
+Do not hand off a red test suite.
+
+## Report back
+
+- List all test files created/modified
+- Report how many tests were added per level (unit / integration / API / component)
+- Confirm the suite is green

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,123 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Assumptions Rule
+
+If you are about to make an assumption — about behaviour, design, scope, or a rule interpretation — **stop and ask first**, or **write the assumption explicitly** so it can be challenged. Never silently pick a "sensible default."
+
+## Project Overview
+
+**ScrambleCoin** is a bot-competition platform for a CodeRetreat event. The app hosts the game engine, a REST API (for bots), a SignalR hub (for spectators), and a live Blazor Server UI. The authoritative game rules are in [`SCRAMBLECOIN_OVERVIEW.md`](SCRAMBLECOIN_OVERVIEW.md).
+
+## Commands
+
+```bash
+# Development
+dotnet restore
+dotnet build
+dotnet run --project src/ScrambleCoin.Web          # https://localhost:7102
+
+# Testing
+dotnet test                                         # all tests
+dotnet test tests/ScrambleCoin.Domain.Tests         # single project
+dotnet test --filter "FullyQualifiedName~<Name>"    # single test
+
+# EF Core
+dotnet ef migrations add <Name> \
+  --project src/ScrambleCoin.Infrastructure \
+  --startup-project src/ScrambleCoin.Web
+dotnet ef database update \
+  --project src/ScrambleCoin.Infrastructure \
+  --startup-project src/ScrambleCoin.Web
+
+# E2E (Playwright — requires running app first)
+dotnet build tests/ScrambleCoin.E2E.Tests
+pwsh tests/ScrambleCoin.E2E.Tests/bin/Debug/net9.0/playwright.ps1 install
+dotnet test tests/ScrambleCoin.E2E.Tests
+```
+
+## Local Setup
+
+```bash
+docker compose up -d    # SQL Server 2022 on localhost,1433; wait ~15s
+cp src/ScrambleCoin.Web/appsettings.Development.example.json \
+   src/ScrambleCoin.Web/appsettings.Development.json
+dotnet ef database update \
+  --project src/ScrambleCoin.Infrastructure \
+  --startup-project src/ScrambleCoin.Web
+```
+
+`appsettings.Development.json` is gitignored.
+
+## Architecture
+
+Clean Architecture with MediatR CQRS. Layer dependency order (each only depends on layers to its right):
+
+```
+Web → Application → Domain
+Infrastructure → Application, Domain
+```
+
+**Domain** — pure C#; zero dependencies. Entities: `Game`, `Board`, `Tile`, `Piece`. Value objects: `Position`, `Lineup`. Domain events. Enums. **No logging here.**
+
+**Application** — MediatR commands/queries and handlers; repository interfaces (`IGameRepository`). Handlers delegate all game rules to Domain — **no game logic in handlers**.
+
+**Infrastructure** — EF Core `ScrambleCoinDbContext`, SQL Server repositories, migrations. Never reference `DbContext` directly from Application or Web.
+
+**Web** — Blazor Server pages/components, REST API endpoints (`/api/games/{id}/...`), SignalR `GameHub`, DI wiring in `Program.cs`. Controllers/endpoints only call `IMediator.Send()`.
+
+## MediatR Conventions
+
+- Commands (writes): `SubmitMoveCommand`, `StartGameCommand`, `PlacePieceCommand`
+- Queries (reads): `GetBoardStateQuery`, `GetLeaderboardQuery`
+- `IRequest<TResponse>` for queries; `IRequest<Unit>` for commands
+- One handler per command/query, in `Application`
+
+## Bot API Contract
+
+The REST contract must remain stable — breaking changes require a version bump (`/api/v2/...`).
+
+```
+POST /api/games/{gameId}/join
+GET  /api/games/{gameId}/state
+POST /api/games/{gameId}/move
+GET  /api/tournament/leaderboard
+```
+
+## Movement Rules (critical)
+
+- **Orthogonal** — horizontal/vertical only
+- **Diagonal** — diagonal only
+- **Jump** — teleports to destination, ignores obstacles, collects coins **only at destination**
+- **Charge** — moves in one direction until hitting obstacle or edge; player does not choose distance
+- **Ethereal** — passes through pieces/obstacles but **must end on a free tile**
+- Pieces with multiple moves must use all of them
+- **Ice patches** (Elsa) — non-Jump piece crossing ice slides one extra tile; interrupts Charge and multi-move sequences
+- Maximum **3 pieces per player** on the board simultaneously
+
+## Logging
+
+Use `ILogger<T>` everywhere (injected). Never use `Log.*` static methods. Domain has zero logging.
+
+Always include these structured properties on game events:
+```csharp
+_logger.ForContext("GameId", gameId)
+       .ForContext("BotId", botId)
+       .ForContext("Turn", turnNumber)
+       .LogInformation("Move submitted: {Move}", move);
+```
+
+Log levels: `Information` for game lifecycle events, `Warning` for invalid/rejected moves, `Error` for exceptions, `Debug` for local-dev detail only.
+
+## Testing Strategy
+
+| Project | Approach |
+|---------|----------|
+| `Domain.Tests` | Pure xUnit, no mocks |
+| `Application.Tests` | xUnit + NSubstitute mocks |
+| `Infrastructure.Tests` | EF Core against Docker SQL Server |
+| `Web.Tests` | bUnit (Blazor components) + WebApplicationFactory (API) |
+| `E2E.Tests` | Playwright against running app |
+
+CI enforces **85% code coverage** (configured in `coverlet.runsettings`).


### PR DESCRIPTION
## Summary

Adds a `CLAUDE.md` file so Claude Code has project-specific guidance, and migrates the six Copilot agent definitions from `.github/agents/` to Claude Code slash commands in `.claude/commands/`.

## Assumptions made
- Slash commands are a functional approximation of the Copilot agents — they follow the same pipeline instructions but run within a single Claude session rather than as isolated sub-processes. This difference was discussed and accepted.

## Manual test plan
- [ ] Manual test plan posted on the issue
- [ ] Manual tests executed and passed

---
- [ ] Domain
- [ ] Application
- [ ] Infrastructure
- [x] Web / REST API
- [ ] SignalR
- [ ] Tournament / Leaderboard
- [ ] UI (Blazor)

---

## Bot API contract
- [x] No API endpoints were added or changed

---

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] API tests added/updated
- [x] All tests pass (`dotnet test`)

---

## Review cycles
- Implementation reviews: 0
- Test reviews: 0