### PR TITLE
feat: Movement REST endpoint — POST /api/games/{gameId}/move (#40)

### DIFF
--- a/src/ScrambleCoin.Api/Endpoints/GameEndpoints.cs
+++ b/src/ScrambleCoin.Api/Endpoints/GameEndpoints.cs
@@ -266,16 +266,19 @@ public static class GameEndpoints
         if (!TryExtractBotToken(httpRequest, out var botToken))
             return ForbiddenBotToken();
 
-        IReadOnlyList<IReadOnlyList<Position>> segments = body.Segments
-            .Select(seg => (IReadOnlyList<Position>)seg
-                .Select(p => new Position(p.Row, p.Col))
-                .ToList()
-                .AsReadOnly())
-            .ToList()
-            .AsReadOnly();
-
         try
         {
+            if (body.Segments is null)
+                return Results.Problem(detail: "'segments' is required.", statusCode: StatusCodes.Status400BadRequest, title: "Bad Request");
+
+            IReadOnlyList<IReadOnlyList<Position>> segments = body.Segments
+                .Select(seg => (IReadOnlyList<Position>)seg
+                    .Select(p => new Position(p.Row, p.Col))
+                    .ToList()
+                    .AsReadOnly())
+                .ToList()
+                .AsReadOnly();
+
             var result = await sender.Send(new MovePieceCommand(gameId, botToken, body.PieceId, segments), ct);
             return Results.Ok(new
             {

--- a/src/ScrambleCoin.Api/Endpoints/GameEndpoints.cs
+++ b/src/ScrambleCoin.Api/Endpoints/GameEndpoints.cs
@@ -2,9 +2,11 @@ using MediatR;
 using ScrambleCoin.Application.Games.CreateGame;
 using ScrambleCoin.Application.Games.GetBoardState;
 using ScrambleCoin.Application.Games.JoinGame;
+using ScrambleCoin.Application.Games.MovePiece;
 using ScrambleCoin.Application.Games.SubmitPlacement;
 using ScrambleCoin.Application.Services;
 using ScrambleCoin.Domain.Exceptions;
+using ScrambleCoin.Domain.ValueObjects;
 
 namespace ScrambleCoin.Api.Endpoints;
 
@@ -45,6 +47,11 @@ public static class GameEndpoints
         // POST /api/games/{gameId}/place — bot submits placement decision
         app.MapPost("/api/games/{gameId}/place", PlacePiece)
             .WithName("PlacePiece")
+            .WithTags("Games");
+
+        // POST /api/games/{gameId}/move — bot submits a piece move during MovePhase
+        app.MapPost("/api/games/{gameId}/move", MovePiece)
+            .WithName("MovePiece")
             .WithTags("Games");
     }
 
@@ -229,6 +236,13 @@ public static class GameEndpoints
     private sealed record QueueRequest(IReadOnlyList<string> Lineup);
 
     /// <summary>
+    /// Request body for <c>POST /api/games/{gameId}/move</c>.
+    /// </summary>
+    /// <param name="PieceId">The piece to move.</param>
+    /// <param name="Segments">One segment per MovesPerTurn; each segment is an ordered list of positions.</param>
+    private sealed record MoveRequest(Guid PieceId, IReadOnlyList<IReadOnlyList<PositionRequest>> Segments);
+
+    /// <summary>
     /// Request body for <c>POST /api/games/{gameId}/place</c>.
     /// </summary>
     /// <param name="Action">One of: "place", "replace", "skip".</param>
@@ -240,6 +254,50 @@ public static class GameEndpoints
         Guid? PieceId,
         Guid? ReplacedPieceId,
         PositionRequest? Position);
+
+    /// <summary>Bot submits a piece move during MovePhase.</summary>
+    private static async Task<IResult> MovePiece(
+        Guid gameId,
+        MoveRequest body,
+        HttpRequest httpRequest,
+        ISender sender,
+        CancellationToken ct)
+    {
+        if (!TryExtractBotToken(httpRequest, out var botToken))
+            return ForbiddenBotToken();
+
+        IReadOnlyList<IReadOnlyList<Position>> segments = body.Segments
+            .Select(seg => (IReadOnlyList<Position>)seg
+                .Select(p => new Position(p.Row, p.Col))
+                .ToList()
+                .AsReadOnly())
+            .ToList()
+            .AsReadOnly();
+
+        try
+        {
+            var result = await sender.Send(new MovePieceCommand(gameId, botToken, body.PieceId, segments), ct);
+            return Results.Ok(new
+            {
+                phase = result.Phase,
+                activePlayer = result.ActivePlayer,
+                yourScore = result.YourScore,
+                opponentScore = result.OpponentScore
+            });
+        }
+        catch (UnauthorizedGameAccessException ex)
+        {
+            return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status403Forbidden, title: "Forbidden");
+        }
+        catch (GameNotFoundException ex)
+        {
+            return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status404NotFound, title: "Not Found");
+        }
+        catch (DomainException ex)
+        {
+            return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest, title: "Bad Request");
+        }
+    }
 
     /// <summary>Bot reads the current board state for a game.</summary>
     private static async Task<IResult> GetBoardState(

--- a/src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommand.cs
+++ b/src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommand.cs
@@ -7,7 +7,7 @@ namespace ScrambleCoin.Application.Games.MovePiece;
 /// Submits a single piece's move action(s) during MovePhase.
 /// </summary>
 /// <param name="GameId">The game identifier.</param>
-/// <param name="PlayerId">The player submitting the move.</param>
+/// <param name="BotToken">The bearer token of the bot submitting the move.</param>
 /// <param name="PieceId">The piece to move.</param>
 /// <param name="Segments">
 /// One segment per <c>MovesPerTurn</c>. Each segment is an ordered list of positions
@@ -15,6 +15,6 @@ namespace ScrambleCoin.Application.Games.MovePiece;
 /// </param>
 public sealed record MovePieceCommand(
     Guid GameId,
-    Guid PlayerId,
+    Guid BotToken,
     Guid PieceId,
-    IReadOnlyList<IReadOnlyList<Position>> Segments) : IRequest;
+    IReadOnlyList<IReadOnlyList<Position>> Segments) : IRequest<MoveResult>;

