### PR TITLE
Piece ability — Ethereal movement (pass through obstacles/pieces, end on free tile)

### DIFF
--- a/src/ScrambleCoin.Domain/Entities/Board.cs
+++ b/src/ScrambleCoin.Domain/Entities/Board.cs
@@ -135,6 +135,64 @@ public sealed class Board
         return true;
     }
 
+    /// <summary>
+    /// Returns <c>true</c> if there is a Fence blocking movement from <paramref name="from"/> to <paramref name="to"/>.
+    /// This method does NOT check for rocks, lakes, or piece occupants — only fence edges.
+    /// </summary>
+    /// <remarks>
+    /// Used by movement types like Ethereal that ignore occupants but still respect fences.
+    /// </remarks>
+    /// <exception cref="DomainException">
+    /// Thrown if <paramref name="from"/> and <paramref name="to"/> are not adjacent.
+    /// </exception>
+    public bool IsFenceBlocked(Position from, Position to)
+    {
+        // Guard: positions must be adjacent (orthogonally or diagonally)
+        if (!from.IsOrthogonallyAdjacentTo(to) && !from.IsDiagonallyAdjacentTo(to))
+            throw new DomainException($"Positions {from} and {to} are not adjacent.");
+
+        var rowDiff = to.Row - from.Row;
+        var colDiff = to.Col - from.Col;
+
+        var isOrthogonal = Math.Abs(rowDiff) == 1 && colDiff == 0 ||
+                           rowDiff == 0 && Math.Abs(colDiff) == 1;
+
+        var isDiagonal = Math.Abs(rowDiff) == 1 && Math.Abs(colDiff) == 1;
+
+        if (isOrthogonal)
+        {
+            // Blocked by a fence directly on this edge
+            if (_fences.Any(f => f.IsOnEdge(from, to)))
+                return true;
+        }
+        else if (isDiagonal)
+        {
+            // A diagonal move from A=(r, c) to B=(r+dr, c+dc) is blocked when two
+            // fences form a corner at either intermediate tile:
+            //   cornerA = (r+dr, c) — shares a row with B, a col with A
+            //   cornerB = (r, c+dc) — shares a col with B, a row with A
+            //
+            // Corner at A: fence A↔cornerA AND fence A↔cornerB → L-shape at A
+            // Corner at B: fence B↔cornerA AND fence B↔cornerB → L-shape at B
+            var cornerA = new Position(from.Row + rowDiff, from.Col); // vertically adjacent to from
+            var cornerB = new Position(from.Row, from.Col + colDiff); // horizontally adjacent to from
+
+            // Corner at the 'from' side
+            var fenceFromVertical   = _fences.Any(f => f.IsOnEdge(from, cornerA));
+            var fenceFromHorizontal = _fences.Any(f => f.IsOnEdge(from, cornerB));
+            if (fenceFromVertical && fenceFromHorizontal)
+                return true;
+
+            // Corner at the 'to' side (symmetric case — blocks *entry* into to)
+            var fenceToVertical   = _fences.Any(f => f.IsOnEdge(to, cornerA));
+            var fenceToHorizontal = _fences.Any(f => f.IsOnEdge(to, cornerB));
+            if (fenceToVertical && fenceToHorizontal)
+                return true;
+        }
+
+        return false;
+    }
+
     // ── Obstacle coverage ────────────────────────────────────────────────────
 
     /// <summary>
@@ -251,6 +309,30 @@ public sealed class Board
 
             var neighbor = new Position(newRow, newCol);
 
+            // For Ethereal, only check fence blocking; destination must have no piece and no obstacle.
+            if (movementType == MovementType.Ethereal)
+            {
+                try
+                {
+                    if (IsFenceBlocked(currentPos, neighbor))
+                        continue;
+                }
+                catch
+                {
+                    continue;
+                }
+
+                // Destination must not have an obstacle (rock or lake) or a piece
+                if (IsObstacleCovering(neighbor))
+                    continue;
+
+                if (_tiles[newRow, newCol].AsPiece is not null)
+                    continue;
+
+                return true;
+            }
+
+            // For other movement types, use the standard passability check.
             try
             {
                 if (!IsPassable(currentPos, neighbor))

--- a/src/ScrambleCoin.Domain/Entities/Game.cs
+++ b/src/ScrambleCoin.Domain/Entities/Game.cs
@@ -780,6 +780,48 @@ public sealed class Game
                         continue;
                     }
                 
+                // Special handling for Ethereal movement.
+                // Ethereal moves are encoded as a sequence of steps (like Orthogonal/Diagonal).
+                case MovementType.Ethereal:
+                    {
+                        if (segment.Count > piece.MaxDistance)
+                            throw new DomainException(
+                                $"Piece {pieceId}, segment {segIndex}: segment has {segment.Count} step(s), but MaxDistance is {piece.MaxDistance}.");
+
+                        var segFrom = currentPosition;
+
+                        foreach (var stepTo in segment)
+                        {
+                            // Ethereal is only valid as Any direction (orthogonal or diagonal)
+                            if (!segFrom.IsOrthogonallyAdjacentTo(stepTo) && !segFrom.IsDiagonallyAdjacentTo(stepTo))
+                                throw new DomainException(
+                                    $"Piece {pieceId}: step from {segFrom} to {stepTo} is not adjacent.");
+
+                            // Ethereal respects fences (but not occupants on intermediate tiles)
+                            if (Board.IsFenceBlocked(segFrom, stepTo))
+                                throw new DomainException(
+                                    $"Piece {pieceId}: step from {segFrom} to {stepTo} is blocked by a fence.");
+
+                            // Collect coin if present at intermediate tiles.
+                            var stepTile = Board.GetTile(stepTo);
+                            var coin = stepTile.AsCoin;
+                            if (coin is not null)
+                            {
+                                stepTile.ClearOccupant();
+                                AddScore(playerId, coin.Value);
+                                _domainEvents.Add(new CoinCollected(
+                                    Id, TurnNumber, playerId, pieceId, stepTo,
+                                    coin.CoinType, coin.Value, DateTimeOffset.UtcNow));
+                            }
+
+                            fullPath.Add(stepTo);
+                            segFrom = stepTo;
+                        }
+
+                        currentPosition = segFrom;
+                        break;
+                    }
+                
                 // For Jump movement, each segment should be a single destination position.
                 // For other movement types, the segment is a sequence of steps.
                 case MovementType.Jump when segment.Count != 1:
@@ -915,6 +957,15 @@ public sealed class Game
                         break;
                     }
             }
+        }
+
+        // Special validation for Ethereal movement: destination must not have a piece occupant (only if moved).
+        if (piece.MovementType == MovementType.Ethereal && currentPosition != startPosition)
+        {
+            var destinationTile = Board.GetTile(currentPosition);
+            if (destinationTile.AsPiece is not null)
+                throw new DomainException(
+                    $"Piece {pieceId}: tile {currentPosition} is already occupied by a piece. Ethereal movement must end on a free tile.");
         }
 
         // Move the piece on the board.

--- a/src/ScrambleCoin.Domain/Entities/Game.cs
+++ b/src/ScrambleCoin.Domain/Entities/Game.cs
@@ -966,6 +966,10 @@ public sealed class Game
             if (destinationTile.AsPiece is not null)
                 throw new DomainException(
                     $"Piece {pieceId}: tile {currentPosition} is already occupied by a piece. Ethereal movement must end on a free tile.");
+            
+            if (Board.IsObstacleCovering(currentPosition))
+                throw new DomainException(
+                    $"Piece {pieceId}: tile {currentPosition} is covered by an obstacle. Ethereal movement must end on a free tile.");
         }
 
         // Move the piece on the board.

--- a/src/ScrambleCoin.Domain/Enums/MovementType.cs
+++ b/src/ScrambleCoin.Domain/Enums/MovementType.cs
@@ -21,5 +21,12 @@ public enum MovementType
     Jump,
 
     /// <summary>The piece slides in a chosen direction until hitting an obstacle, piece, or board edge. The player does not choose how far it goes.</summary>
-    Charge
+    Charge,
+
+    /// <summary>
+    /// The piece passes through pieces and obstacles on intermediate tiles but must end on a free tile.
+    /// Collects coins on all tiles in the path (intermediate and destination).
+    /// Fences still block Ethereal movement.
+    /// </summary>
+    Ethereal
 }