--- a/src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommandHandler.cs
@@ -1,9 +1,11 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
+using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Interfaces;
 using ScrambleCoin.Application.Notifications;
 using ScrambleCoin.Domain.Enums;
 using ScrambleCoin.Domain.Events;
+using ScrambleCoin.Domain.Exceptions;
 
 namespace ScrambleCoin.Application.Games.MovePiece;
 
@@ -15,33 +17,45 @@ namespace ScrambleCoin.Application.Games.MovePiece;
 /// <see cref="TurnRolledOver"/> MediatR notification, which <see cref="TurnRolledOverHandler"/>
 /// reacts to — keeping coin-spawn logic out of this handler entirely.
 /// </summary>
-public sealed class MovePieceCommandHandler : IRequestHandler<MovePieceCommand>
+public sealed class MovePieceCommandHandler : IRequestHandler<MovePieceCommand, MoveResult>
 {
     private readonly IGameRepository _gameRepository;
+    private readonly IBotRegistrationRepository _botRegistrationRepository;
     private readonly IPublisher _publisher;
     private readonly ILogger<MovePieceCommandHandler> _logger;
 
     public MovePieceCommandHandler(
         IGameRepository gameRepository,
+        IBotRegistrationRepository botRegistrationRepository,
         IPublisher publisher,
         ILogger<MovePieceCommandHandler> logger)
     {
         _gameRepository = gameRepository;
+        _botRegistrationRepository = botRegistrationRepository;
         _publisher = publisher;
         _logger = logger;
     }
 
-    public async Task Handle(MovePieceCommand request, CancellationToken cancellationToken)
+    public async Task<MoveResult> Handle(MovePieceCommand request, CancellationToken cancellationToken)
     {
-        var game = await _gameRepository.GetByIdAsync(request.GameId, cancellationToken);
+        var registration = await _botRegistrationRepository.GetByTokenAsync(request.BotToken, cancellationToken);
+        if (registration is null || registration.GameId != request.GameId)
+        {
+            _logger.LogWarning(
+                "Unauthorized move attempt in game {GameId}: token did not resolve to a registered player.",
+                request.GameId);
+            throw new UnauthorizedGameAccessException();
+        }
 
+        var playerId = registration.PlayerId;
+        var game = await _gameRepository.GetByIdAsync(request.GameId, cancellationToken);
         var turnNumber = game.TurnNumber;
 
-        game.MovePiece(request.PlayerId, request.PieceId, request.Segments);
+        game.MovePiece(playerId, request.PieceId, request.Segments);
 
         _logger.LogInformation(
-            "Piece {PieceId} moved by player {PlayerId} in game {GameId} on turn {Turn}.",
-            request.PieceId, request.PlayerId, request.GameId, turnNumber);
+            "Piece {PieceId} moved by bot {BotId} in game {GameId} on turn {Turn}.",
+            request.PieceId, playerId, request.GameId, turnNumber);
 
         // Capture whether the turn rolled over BEFORE SaveAsync clears domain events.
         var turnRolledOver = game.DomainEvents
@@ -52,5 +66,15 @@ public sealed class MovePieceCommandHandler : IRequestHandler<MovePieceCommand>
 
         if (turnRolledOver)
             await _publisher.Publish(new TurnRolledOver(request.GameId), cancellationToken);
+
+        var yourScore = game.Scores.TryGetValue(playerId, out var s) ? s : 0;
+        var opponentId = game.PlayerOne == playerId ? game.PlayerTwo : game.PlayerOne;
+        var opponentScore = game.Scores.TryGetValue(opponentId, out var os) ? os : 0;
+
+        return new MoveResult(
+            game.CurrentPhase?.ToString(),
+            game.MovePhaseActivePlayer,
+            yourScore,
+            opponentScore);
     }
 }

--- a/src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommandHandler.cs
@@ -53,16 +53,16 @@ public sealed class MovePieceCommandHandler : IRequestHandler<MovePieceCommand, 
 
         game.MovePiece(playerId, request.PieceId, request.Segments);
 