--- a/tests/ScrambleCoin.Application.Tests/EtherealMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/EtherealMovementIntegrationTests.cs
@@ -1,0 +1,500 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using ScrambleCoin.Application.BotRegistration;
+using ScrambleCoin.Application.Games.MovePiece;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Events;
+using ScrambleCoin.Domain.Exceptions;
+using ScrambleCoin.Domain.Obstacles;
+using ScrambleCoin.Domain.ValueObjects;
+using DomainBotReg = ScrambleCoin.Domain.BotRegistrations.BotRegistration;
+
+namespace ScrambleCoin.Application.Tests;
+
+/// <summary>
+/// Integration tests for Ethereal movement (Issue #46) via the Application layer.
+/// Tests the full flow: game creation → piece placement → ethereal move → score updates.
+/// Follows the same pattern as ChargeMovementIntegrationTests.
+/// </summary>
+public class EtherealMovementIntegrationTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a game in MovePhase with an Ethereal piece for P1 and a normal piece for P2.
+    /// </summary>
+    private static (Game game, Guid p1, Guid p2, Piece etherealPiece, Piece p2Piece)
+        GameInMovePhaseWithEtherealPiece(
+            Position? etherealStartPos = null,
+            Position? p2StartPos = null,
+            int etherealMaxDistance = 3)
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        var actualEtherealStartPos = etherealStartPos ?? new Position(0, 0);
+        var actualP2StartPos = p2StartPos ?? new Position(7, 7);
+
+        var etherealPiece = new Piece(Guid.NewGuid(), "Ethereal", p1,
+            EntryPointType.Corners, MovementType.Ethereal, etherealMaxDistance, 1);
+        var p1Fill = Enumerable.Range(0, 4)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Fill{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+
+        var p2Piece = new Piece(Guid.NewGuid(), "P2Mover", p2,
+            EntryPointType.Borders, MovementType.Orthogonal, 1, 1);
+        var p2Fill = Enumerable.Range(0, 4)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Fill{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(new[] { etherealPiece }.Concat(p1Fill)));
+        game.SetLineup(p2, new Lineup(new[] { p2Piece }.Concat(p2Fill)));
+        game.Start();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+
+        game.PlacePiece(p1, etherealPiece.Id, actualEtherealStartPos);
+        game.PlacePiece(p2, p2Piece.Id, actualP2StartPos);
+
+        return (game, p1, p2, etherealPiece, p2Piece);
+    }
+
+    /// <summary>
+    /// Creates a mock game repository that returns a game by ID and allows saving.
+    /// </summary>
+    private static IGameRepository MockGameRepository(Game game)
+    {
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+        return repo;
+    }
+
+    /// <summary>
+    /// Creates a mock bot registration repository.
+    /// </summary>
+    private static IBotRegistrationRepository MockBotRepository(Guid token, Guid playerId, Guid gameId)
+    {
+        var repo = Substitute.For<IBotRegistrationRepository>();
+        repo.GetByTokenAsync(token, Arg.Any<CancellationToken>())
+            .Returns(new DomainBotReg(token, playerId, gameId));
+        return repo;
+    }
+
+    /// <summary>
+    /// Builds a handler with the provided repositories.
+    /// </summary>
+    private static MovePieceCommandHandler BuildHandler(
+        IGameRepository gameRepo,
+        IBotRegistrationRepository botRepo,
+        IPublisher? publisher = null)
+        => new(gameRepo,
+            botRepo,
+            publisher ?? Substitute.For<IPublisher>(),
+            Substitute.For<ILogger<MovePieceCommandHandler>>());
+
+    /// <summary>
+    /// Builds a multi-step segment for Ethereal movement.
+    /// </summary>
+    private static IReadOnlyList<IReadOnlyList<Position>> BuildEtherealSegment(params Position[] positions)
+    {
+        var segment = (IReadOnlyList<Position>)positions.ToList().AsReadOnly();
+        return new List<IReadOnlyList<Position>> { segment }.AsReadOnly();
+    }
+
+    // ── Integration Test 1: Basic Ethereal movement through rock ──────────────────
+
+    [Fact]
+    public async Task EtherealMovement_ViaApplicationLayer_PassThroughRockAndCollectsCoin()
+    {
+        // Arrange: Ethereal at (0,0), rock at (0,1), coin at (0,2)
+        var (game, p1, _, etherealPiece, _) = GameInMovePhaseWithEtherealPiece(
+            etherealStartPos: new Position(0, 0),
+            etherealMaxDistance: 2);
+
+        var rockPos = new Position(0, 1);
+        var coinPos = new Position(0, 2);
+        game.Board.AddRock(new Rock(rockPos));
+        game.Board.GetTile(coinPos).SetOccupant(new Coin(CoinType.Silver));
+
+        var token = Guid.NewGuid();
+        var gameRepo = MockGameRepository(game);
+        var botRepo = MockBotRepository(token, p1, game.Id);
+        var handler = BuildHandler(gameRepo, botRepo);
+
+        // Act: Move ethereal through rock to coin tile
+        await handler.Handle(
+            new MovePieceCommand(game.Id, token, etherealPiece.Id, BuildEtherealSegment(rockPos, coinPos)),
+            CancellationToken.None);
+
+        // Assert: piece moved through rock to coin position
+        Assert.Equal(coinPos, etherealPiece.Position);
+
+        // Assert: coin was collected
+        Assert.Equal(1, game.Scores[p1]);
+
+        // Assert: coin removed from board
+        Assert.Null(game.Board.GetTile(coinPos).AsCoin);
+
+        // Assert: game was saved
+        await gameRepo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+
+    // ── Integration Test 2: Ethereal passes through opponent piece ──────────────────
+
+    [Fact]
+    public async Task EtherealMovement_PassThroughOpponentPiece_ReachesDestinationAndSaves()
+    {
+        // Arrange: Ethereal at (0,0), opponent at (0,1), destination at (0,2)
+        var (game, p1, p2, etherealPiece, p2Piece) = GameInMovePhaseWithEtherealPiece(
+            etherealStartPos: new Position(0, 0),
+            p2StartPos: new Position(0, 1),
+            etherealMaxDistance: 2);
+
+        var token = Guid.NewGuid();
+        var gameRepo = MockGameRepository(game);
+        var botRepo = MockBotRepository(token, p1, game.Id);
+        var handler = BuildHandler(gameRepo, botRepo);
+
+        // Act: Move ethereal through opponent
+        await handler.Handle(
+            new MovePieceCommand(game.Id, token, etherealPiece.Id, 
+                BuildEtherealSegment(new Position(0, 1), new Position(0, 2))),
+            CancellationToken.None);
+
+        // Assert: ethereal reached destination
+        Assert.Equal(new Position(0, 2), etherealPiece.Position);
+
+        // Assert: opponent piece still in place (not captured)
+        Assert.Equal(new Position(0, 1), p2Piece.Position);
+
+        // Assert: game was saved
+        await gameRepo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+
+    // ── Integration Test 3: Ethereal rejects ending on occupied tile ───────────────
+
+    [Fact]
+    public async Task EtherealMovement_EndOnOccupiedTile_ThrowsAndDoesNotSave()
+    {
+        // Arrange: Ethereal at (0,0), opponent at destination (0,1)
+        var (game, p1, p2, etherealPiece, p2Piece) = GameInMovePhaseWithEtherealPiece(
+            etherealStartPos: new Position(0, 0),
+            p2StartPos: new Position(0, 1));
+
+        var token = Guid.NewGuid();
+        var gameRepo = MockGameRepository(game);
+        var botRepo = MockBotRepository(token, p1, game.Id);
+        var handler = BuildHandler(gameRepo, botRepo);
+
+        // Act & Assert: attempting to end on occupied tile throws
+        var ex = await Assert.ThrowsAsync<DomainException>(async () =>
+            await handler.Handle(
+                new MovePieceCommand(game.Id, token, etherealPiece.Id, BuildEtherealSegment(new Position(0, 1))),
+                CancellationToken.None));
+
+        Assert.Contains("free tile", ex.Message);
+
+        // Assert: game was NOT saved (move was rejected)
+        await gameRepo.DidNotReceive().SaveAsync(Arg.Any<Game>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Integration Test 4: Ethereal collects all coins in path ────────────────────
+
+    [Fact]
+    public async Task EtherealMovement_CollectsAllCoinsInPath_UpdatesScore()
+    {
+        // Arrange: Ethereal at (0,0), coins at intermediate and destination tiles
+        var (game, p1, _, etherealPiece, _) = GameInMovePhaseWithEtherealPiece(
+            etherealStartPos: new Position(0, 0),
+            etherealMaxDistance: 3);
+
+        game.Board.GetTile(new Position(0, 1)).SetOccupant(new Coin(CoinType.Silver)); // 1 pt
+        game.Board.GetTile(new Position(0, 2)).SetOccupant(new Coin(CoinType.Silver)); // 1 pt
+        game.Board.GetTile(new Position(0, 3)).SetOccupant(new Coin(CoinType.Gold));   // 3 pts
+
+        var token = Guid.NewGuid();
+        var gameRepo = MockGameRepository(game);
+        var botRepo = MockBotRepository(token, p1, game.Id);
+        var handler = BuildHandler(gameRepo, botRepo);
+
+        // Act: Move through all tiles
+        await handler.Handle(
+            new MovePieceCommand(game.Id, token, etherealPiece.Id,
+                BuildEtherealSegment(new Position(0, 1), new Position(0, 2), new Position(0, 3))),
+            CancellationToken.None);
+
+        // Assert: all coins collected (1 + 1 + 3 = 5)
+        Assert.Equal(5, game.Scores[p1]);
+
+        // Assert: all tiles are now clear
+        Assert.Null(game.Board.GetTile(new Position(0, 1)).AsCoin);
+        Assert.Null(game.Board.GetTile(new Position(0, 2)).AsCoin);
+        Assert.Null(game.Board.GetTile(new Position(0, 3)).AsCoin);
+
+        // Assert: game was saved
+        await gameRepo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+
+    // ── Integration Test 5: Ethereal fence blocks movement ────────────────────────
+
+    [Fact]
+    public async Task EtherealMovement_FenceBlocksPath_ThrowsAndDoesNotSave()
+    {
+        // Arrange: Ethereal at (0,0), fence between (0,0) and (0,1)
+        var (game, p1, _, etherealPiece, _) = GameInMovePhaseWithEtherealPiece(
+            etherealStartPos: new Position(0, 0));
+
+        var fence = new Fence(new Position(0, 0), new Position(0, 1));
+        game.Board.AddFence(fence);
+
+        var token = Guid.NewGuid();
+        var gameRepo = MockGameRepository(game);
+        var botRepo = MockBotRepository(token, p1, game.Id);
+        var handler = BuildHandler(gameRepo, botRepo);
+
+        // Act & Assert: attempting to cross fence throws
+        var ex = await Assert.ThrowsAsync<DomainException>(async () =>
+            await handler.Handle(
+                new MovePieceCommand(game.Id, token, etherealPiece.Id, BuildEtherealSegment(new Position(0, 1))),
+                CancellationToken.None));
+
+        Assert.Contains("fence", ex.Message);
+
+        // Assert: game was NOT saved
+        await gameRepo.DidNotReceive().SaveAsync(Arg.Any<Game>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Integration Test 6: Ethereal with multiple obstacles and coins ────────────────
+
+    [Fact]
+    public async Task EtherealMovement_MultipleRocksOpponentAndCoins_PassThroughAllAndCollectCoins()
+    {
+        // Arrange: Ethereal at (0,0), path with rock, opponent, rock, and coin
+        var (game, p1, p2, etherealPiece, p2Piece) = GameInMovePhaseWithEtherealPiece(
+            etherealStartPos: new Position(0, 0),
+            p2StartPos: new Position(0, 2),
+            etherealMaxDistance: 4);
+
+        game.Board.AddRock(new Rock(new Position(0, 1))); // Rock at (0,1)
+        // Opponent at (0,2) — set via GameInMovePhaseWithEtherealPiece
+        game.Board.AddRock(new Rock(new Position(0, 3))); // Rock at (0,3)
+        game.Board.GetTile(new Position(0, 4)).SetOccupant(new Coin(CoinType.Silver));
+
+        var token = Guid.NewGuid();
+        var gameRepo = MockGameRepository(game);
+        var botRepo = MockBotRepository(token, p1, game.Id);
+        var handler = BuildHandler(gameRepo, botRepo);
+
+        // Act: Move through all obstacles
+        await handler.Handle(
+            new MovePieceCommand(game.Id, token, etherealPiece.Id,
+                BuildEtherealSegment(
+                    new Position(0, 1),
+                    new Position(0, 2),
+                    new Position(0, 3),
+                    new Position(0, 4))),
+            CancellationToken.None);
+
+        // Assert: reached destination
+        Assert.Equal(new Position(0, 4), etherealPiece.Position);
+
+        // Assert: coin collected
+        Assert.Equal(1, game.Scores[p1]);
+
+        // Assert: opponent still in place
+        Assert.Equal(new Position(0, 2), p2Piece.Position);
+
+        // Assert: game was saved
+        await gameRepo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+
+    // ── Integration Test 7: Ethereal diagonal movement ─────────────────────────────
+
+    [Fact]
+    public async Task EtherealMovement_DiagonalPath_PassesThroughObstaclesAndCollectsCoin()
+    {
+        // Arrange: Ethereal at (0,0), move diagonally through rock to destination with coin
+        var (game, p1, _, etherealPiece, _) = GameInMovePhaseWithEtherealPiece(
+            etherealStartPos: new Position(0, 0),
+            etherealMaxDistance: 2);
+
+        game.Board.AddRock(new Rock(new Position(1, 1))); // Rock at (1,1)
+        game.Board.GetTile(new Position(2, 2)).SetOccupant(new Coin(CoinType.Silver));
+
+        var token = Guid.NewGuid();
+        var gameRepo = MockGameRepository(game);
+        var botRepo = MockBotRepository(token, p1, game.Id);
+        var handler = BuildHandler(gameRepo, botRepo);
+
+        // Act: Move diagonally through rock to destination
+        await handler.Handle(
+            new MovePieceCommand(game.Id, token, etherealPiece.Id,
+                BuildEtherealSegment(new Position(1, 1), new Position(2, 2))),
+            CancellationToken.None);
+
+        // Assert: reached destination
+        Assert.Equal(new Position(2, 2), etherealPiece.Position);
+
+        // Assert: coin collected
+        Assert.Equal(1, game.Scores[p1]);
+
+        // Assert: game was saved
+        await gameRepo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+
+    // ── Integration Test 8: Ethereal end on rock throws ────────────────────────────
+
+    [Fact]
+    public async Task EtherealMovement_EndOnRock_ThrowsAndDoesNotSave()
+    {
+        // Arrange: Ethereal at (0,0), rock at destination (0,1)
+        var (game, p1, _, etherealPiece, _) = GameInMovePhaseWithEtherealPiece(
+            etherealStartPos: new Position(0, 0));
+
+        game.Board.AddRock(new Rock(new Position(0, 1)));
+
+        var token = Guid.NewGuid();
+        var gameRepo = MockGameRepository(game);
+        var botRepo = MockBotRepository(token, p1, game.Id);
+        var handler = BuildHandler(gameRepo, botRepo);
+
+        // Act & Assert: attempting to end on rock throws
+        var ex = await Assert.ThrowsAsync<DomainException>(async () =>
+            await handler.Handle(
+                new MovePieceCommand(game.Id, token, etherealPiece.Id, BuildEtherealSegment(new Position(0, 1))),
+                CancellationToken.None));
+
+        Assert.Contains("obstacle", ex.Message);
+
+        // Assert: game was NOT saved
+        await gameRepo.DidNotReceive().SaveAsync(Arg.Any<Game>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Integration Test 9: Ethereal end on lake throws ────────────────────────────
+
+    [Fact]
+    public async Task EtherealMovement_EndOnLake_ThrowsAndDoesNotSave()
+    {
+        // Arrange: Ethereal at (0,0), lake at destination (0,1)
+        var (game, p1, _, etherealPiece, _) = GameInMovePhaseWithEtherealPiece(
+            etherealStartPos: new Position(0, 0));
+
+        game.Board.AddLake(new Lake(new Position(0, 1)));
+
+        var token = Guid.NewGuid();
+        var gameRepo = MockGameRepository(game);
+        var botRepo = MockBotRepository(token, p1, game.Id);
+        var handler = BuildHandler(gameRepo, botRepo);
+
+        // Act & Assert: attempting to end on lake throws
+        var ex = await Assert.ThrowsAsync<DomainException>(async () =>
+            await handler.Handle(
+                new MovePieceCommand(game.Id, token, etherealPiece.Id, BuildEtherealSegment(new Position(0, 1))),
+                CancellationToken.None));
+
+        Assert.Contains("obstacle", ex.Message);
+
+        // Assert: game was NOT saved
+        await gameRepo.DidNotReceive().SaveAsync(Arg.Any<Game>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Integration Test 10: Ethereal respects MaxDistance ────────────────────────
+
+    [Fact]
+    public async Task EtherealMovement_ExceedsMaxDistance_ThrowsAndDoesNotSave()
+    {
+        // Arrange: Ethereal with MaxDistance=2
+        var (game, p1, _, etherealPiece, _) = GameInMovePhaseWithEtherealPiece(
+            etherealStartPos: new Position(0, 0),
+            etherealMaxDistance: 2);
+
+        var token = Guid.NewGuid();
+        var gameRepo = MockGameRepository(game);
+        var botRepo = MockBotRepository(token, p1, game.Id);
+        var handler = BuildHandler(gameRepo, botRepo);
+
+        // Act & Assert: attempting 3-step movement throws
+        var ex = await Assert.ThrowsAsync<DomainException>(async () =>
+            await handler.Handle(
+                new MovePieceCommand(game.Id, token, etherealPiece.Id,
+                    BuildEtherealSegment(
+                        new Position(0, 1),
+                        new Position(0, 2),
+                        new Position(0, 3))),
+                CancellationToken.None));
+
+        Assert.Contains("MaxDistance", ex.Message);
+
+        // Assert: game was NOT saved
+        await gameRepo.DidNotReceive().SaveAsync(Arg.Any<Game>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Integration Test 11: Ethereal raises domain events ────────────────────────
+
+    [Fact]
+    public async Task EtherealMovement_RaisesCoinCollectedAndPieceMovedEvents()
+    {
+        // Arrange: Ethereal at (0,0), coins at (0,1) and (0,2)
+        var (game, p1, _, etherealPiece, _) = GameInMovePhaseWithEtherealPiece(
+            etherealStartPos: new Position(0, 0),
+            etherealMaxDistance: 2);
+
+        game.Board.GetTile(new Position(0, 1)).SetOccupant(new Coin(CoinType.Silver));
+        game.Board.GetTile(new Position(0, 2)).SetOccupant(new Coin(CoinType.Gold));
+
+        var token = Guid.NewGuid();
+        var gameRepo = MockGameRepository(game);
+        var botRepo = MockBotRepository(token, p1, game.Id);
+        var handler = BuildHandler(gameRepo, botRepo);
+
+        // Act: Move ethereal
+        await handler.Handle(
+            new MovePieceCommand(game.Id, token, etherealPiece.Id,
+                BuildEtherealSegment(new Position(0, 1), new Position(0, 2))),
+            CancellationToken.None);
+
+        // Assert: CoinCollected events raised (2 coins)
+        var coinEvents = game.DomainEvents.Where(e => e.GetType().Name == "CoinCollected").ToList();
+        Assert.Equal(2, coinEvents.Count);
+
+        // Assert: PieceMoved event raised
+        var moveEvent = game.DomainEvents.OfType<PieceMoved>().Single();
+        Assert.Equal(new Position(0, 0), moveEvent.From);
+        Assert.Equal(new Position(0, 2), moveEvent.To);
+
+        // Assert: game was saved
+        await gameRepo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+
+    // ── Integration Test 13: Ethereal end on empty tile (no coin) ──────────────────
+
+    [Fact]
+    public async Task EtherealMovement_EndOnEmptyTile_SucceedsAndSaves()
+    {
+        // Arrange: Ethereal at (0,0), move to empty tile (0,1)
+        var (game, p1, _, etherealPiece, _) = GameInMovePhaseWithEtherealPiece(
+            etherealStartPos: new Position(0, 0));
+
+        var token = Guid.NewGuid();
+        var gameRepo = MockGameRepository(game);
+        var botRepo = MockBotRepository(token, p1, game.Id);
+        var handler = BuildHandler(gameRepo, botRepo);
+
+        // Act: Move to empty tile
+        await handler.Handle(
+            new MovePieceCommand(game.Id, token, etherealPiece.Id, BuildEtherealSegment(new Position(0, 1))),
+            CancellationToken.None);
+
+        // Assert: piece moved
+        Assert.Equal(new Position(0, 1), etherealPiece.Position);
+
+        // Assert: score unchanged (no coins collected)
+        Assert.Equal(0, game.Scores[p1]);
+
+        // Assert: game was saved
+        await gameRepo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/ScrambleCoin.Domain.Tests/EtherealMovementTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/EtherealMovementTests.cs
@@ -374,4 +374,40 @@ public class EtherealMovementTests
         Assert.Equal(new Position(0, 2), moveEvent.To);
         Assert.Equal(new[] { new Position(0, 1), new Position(0, 2) }, moveEvent.Path);
     }
+
+    [Fact]
+    public void Ethereal_EndOnRock_Throws()
+    {
+        // Arrange: Ethereal piece at (0,0), rock at destination (0,1)
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 1,
+            p1StartPos: new Position(0, 0));
+        
+        var destPos = new Position(0, 1);
+        game.Board.AddRock(new Rock(destPos));
+
+        // Act & Assert: attempting to end on rock throws
+        var ex = Assert.Throws<DomainException>(() =>
+            game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(destPos))
+        );
+        Assert.Contains("obstacle", ex.Message);
+    }
+
+    [Fact]
+    public void Ethereal_EndOnLake_Throws()
+    {
+        // Arrange: Ethereal piece at (0,0), lake at destination (0,1)
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 1,
+            p1StartPos: new Position(0, 0));
+        
+        var destPos = new Position(0, 1);
+        game.Board.AddLake(new Lake(destPos));
+
+        // Act & Assert: attempting to end on lake throws
+        var ex = Assert.Throws<DomainException>(() =>
+            game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(destPos))
+        );
+        Assert.Contains("obstacle", ex.Message);
+    }
 }

--- a/tests/ScrambleCoin.Domain.Tests/EtherealMovementTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/EtherealMovementTests.cs
@@ -1,0 +1,377 @@
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Events;
+using ScrambleCoin.Domain.Exceptions;
+using ScrambleCoin.Domain.Factories;
+using ScrambleCoin.Domain.Obstacles;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Domain.Tests;
+
+/// <summary>
+/// Unit tests for Ethereal movement type (Issue #46).
+/// Ethereal pieces pass through obstacles and pieces on intermediate tiles but must end on a free tile.
+/// Coins are collected on all tiles in the path (intermediate and destination).
+/// Fences still block Ethereal movement.
+/// </summary>
+public class EtherealMovementTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a game in MovePhase with exactly one Ethereal piece for P1 and a normal piece for P2.
+    /// P1's Ethereal piece is at p1StartPos; P2's orthogonal piece is at p2StartPos.
+    /// </summary>
+    private static (Game game, Guid p1, Guid p2, Piece p1Piece, Piece p2Piece) GameInMovePhaseWithEtherealPiece(
+        int p1MaxDistance = 3,
+        Position? p1StartPos = null,
+        Position? p2StartPos = null)
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var board = new Board();
+
+        var actualP1Pos = p1StartPos ?? new Position(0, 0);
+        var actualP2Pos = p2StartPos ?? new Position(7, 7);
+
+        // Create an Ethereal piece for P1 (like a fairy/ghost)
+        var p1Piece = new Piece(
+            Guid.NewGuid(), "TestEthereal", p1,
+            EntryPointType.Corners, MovementType.Ethereal, p1MaxDistance, 1);
+        var p1Fill = Enumerable.Range(0, 4)
+            .Select(i => new Piece(
+                Guid.NewGuid(), $"P1Fill{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+
+        var p2Piece = new Piece(
+            Guid.NewGuid(), "P2Mover", p2,
+            EntryPointType.Borders, MovementType.Orthogonal, 1, 1);
+        var p2Fill = Enumerable.Range(0, 4)
+            .Select(i => new Piece(
+                Guid.NewGuid(), $"P2Fill{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, board);
+        game.SetLineup(p1, new Lineup(new[] { p1Piece }.Concat(p1Fill)));
+        game.SetLineup(p2, new Lineup(new[] { p2Piece }.Concat(p2Fill)));
+        game.Start();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+
+        // Placing both pieces auto-advances to MovePhase.
+        game.PlacePiece(p1, p1Piece.Id, actualP1Pos);
+        game.PlacePiece(p2, p2Piece.Id, actualP2Pos);
+
+        return (game, p1, p2, p1Piece, p2Piece);
+    }
+
+    /// <summary>
+    /// Builds a multi-step segment for Ethereal movement.
+    /// </summary>
+    private static IReadOnlyList<IReadOnlyList<Position>> BuildEtherealSegment(params Position[] positions)
+    {
+        var segment = (IReadOnlyList<Position>)positions.ToList().AsReadOnly();
+        return new List<IReadOnlyList<Position>> { segment }.AsReadOnly();
+    }
+
+    // ── Core Ethereal Logic Tests ──────────────────────────────────────────
+
+    [Fact]
+    public void Ethereal_PassThroughRock_CollectsCoinBehindRock()
+    {
+        // Arrange: Ethereal piece at (0,0), rock at (0,1), coin at (0,2)
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 2,
+            p1StartPos: new Position(0, 0));
+        
+        var rockPos = new Position(0, 1);
+        var coinPos = new Position(0, 2);
+        
+        game.Board.AddRock(new Rock(rockPos));
+        game.Board.GetTile(coinPos).SetOccupant(new Coin(CoinType.Silver));
+
+        // Act: Move ethereal through rock to coin tile
+        game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(rockPos, coinPos));
+
+        // Assert: piece moved to coin position
+        Assert.Equal(coinPos, p1Piece.Position);
+
+        // Assert: coin was collected
+        Assert.Equal(1, game.Scores[p1]);
+
+        // Assert: coin removed from board
+        Assert.Null(game.Board.GetTile(coinPos).AsCoin);
+    }
+
+    [Fact]
+    public void Ethereal_PassThroughOpponentPiece_ReachesDestination()
+    {
+        // Arrange: Ethereal piece at (0,0), opponent piece at (0,1), destination at (0,2)
+        var (game, p1, p2, p1Piece, p2Piece) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 2,
+            p1StartPos: new Position(0, 0),
+            p2StartPos: new Position(0, 1));
+
+        // Act: Move ethereal through opponent piece
+        game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(
+            new Position(0, 1), // through opponent
+            new Position(0, 2)  // to free tile
+        ));
+
+        // Assert: piece moved to destination (passed through opponent)
+        Assert.Equal(new Position(0, 2), p1Piece.Position);
+
+        // Assert: opponent piece is still there (not captured)
+        Assert.Equal(new Position(0, 1), p2Piece.Position);
+    }
+
+    [Fact]
+    public void Ethereal_EndOnCoinTile_CollectsCoin()
+    {
+        // Arrange: Ethereal piece at (0,0), coin at destination (0,1)
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 1,
+            p1StartPos: new Position(0, 0));
+        
+        var destPos = new Position(0, 1);
+        game.Board.GetTile(destPos).SetOccupant(new Coin(CoinType.Gold));
+
+        // Act: Move ethereal to coin tile
+        game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(destPos));
+
+        // Assert: coin collected
+        Assert.Equal(3, game.Scores[p1]); // Gold = 3 pts
+
+        // Assert: coin removed
+        Assert.Null(game.Board.GetTile(destPos).AsCoin);
+    }
+
+    [Fact]
+    public void Ethereal_EndOnPieceTile_Throws()
+    {
+        // Arrange: Ethereal piece at (0,0), opponent piece at (0,1)
+        var (game, p1, p2, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 1,
+            p1StartPos: new Position(0, 0),
+            p2StartPos: new Position(0, 1));
+
+        // Act & Assert: attempting to end on occupied tile throws
+        var ex = Assert.Throws<DomainException>(() =>
+            game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(new Position(0, 1)))
+        );
+        Assert.Contains("Ethereal movement must end on a free tile", ex.Message);
+    }
+
+    [Fact]
+    public void Ethereal_FenceStillBlocks_Throws()
+    {
+        // Arrange: Ethereal piece at (0,0), fence between (0,0) and (0,1)
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 1,
+            p1StartPos: new Position(0, 0));
+        
+        var fence = new Fence(new Position(0, 0), new Position(0, 1)); // Vertical fence
+        game.Board.AddFence(fence);
+
+        // Act & Assert: attempting to cross fence throws
+        var ex = Assert.Throws<DomainException>(() =>
+            game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(new Position(0, 1)))
+        );
+        Assert.Contains("blocked by a fence", ex.Message);
+    }
+
+    [Fact]
+    public void Ethereal_CollectCoinsOnAllTilesInPath()
+    {
+        // Arrange: Ethereal at (0,0), path through (0,1), (0,2), (0,3)
+        //         Coins at intermediate (0,1) and (0,2)
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 3,
+            p1StartPos: new Position(0, 0));
+        
+        game.Board.GetTile(new Position(0, 1)).SetOccupant(new Coin(CoinType.Silver));
+        game.Board.GetTile(new Position(0, 2)).SetOccupant(new Coin(CoinType.Silver));
+        game.Board.GetTile(new Position(0, 3)).SetOccupant(new Coin(CoinType.Gold));
+
+        // Act: Move through all tiles
+        game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(
+            new Position(0, 1),
+            new Position(0, 2),
+            new Position(0, 3)
+        ));
+
+        // Assert: all coins collected (1 + 1 + 3 = 5)
+        Assert.Equal(5, game.Scores[p1]);
+    }
+
+    [Fact]
+    public void Ethereal_RaisesCoinsCollectedEvents()
+    {
+        // Arrange: Ethereal at (0,0), path with coins at (0,1) and (0,2)
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 2,
+            p1StartPos: new Position(0, 0));
+        
+        game.Board.GetTile(new Position(0, 1)).SetOccupant(new Coin(CoinType.Silver));
+        game.Board.GetTile(new Position(0, 2)).SetOccupant(new Coin(CoinType.Gold));
+
+        // Act: Move through all tiles
+        game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(
+            new Position(0, 1),
+            new Position(0, 2)
+        ));
+
+        // Assert: CoinCollected events raised
+        var coinEvents = game.DomainEvents.OfType<CoinCollected>().ToList();
+        Assert.Equal(2, coinEvents.Count);
+        Assert.Contains(coinEvents, e => e.Position == new Position(0, 1) && e.CoinType == CoinType.Silver);
+        Assert.Contains(coinEvents, e => e.Position == new Position(0, 2) && e.CoinType == CoinType.Gold);
+    }
+
+    [Fact]
+    public void Ethereal_CannotExceedMaxDistance()
+    {
+        // Arrange: Ethereal with MaxDistance=2
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 2,
+            p1StartPos: new Position(0, 0));
+
+        // Act & Assert: attempting 3-step movement throws
+        var ex = Assert.Throws<DomainException>(() =>
+            game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(
+                new Position(0, 1),
+                new Position(0, 2),
+                new Position(0, 3)
+            ))
+        );
+        Assert.Contains("MaxDistance", ex.Message);
+    }
+
+    [Fact]
+    public void Ethereal_DiagonalMovement_Allowed()
+    {
+        // Arrange: Ethereal at (0,0), move diagonally to (2,2)
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 2,
+            p1StartPos: new Position(0, 0));
+        
+        game.Board.GetTile(new Position(1, 1)).SetOccupant(new Coin(CoinType.Silver));
+
+        // Act: Move diagonally through coin to destination
+        game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(
+            new Position(1, 1),
+            new Position(2, 2)
+        ));
+
+        // Assert: moved to destination and collected coin
+        Assert.Equal(new Position(2, 2), p1Piece.Position);
+        Assert.Equal(1, game.Scores[p1]);
+    }
+
+    [Fact]
+    public void Ethereal_NonAdjacentStep_Throws()
+    {
+        // Arrange: Ethereal at (0,0)
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 3,
+            p1StartPos: new Position(0, 0));
+
+        // Act & Assert: non-adjacent step throws
+        var ex = Assert.Throws<DomainException>(() =>
+            game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(
+                new Position(0, 2) // Not adjacent!
+            ))
+        );
+        Assert.Contains("not adjacent", ex.Message);
+    }
+
+    [Fact]
+    public void Ethereal_MultipleRocksAndPieces_PassesThrough()
+    {
+        // Arrange: Ethereal at (0,0), path with rock at (0,1), opponent at (0,2), rock at (0,3), destination (0,4)
+        var (game, p1, p2, p1Piece, p2Piece) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 4,
+            p1StartPos: new Position(0, 0),
+            p2StartPos: new Position(0, 2)); // Opponent at (0,2)
+
+        game.Board.AddRock(new Rock(new Position(0, 1))); // Rock at (0,1)
+        game.Board.AddRock(new Rock(new Position(0, 3))); // Rock at (0,3)
+        game.Board.GetTile(new Position(0, 4)).SetOccupant(new Coin(CoinType.Silver));
+
+        // Act: Move through obstacles and opponent
+        game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(
+            new Position(0, 1),
+            new Position(0, 2),
+            new Position(0, 3),
+            new Position(0, 4)
+        ));
+
+        // Assert: reached destination and collected coin
+        Assert.Equal(new Position(0, 4), p1Piece.Position);
+        Assert.Equal(1, game.Scores[p1]);
+        
+        // Assert: opponent piece still in place
+        Assert.Equal(new Position(0, 2), p2Piece.Position);
+    }
+
+    [Fact]
+    public void Ethereal_CornerFence_StillBlocks()
+    {
+        // Arrange: Ethereal at (0,0), diagonal move blocked by corner fences
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 1,
+            p1StartPos: new Position(0, 0));
+        
+        // Add two fences forming an L-shape (corner at (1,1))
+        game.Board.AddFence(new Fence(new Position(0, 0), new Position(1, 0))); // Vertical fence
+        game.Board.AddFence(new Fence(new Position(0, 0), new Position(0, 1))); // Horizontal fence
+
+        // Act & Assert: diagonal move blocked by corner fence
+        var ex = Assert.Throws<DomainException>(() =>
+            game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(new Position(1, 1)))
+        );
+        Assert.Contains("blocked by a fence", ex.Message);
+    }
+
+    [Fact]
+    public void Ethereal_EmptySegmentWhenFenceBlocked()
+    {
+        // Arrange: Ethereal piece at (0,0) with all adjacent tiles blocked by fences
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 1,
+            p1StartPos: new Position(0, 0));
+        
+        // Add fences on all edges around (0,0)
+        game.Board.AddFence(new Fence(new Position(0, 0), new Position(0, 1))); // Right
+        game.Board.AddFence(new Fence(new Position(0, 0), new Position(1, 0))); // Down
+
+        // Act: Submit empty segment
+        game.MovePiece(p1, p1Piece.Id, new List<IReadOnlyList<Position>>
+        {
+            new List<Position>().AsReadOnly()
+        }.AsReadOnly());
+
+        // Assert: piece did not move
+        Assert.Equal(new Position(0, 0), p1Piece.Position);
+    }
+
+    [Fact]
+    public void Ethereal_PieceMoved_EventRaisedWithFullPath()
+    {
+        // Arrange: Ethereal path (0,0) → (0,1) → (0,2)
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithEtherealPiece(
+            p1MaxDistance: 2,
+            p1StartPos: new Position(0, 0));
+
+        // Act: Move ethereal
+        game.MovePiece(p1, p1Piece.Id, BuildEtherealSegment(
+            new Position(0, 1),
+            new Position(0, 2)
+        ));
+
+        // Assert: PieceMoved event includes full path
+        var moveEvent = game.DomainEvents.OfType<PieceMoved>().Single();
+        Assert.Equal(new Position(0, 0), moveEvent.From);
+        Assert.Equal(new Position(0, 2), moveEvent.To);
+        Assert.Equal(new[] { new Position(0, 1), new Position(0, 2) }, moveEvent.Path);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #46.

Implements the **Ethereal** movement ability. An Ethereal piece can pass through obstacles and other pieces as if they are not there, but must end on a completely free tile (no piece, no obstacle). Collects coins along the entire path.

## Changes
- **Domain layer:** Added `MovementType.Ethereal` enum value
- **Board.cs:** Added `IsFenceBlocked()` method to check only fence blocking (not obstacles/pieces)
- **Game.cs:** Added Ethereal movement logic that:
  - Allows passing through obstacles and pieces on intermediate tiles
  - Validates fence blocking for each step
  - Collects coins on all tiles (intermediate + destination)
  - Requires destination to be free of both pieces and obstacles
- **Tests:** 16 unit tests + 12 integration tests covering all acceptance criteria

## Testing
- Unit tests: 16 added (pass through rock/piece, end on coin, reject occupied destination, fence blocks, obstacle rejection)
- Integration tests: 12 added (full application layer flow with game state persistence)
- Manual tests: 12 scenarios documented on issue #46
- All tests pass: 839 total ✅

## Acceptance Criteria
- ✅ Ethereal movement skips passability checks for intermediate tiles
- ✅ Ethereal piece must end on a free tile (no piece, no obstacle)
- ✅ Ethereal collects coins on all tiles it passes through including destination
- ✅ Attempting to end on an occupied tile (another piece) is rejected with DomainException
- ✅ Attempting to end on an obstacle tile (rock/lake) is rejected with DomainException
- ✅ Fences still block Ethereal movement
- ✅ Unit tests cover all scenarios
- ✅ Integration tests cover application layer flow
- ✅ Manual test plan documented

## Documentation
- ✅ Updated 2 wiki pages:
  - Piece-Movement-Ethereal.md (enhanced with corrected enum info)
  - Movement-Types.md (added Ethereal section + comparison table update)

## Out of Scope (addressed separately)
- Fairy Godmother's +1 move buff (Passive Abilities issue)
- Ursula's −1 move debuff (Passive Abilities issue)
- Merlin's silver→gold conversion (Passive Abilities issue)

## Review Cycles
- Implementation: 1 cycle (fixed missing obstacle validation)
- Tests: 0 cycles ✅

## Version Bump
Label applied: `minor` (new game mechanic)