-        _logger.LogInformation(
-            "Piece {PieceId} moved by bot {BotId} in game {GameId} on turn {Turn}.",
-            request.PieceId, playerId, request.GameId, turnNumber);
-
         // Capture whether the turn rolled over BEFORE SaveAsync clears domain events.
         var turnRolledOver = game.DomainEvents
             .OfType<TurnPhaseAdvanced>()
             .Any(e => e.NewPhase == TurnPhase.CoinSpawn);
 
         await _gameRepository.SaveAsync(game, cancellationToken);
+
+        _logger.LogInformation(
+            "Piece {PieceId} moved by bot {BotId} in game {GameId} on turn {Turn}.",
+            request.PieceId, playerId, request.GameId, turnNumber);
 
         if (turnRolledOver)
             await _publisher.Publish(new TurnRolledOver(request.GameId), cancellationToken);

--- a/src/ScrambleCoin.Application/Games/MovePiece/MoveResult.cs
+++ b/src/ScrambleCoin.Application/Games/MovePiece/MoveResult.cs
@@ -1,0 +1,8 @@
+namespace ScrambleCoin.Application.Games.MovePiece;
+
+/// <summary>Returned by <see cref="MovePieceCommand"/> after a piece is successfully moved.</summary>
+/// <param name="Phase">Current phase after the move, or null if game ended.</param>
+/// <param name="ActivePlayer">Next player to move, or null if MovePhase ended.</param>
+/// <param name="YourScore">Score of the bot that submitted the move.</param>
+/// <param name="OpponentScore">Score of the opposing player.</param>
+public sealed record MoveResult(string? Phase, Guid? ActivePlayer, int YourScore, int OpponentScore);

--- a/tests/ScrambleCoin.Application.Tests/MovePieceCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/MovePieceCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Games.MovePiece;
 using ScrambleCoin.Application.Interfaces;
 using ScrambleCoin.Application.Notifications;
@@ -9,6 +10,7 @@ using ScrambleCoin.Domain.Entities;
 using ScrambleCoin.Domain.Enums;
 using ScrambleCoin.Domain.Exceptions;
 using ScrambleCoin.Domain.ValueObjects;
+using DomainBotReg = ScrambleCoin.Domain.BotRegistrations.BotRegistration;
 namespace ScrambleCoin.Application.Tests;
 
 /// <summary>
@@ -76,8 +78,22 @@ public class MovePieceCommandHandlerTests
         return (game, p1);
     }
 
-    private static MovePieceCommandHandler BuildHandler(IGameRepository repo, IPublisher? publisher = null)
-        => new(repo, publisher ?? Substitute.For<IPublisher>(),
+    /// <summary>Creates a mock <see cref="IBotRegistrationRepository"/> that maps a token to a player+game.</summary>
+    private static IBotRegistrationRepository BotRepo(Guid token, Guid playerId, Guid gameId)
+    {
+        var repo = Substitute.For<IBotRegistrationRepository>();
+        repo.GetByTokenAsync(token, Arg.Any<CancellationToken>())
+            .Returns(new DomainBotReg(token, playerId, gameId));
+        return repo;
+    }
+
+    private static MovePieceCommandHandler BuildHandler(
+        IGameRepository repo,
+        IBotRegistrationRepository? botRepo = null,
+        IPublisher? publisher = null)
+        => new(repo,
+               botRepo ?? Substitute.For<IBotRegistrationRepository>(),
+               publisher ?? Substitute.For<IPublisher>(),
                Substitute.For<ILogger<MovePieceCommandHandler>>());
 
     // ── Test 1: Handler delegates to domain and saves ──────────────────────────
@@ -87,11 +103,12 @@ public class MovePieceCommandHandlerTests
     {
         // Arrange
         var (game, p1, _, p1Piece, _) = GameInMovePhaseWithPieces();
+        var token = Guid.NewGuid();
 
         var repo = Substitute.For<IGameRepository>();
         repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
 
-        var handler = BuildHandler(repo);
+        var handler = BuildHandler(repo, BotRepo(token, p1, game.Id));
 
         var segments = (IReadOnlyList<IReadOnlyList<Position>>)new List<IReadOnlyList<Position>>
         {
@@ -99,7 +116,7 @@ public class MovePieceCommandHandlerTests
         }.AsReadOnly();
 
         // Act
-        await handler.Handle(new MovePieceCommand(game.Id, p1, p1Piece.Id, segments), CancellationToken.None);
+        await handler.Handle(new MovePieceCommand(game.Id, token, p1Piece.Id, segments), CancellationToken.None);
 
         // Assert: domain applied the move
         Assert.Equal(new Position(0, 4), p1Piece.Position);
@@ -112,6 +129,7 @@ public class MovePieceCommandHandlerTests
     public async Task Handle_ValidCommand_DoesNotThrow()
     {
         var (game, p1, _, p1Piece, _) = GameInMovePhaseWithPieces();
+        var token = Guid.NewGuid();
 
         var repo = Substitute.For<IGameRepository>();
         repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
@@ -122,7 +140,8 @@ public class MovePieceCommandHandlerTests
         }.AsReadOnly();
 
         var ex = await Record.ExceptionAsync(() =>
-            BuildHandler(repo).Handle(new MovePieceCommand(game.Id, p1, p1Piece.Id, segments), CancellationToken.None));
+            BuildHandler(repo, BotRepo(token, p1, game.Id))
+                .Handle(new MovePieceCommand(game.Id, token, p1Piece.Id, segments), CancellationToken.None));
 
         Assert.Null(ex);
     }
@@ -133,27 +152,29 @@ public class MovePieceCommandHandlerTests
     public async Task Handle_WhenDomainThrows_ExceptionPropagates()
     {
         var (game, p1) = GameInCoinSpawnPhase();
+        var token = Guid.NewGuid();
 
         var repo = Substitute.For<IGameRepository>();
         repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
 
-        var command = new MovePieceCommand(game.Id, p1, Guid.NewGuid(), new List<IReadOnlyList<Position>>());
+        var command = new MovePieceCommand(game.Id, token, Guid.NewGuid(), new List<IReadOnlyList<Position>>());
 
         await Assert.ThrowsAsync<DomainException>(() =>
-            BuildHandler(repo).Handle(command, CancellationToken.None));
+            BuildHandler(repo, BotRepo(token, p1, game.Id)).Handle(command, CancellationToken.None));
     }
 
     [Fact]
     public async Task Handle_WhenDomainThrows_GameIsNotSaved()
     {
         var (game, p1) = GameInCoinSpawnPhase();
+        var token = Guid.NewGuid();
 
         var repo = Substitute.For<IGameRepository>();
         repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
 
-        var command = new MovePieceCommand(game.Id, p1, Guid.NewGuid(), new List<IReadOnlyList<Position>>());
+        var command = new MovePieceCommand(game.Id, token, Guid.NewGuid(), new List<IReadOnlyList<Position>>());
 
-        try { await BuildHandler(repo).Handle(command, CancellationToken.None); } catch { /* expected */ }
+        try { await BuildHandler(repo, BotRepo(token, p1, game.Id)).Handle(command, CancellationToken.None); } catch { /* expected */ }
 
         await repo.DidNotReceive().SaveAsync(Arg.Any<Game>(), Arg.Any<CancellationToken>());
     }
@@ -165,6 +186,8 @@ public class MovePieceCommandHandlerTests
     {
         // Arrange: P1 has already moved; P2's move will complete the turn.
         var (game, p1, p2, p1Piece, p2Piece) = GameInMovePhaseWithPieces();
+        var p1Token = Guid.NewGuid();
+        var p2Token = Guid.NewGuid();
 
         var p1Segments = (IReadOnlyList<IReadOnlyList<Position>>)new List<IReadOnlyList<Position>>
         {
@@ -176,7 +199,7 @@ public class MovePieceCommandHandlerTests
         repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
 
         var publisher = Substitute.For<IPublisher>();
-        var handler = BuildHandler(repo, publisher);
+        var handler = BuildHandler(repo, BotRepo(p2Token, p2, game.Id), publisher);
 
         var p2Segments = (IReadOnlyList<IReadOnlyList<Position>>)new List<IReadOnlyList<Position>>
         {
@@ -184,7 +207,7 @@ public class MovePieceCommandHandlerTests
         }.AsReadOnly();
 
         // Act
-        await handler.Handle(new MovePieceCommand(game.Id, p2, p2Piece.Id, p2Segments), CancellationToken.None);
+        await handler.Handle(new MovePieceCommand(game.Id, p2Token, p2Piece.Id, p2Segments), CancellationToken.None);
 
         // Assert: TurnRolledOver notification published for the correct game
         await publisher.Received(1).Publish(
@@ -197,12 +220,13 @@ public class MovePieceCommandHandlerTests
     {
         // Arrange: only P1 moves — turn is not yet complete.
         var (game, p1, _, p1Piece, _) = GameInMovePhaseWithPieces();
+        var token = Guid.NewGuid();
 
         var repo = Substitute.For<IGameRepository>();
         repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
 
         var publisher = Substitute.For<IPublisher>();
-        var handler = BuildHandler(repo, publisher);
+        var handler = BuildHandler(repo, BotRepo(token, p1, game.Id), publisher);
 
         var segments = (IReadOnlyList<IReadOnlyList<Position>>)new List<IReadOnlyList<Position>>
         {
@@ -210,7 +234,7 @@ public class MovePieceCommandHandlerTests
         }.AsReadOnly();
 
         // Act
-        await handler.Handle(new MovePieceCommand(game.Id, p1, p1Piece.Id, segments), CancellationToken.None);
+        await handler.Handle(new MovePieceCommand(game.Id, token, p1Piece.Id, segments), CancellationToken.None);
 
         // Assert: no TurnRolledOver published
         await publisher.DidNotReceive().Publish(Arg.Any<TurnRolledOver>(), Arg.Any<CancellationToken>());

--- a/tests/ScrambleCoin.Web.Tests/MoveEndpointTests.cs
+++ b/tests/ScrambleCoin.Web.Tests/MoveEndpointTests.cs
@@ -1,0 +1,660 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ScrambleCoin.Application.BotRegistration;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Domain.BotRegistrations;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.ValueObjects;
+using ScrambleCoin.Infrastructure.Persistence;
+
+namespace ScrambleCoin.Web.Tests;
+
+/// <summary>
+/// Integration tests for <c>POST /api/games/{gameId}/move</c> (Issue #40).
+/// Uses <see cref="WebApplicationFactory{TEntryPoint}"/> with an in-memory database.
+/// </summary>
+public class MoveEndpointTests : IClassFixture<MoveEndpointTests.TestWebApplicationFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly TestWebApplicationFactory _factory;
+
+    public MoveEndpointTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    // ── Test factory ──────────────────────────────────────────────────────────
+
+    public sealed class TestWebApplicationFactory : WebApplicationFactory<ScrambleCoin.Api.ApiMarker>
+    {
+        // Unique DB name per factory instance so test classes don't share state.
+        private readonly string _dbName = $"MoveTestDb_{Guid.NewGuid()}";
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                // Remove every DbContext-related registration added by Program.cs.
+                var descriptorsToRemove = services
+                    .Where(d =>
+                        d.ServiceType == typeof(DbContextOptions<ScrambleCoinDbContext>) ||
+                        d.ServiceType == typeof(DbContextOptions) ||
+                        d.ServiceType == typeof(ScrambleCoinDbContext))
+                    .ToList();
+
+                foreach (var d in descriptorsToRemove)
+                    services.Remove(d);
+
+                // Re-register using a factory that builds fresh DbContextOptions with
+                // ONLY the InMemory provider.
+                var dbName = _dbName;
+                services.AddScoped<ScrambleCoinDbContext>(_ =>
+                {
+                    var opts = new DbContextOptionsBuilder<ScrambleCoinDbContext>()
+                        .UseInMemoryDatabase(dbName)
+                        .Options;
+                    return new ScrambleCoinDbContext(opts);
+                });
+
+                services.Configure<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckServiceOptions>(
+                    opts => opts.Registrations.Clear());
+            });
+
+            builder.UseUrls("http://127.0.0.1:0");
+        }
+    }
+
+    // ── Seed helpers ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Seeds a game in <see cref="TurnPhase.MovePhase"/> where P1 has one piece at (0,0)
+    /// and P2 has no pieces on board (P2 skipped placement).
+    /// Returns (game, tokenP1, tokenP2, p1PieceId).
+    /// </summary>
+    private async Task<(Game game, Guid tokenP1, Guid tokenP2, Guid p1PieceId)>
+        SeedGameInMovePhaseWithP1PieceAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var gameRepo = scope.ServiceProvider.GetRequiredService<IGameRepository>();
+        var botRepo = scope.ServiceProvider.GetRequiredService<IBotRegistrationRepository>();
+
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Piece{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 3, 1))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Piece{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 3, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start();            // → CoinSpawn Turn 1
+        game.AdvancePhase();     // → PlacePhase Turn 1
+
+        // P1 places piece at corner (0, 0); P2 skips → auto-advances to MovePhase
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        game.SkipPlacement(p2); // → MovePhase
+
+        await gameRepo.SaveAsync(game);
+
+        var tokenP1 = Guid.NewGuid();
+        var tokenP2 = Guid.NewGuid();
+        await botRepo.SaveAsync(new BotRegistration(tokenP1, p1, game.Id));
+        await botRepo.SaveAsync(new BotRegistration(tokenP2, p2, game.Id));
+
+        return (game, tokenP1, tokenP2, p1Pieces[0].Id);
+    }
+
+    /// <summary>
+    /// Seeds a game in <see cref="TurnPhase.MovePhase"/> where both players have one piece
+    /// on the board: P1 at (0,0) and P2 at (7,7).
+    /// Returns (game, tokenP1, tokenP2, p1PieceId, p2PieceId).
+    /// </summary>
+    private async Task<(Game game, Guid tokenP1, Guid tokenP2, Guid p1PieceId, Guid p2PieceId)>
+        SeedGameInMovePhaseWithBothPiecesAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var gameRepo = scope.ServiceProvider.GetRequiredService<IGameRepository>();
+        var botRepo = scope.ServiceProvider.GetRequiredService<IBotRegistrationRepository>();
+
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Piece{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 3, 1))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Piece{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 3, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start();            // → CoinSpawn Turn 1
+        game.AdvancePhase();     // → PlacePhase Turn 1
+
+        // Both players place a piece → auto-advances to MovePhase
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 7));
+
+        await gameRepo.SaveAsync(game);
+
+        var tokenP1 = Guid.NewGuid();
+        var tokenP2 = Guid.NewGuid();
+        await botRepo.SaveAsync(new BotRegistration(tokenP1, p1, game.Id));
+        await botRepo.SaveAsync(new BotRegistration(tokenP2, p2, game.Id));
+
+        return (game, tokenP1, tokenP2, p1Pieces[0].Id, p2Pieces[0].Id);
+    }
+
+    /// <summary>
+    /// Seeds a game in <see cref="TurnPhase.MovePhase"/> where P1 has one piece at (0,0)
+    /// and a silver coin is sitting at (0,1) — the tile P1's piece will step onto.
+    /// Returns (game, tokenP1, tokenP2, p1PieceId).
+    /// </summary>
+    private async Task<(Game game, Guid tokenP1, Guid tokenP2, Guid p1PieceId)>
+        SeedGameInMovePhaseWithCoinAtTargetAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var gameRepo = scope.ServiceProvider.GetRequiredService<IGameRepository>();
+        var botRepo = scope.ServiceProvider.GetRequiredService<IBotRegistrationRepository>();
+
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Piece{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 3, 1))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Piece{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 3, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start(); // → CoinSpawn Turn 1
+
+        // Spawn a silver coin at (0,1) — right next to where P1's piece will be placed.
+        game.SpawnCoins(new[] { (new Position(0, 1), CoinType.Silver) });
+
+        game.AdvancePhase();     // → PlacePhase Turn 1
+
+        // P1 places piece at (0,0); P2 skips → auto-advances to MovePhase
+        game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0));
+        game.SkipPlacement(p2); // → MovePhase
+
+        await gameRepo.SaveAsync(game);
+
+        var tokenP1 = Guid.NewGuid();
+        var tokenP2 = Guid.NewGuid();
+        await botRepo.SaveAsync(new BotRegistration(tokenP1, p1, game.Id));
+        await botRepo.SaveAsync(new BotRegistration(tokenP2, p2, game.Id));
+
+        return (game, tokenP1, tokenP2, p1Pieces[0].Id);
+    }
+
+    /// <summary>
+    /// Seeds a game in <see cref="TurnPhase.PlacePhase"/> (Turn 1), two bot registrations.
+    /// Returns (game, tokenP1, tokenP2).
+    /// </summary>
+    private async Task<(Game game, Guid tokenP1, Guid tokenP2)> SeedGameInPlacePhaseAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var gameRepo = scope.ServiceProvider.GetRequiredService<IGameRepository>();
+        var botRepo = scope.ServiceProvider.GetRequiredService<IBotRegistrationRepository>();
+
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        var p1Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Piece{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 3, 1))
+            .ToList();
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Piece{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 3, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start();        // → CoinSpawn Turn 1
+        game.AdvancePhase(); // → PlacePhase Turn 1
+
+        await gameRepo.SaveAsync(game);
+
+        var tokenP1 = Guid.NewGuid();
+        var tokenP2 = Guid.NewGuid();
+        await botRepo.SaveAsync(new BotRegistration(tokenP1, p1, game.Id));
+        await botRepo.SaveAsync(new BotRegistration(tokenP2, p2, game.Id));
+
+        return (game, tokenP1, tokenP2);
+    }
+
+    // ── AC 1 : valid token + valid move during MovePhase → 200 OK ─────────────
+
+    [Fact]
+    public async Task Move_ValidTokenAndMove_Returns200()
+    {
+        // Arrange: game in MovePhase with P1's piece at (0,0)
+        var (game, tokenP1, _, p1PieceId) = await SeedGameInMovePhaseWithP1PieceAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        var body = new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Move_ValidMove_ResponseContainsPhaseField()
+    {
+        // Arrange
+        var (game, tokenP1, _, p1PieceId) = await SeedGameInMovePhaseWithP1PieceAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        var body = new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        // Assert
+        Assert.True(json.RootElement.TryGetProperty("phase", out _),
+            "Response JSON must contain a 'phase' field.");
+    }
+
+    [Fact]
+    public async Task Move_ValidMove_ResponseContainsActivePlayerField()
+    {
+        // Arrange
+        var (game, tokenP1, _, p1PieceId) = await SeedGameInMovePhaseWithP1PieceAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        var body = new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        // Assert
+        Assert.True(json.RootElement.TryGetProperty("activePlayer", out _),
+            "Response JSON must contain an 'activePlayer' field (may be null).");
+    }
+
+    [Fact]
+    public async Task Move_ValidMove_ResponseContainsYourScoreField()
+    {
+        // Arrange
+        var (game, tokenP1, _, p1PieceId) = await SeedGameInMovePhaseWithP1PieceAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        var body = new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        // Assert
+        Assert.True(json.RootElement.TryGetProperty("yourScore", out _),
+            "Response JSON must contain a 'yourScore' field.");
+    }
+
+    [Fact]
+    public async Task Move_ValidMove_ResponseContainsOpponentScoreField()
+    {
+        // Arrange
+        var (game, tokenP1, _, p1PieceId) = await SeedGameInMovePhaseWithP1PieceAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        var body = new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        // Assert
+        Assert.True(json.RootElement.TryGetProperty("opponentScore", out _),
+            "Response JSON must contain an 'opponentScore' field.");
+    }
+
+    // ── AC 2 : missing X-Bot-Token header → 403 ──────────────────────────────
+
+    [Fact]
+    public async Task Move_WithoutBotTokenHeader_Returns403()
+    {
+        // Arrange: game in MovePhase, no token header added
+        var (game, _, _, p1PieceId) = await SeedGameInMovePhaseWithP1PieceAsync();
+        var client = _factory.CreateClient();
+        // No X-Bot-Token header
+
+        var body = new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    // ── AC 3 : malformed (non-GUID) X-Bot-Token → 403 ────────────────────────
+
+    [Fact]
+    public async Task Move_WithMalformedBotToken_Returns403()
+    {
+        // Arrange: token is not a valid GUID
+        var (game, _, _, p1PieceId) = await SeedGameInMovePhaseWithP1PieceAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", "not-a-valid-guid");
+
+        var body = new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    // ── AC 4 : valid token but for a different game → 403 ────────────────────
+
+    [Fact]
+    public async Task Move_WithTokenFromDifferentGame_Returns403()
+    {
+        // Arrange: seed two separate games; use tokenP1 from game1 against game2
+        var (_, tokenFromOtherGame, _, _) = await SeedGameInMovePhaseWithP1PieceAsync();
+        var (game2, _, _, p1PieceId) = await SeedGameInMovePhaseWithP1PieceAsync();
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", tokenFromOtherGame.ToString());
+
+        var body = new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        };
+
+        // Act: present a valid token, but it belongs to a different game
+        var response = await client.PostAsJsonAsync($"/api/games/{game2.Id}/move", body);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    // ── AC 5 : move during PlacePhase (wrong phase) → 400 ────────────────────
+
+    [Fact]
+    public async Task Move_DuringPlacePhase_Returns400()
+    {
+        // Arrange: game has NOT yet advanced to MovePhase
+        var (game, tokenP1, _) = await SeedGameInPlacePhaseAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        var body = new
+        {
+            pieceId = Guid.NewGuid(),
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    // ── AC 6 : move when it's not your turn → 400 ────────────────────────────
+
+    [Fact]
+    public async Task Move_WhenNotYourTurn_Returns400()
+    {
+        // Arrange: game in MovePhase with both players having one piece on the board.
+        // MovePhaseActivePlayer == PlayerOne, so P2 should be rejected.
+        var (game, _, tokenP2, _, p2PieceId) = await SeedGameInMovePhaseWithBothPiecesAsync();
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", tokenP2.ToString());
+
+        var body = new
+        {
+            pieceId = p2PieceId,
+            segments = new[] { new[] { new { row = 7, col = 6 } } }
+        };
+
+        // Act: P2 tries to move before P1 has made any move
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    // ── AC 7 : body.Segments is null → 400 ───────────────────────────────────
+
+    [Fact]
+    public async Task Move_WithNullSegments_Returns400()
+    {
+        // Arrange: valid token and game, but segments field is omitted (null)
+        var (game, tokenP1, _, p1PieceId) = await SeedGameInMovePhaseWithP1PieceAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        // Omit segments — deserialises as null
+        var body = new { pieceId = p1PieceId };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    // ── AC 8 : move through a coin tile → yourScore incremented ──────────────
+
+    [Fact]
+    public async Task Move_ThroughCoinTile_ReturnsIncrementedYourScore()
+    {
+        // Arrange: game in MovePhase with P1's piece at (0,0) and a silver coin at (0,1).
+        // Silver coin value = 1.
+        var (game, tokenP1, _, p1PieceId) = await SeedGameInMovePhaseWithCoinAtTargetAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        var body = new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } } // steps onto the coin tile
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(json.RootElement.TryGetProperty("yourScore", out var yourScore));
+        Assert.Equal(1, yourScore.GetInt32()); // Silver coin = 1 point
+    }
+
+    [Fact]
+    public async Task Move_ThroughCoinTile_OpponentScoreUnchanged()
+    {
+        // Arrange
+        var (game, tokenP1, _, p1PieceId) = await SeedGameInMovePhaseWithCoinAtTargetAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        var body = new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        // Assert: opponent score is still zero
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(json.RootElement.TryGetProperty("opponentScore", out var opponentScore));
+        Assert.Equal(0, opponentScore.GetInt32());
+    }
+
+    [Fact]
+    public async Task Move_ThroughEmptyTile_YourScoreRemainsZero()
+    {
+        // Arrange: game in MovePhase with no coins on board
+        var (game, tokenP1, _, p1PieceId) = await SeedGameInMovePhaseWithP1PieceAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        var body = new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/games/{game.Id}/move", body);
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        // Assert: no coin collected, score stays 0
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(json.RootElement.TryGetProperty("yourScore", out var yourScore));
+        Assert.Equal(0, yourScore.GetInt32());
+    }
+
+    // ── AC 9 : both players complete all moves → phase advances to CoinSpawn ──
+
+    [Fact]
+    public async Task Move_BothPlayersCompleteAllMoves_PhaseAdvancesToCoinSpawn()
+    {
+        // Arrange: P1 at (0,0), P2 at (7,7) — both in MovePhase
+        var (game, tokenP1, tokenP2, p1PieceId, p2PieceId) =
+            await SeedGameInMovePhaseWithBothPiecesAsync();
+
+        var clientP1 = _factory.CreateClient();
+        clientP1.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        var clientP2 = _factory.CreateClient();
+        clientP2.DefaultRequestHeaders.Add("X-Bot-Token", tokenP2.ToString());
+
+        // P1 moves first (P1 is always the first active player in MovePhase)
+        await clientP1.PostAsJsonAsync($"/api/games/{game.Id}/move", new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        });
+
+        // Act: P2 moves — this completes all moves for both players
+        var response = await clientP2.PostAsJsonAsync($"/api/games/{game.Id}/move", new
+        {
+            pieceId = p2PieceId,
+            segments = new[] { new[] { new { row = 7, col = 6 } } }
+        });
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        // Assert: turn rolled over → phase is now CoinSpawn (new turn)
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(json.RootElement.TryGetProperty("phase", out var phaseElement));
+        Assert.Equal("CoinSpawn", phaseElement.GetString());
+    }
+
+    [Fact]
+    public async Task Move_AfterP1MovesButBeforeP2_PhaseIsStillMovePhase()
+    {
+        // Arrange
+        var (game, tokenP1, _, p1PieceId, _) = await SeedGameInMovePhaseWithBothPiecesAsync();
+
+        var clientP1 = _factory.CreateClient();
+        clientP1.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        // Act: only P1 moves — P2 still pending
+        var response = await clientP1.PostAsJsonAsync($"/api/games/{game.Id}/move", new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        });
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        // Assert: phase has NOT yet rolled over
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(json.RootElement.TryGetProperty("phase", out var phaseElement));
+        Assert.Equal("MovePhase", phaseElement.GetString());
+    }
+
+    [Fact]
+    public async Task Move_AfterP1Moves_ActivePlayerSwitchesToP2()
+    {
+        // Arrange: both players have one piece on board
+        var (game, tokenP1, tokenP2, p1PieceId, _) = await SeedGameInMovePhaseWithBothPiecesAsync();
+
+        var clientP1 = _factory.CreateClient();
+        clientP1.DefaultRequestHeaders.Add("X-Bot-Token", tokenP1.ToString());
+
+        // Act: P1 moves their piece
+        var response = await clientP1.PostAsJsonAsync($"/api/games/{game.Id}/move", new
+        {
+            pieceId = p1PieceId,
+            segments = new[] { new[] { new { row = 0, col = 1 } } }
+        });
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        // Assert: activePlayer has switched to P2 (the other player)
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(json.RootElement.TryGetProperty("activePlayer", out var activePlayerElement));
+        Assert.NotEqual(JsonValueKind.Null, activePlayerElement.ValueKind);
+
+        // The activePlayer ID should NOT be the same as the game's PlayerOne (P1)
+        var activePlayerId = Guid.Parse(activePlayerElement.GetString()!);
+        Assert.NotEqual(game.PlayerOne, activePlayerId);
+    }
+}

--- a/tests/ScrambleCoin.Web.Tests/MoveEndpointTests.cs
+++ b/tests/ScrambleCoin.Web.Tests/MoveEndpointTests.cs
@@ -655,6 +655,6 @@ public class MoveEndpointTests : IClassFixture<MoveEndpointTests.TestWebApplicat
 
         // The activePlayer ID should NOT be the same as the game's PlayerOne (P1)
         var activePlayerId = Guid.Parse(activePlayerElement.GetString()!);
-        Assert.NotEqual(game.PlayerOne, activePlayerId);
+        Assert.Equal(game.PlayerTwo, activePlayerId);
     }
 }


### PR DESCRIPTION
## Summary

Implements the move REST endpoint so bots can submit move decisions during the Move phase.

Closes #40

## Changes

| File | Change |
|------|--------|
| `src/ScrambleCoin.Application/Games/MovePiece/MoveResult.cs` | **New** — `record MoveResult(string? Phase, Guid? ActivePlayer, int YourScore, int OpponentScore)` |
| `src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommand.cs` | `PlayerId` → `BotToken`; `IRequest` → `IRequest<MoveResult>` |
| `src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommandHandler.cs` | Injects `IBotRegistrationRepository`; resolves player from token; returns `MoveResult`; logs after save |
| `src/ScrambleCoin.Api/Endpoints/GameEndpoints.cs` | Added `POST /api/games/{gameId}/move` route + `MoveRequest` record; null guard for segments inside try block |
| `tests/ScrambleCoin.Web.Tests/MoveEndpointTests.cs` | **New** — 17 integration tests covering all 9 acceptance criteria |
| `tests/ScrambleCoin.Application.Tests/MovePieceCommandHandlerTests.cs` | Updated to use `BotToken` + mock `IBotRegistrationRepository` |

## API contract

```
POST /api/games/{gameId}/move
X-Bot-Token: <guid>
Content-Type: application/json

{
  "pieceId": "<guid>",
  "segments": [{ "row": 3, "col": 4 }]
}
```

**200 OK:**
```json
{ "phase": "MovePhase", "activePlayer": "<guid>", "yourScore": 3, "opponentScore": 1 }
```

| Status | Reason |
|--------|--------|
| 400 | Not in MovePhase / not your turn / null segments / invalid position |
| 403 | Missing/malformed/wrong-game X-Bot-Token |
| 404 | Game not found |

## Review cycles
- Implementation: 1 cycle (segment null guard + log ordering)
- Tests: 1 cycle (false-positive assertion fixed)

## Test counts
- 17 new integration tests added
- All 698 tests pass