### PR TITLE
Admin panel — organiser UI for tournament management and live game monitoring

### DIFF
--- a/ScrambleCoin.sln
+++ b/ScrambleCoin.sln
@@ -40,6 +40,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScrambleCoin.StarterBot.Tests", "tests\ScrambleCoin.StarterBot.Tests\ScrambleCoin.StarterBot.Tests.csproj", "{9B36A08A-3498-48DF-8E88-9D85ABD0291F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScrambleCoin.TournamentHarness", "samples\ScrambleCoin.TournamentHarness\ScrambleCoin.TournamentHarness.csproj", "{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -206,6 +208,18 @@ Global
 		{9B36A08A-3498-48DF-8E88-9D85ABD0291F}.Release|x64.Build.0 = Release|Any CPU
 		{9B36A08A-3498-48DF-8E88-9D85ABD0291F}.Release|x86.ActiveCfg = Release|Any CPU
 		{9B36A08A-3498-48DF-8E88-9D85ABD0291F}.Release|x86.Build.0 = Release|Any CPU
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}.Debug|x64.Build.0 = Debug|Any CPU
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}.Debug|x86.Build.0 = Debug|Any CPU
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}.Release|x64.ActiveCfg = Release|Any CPU
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}.Release|x64.Build.0 = Release|Any CPU
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}.Release|x86.ActiveCfg = Release|Any CPU
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -225,5 +239,6 @@ Global
 		{BACA2232-0F6C-4B56-A822-49C0EB59491F} = {8537B41B-6FEF-486F-90F9-859831449740}
 		{5A89F787-0F1A-4E20-9B00-E9E2EFC4BFD2} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 		{9B36A08A-3498-48DF-8E88-9D85ABD0291F} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{F65BB7A6-16C2-4BCF-B61B-26CA9B4FEEB3} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 	EndGlobalSection
 EndGlobal

--- a/samples/ScrambleCoin.StarterBot/.env.example
+++ b/samples/ScrambleCoin.StarterBot/.env.example
@@ -3,7 +3,7 @@
 # Then load it before running: `export $(cat .env | xargs) && dotnet run`
 
 # Base URL of the ScrambleCoin API server (no trailing slash)
-BASE_URL=http://localhost:5000
+BASE_URL=http://localhost:5001
 
 # Display name for this bot (used in console output only)
 BOT_NAME=MyBot

--- a/samples/ScrambleCoin.StarterBot/BotClient.cs
+++ b/samples/ScrambleCoin.StarterBot/BotClient.cs
@@ -22,17 +22,27 @@ public sealed class BotClient : IDisposable
     public BotClient(string baseUrl)
     {
         _http = new HttpClient { BaseAddress = new Uri(baseUrl.TrimEnd('/') + '/') };
+        HubUrl = new Uri(_http.BaseAddress, "/hubs/game").ToString();
     }
+
+    /// <summary>Absolute URL of the ScrambleCoin SignalR hub (e.g. <c>http://localhost:5001/hubs/game</c>).</summary>
+    public string HubUrl { get; }
 
     /// <summary>
     /// Test seam: inject a pre-configured <see cref="HttpClient"/> directly.
     /// The caller is responsible for setting <c>BaseAddress</c>.
     /// </summary>
-    internal BotClient(HttpClient http) => _http = http;
+    internal BotClient(HttpClient http)
+    {
+        _http   = http;
+        HubUrl  = http.BaseAddress is not null
+            ? new Uri(http.BaseAddress, "/hubs/game").ToString()
+            : string.Empty;
+    }
 
     // ── Authentication ────────────────────────────────────────────────────────
 
-    /// <summary>Sets the bot token sent on every subsequent request via <c>X-Bot-Token</c>.</summary>
+    /// <summary>Sets the bot token sent on every later request via <c>X-Bot-Token</c>.</summary>
     public void SetBotToken(Guid token)
     {
         _http.DefaultRequestHeaders.Remove("X-Bot-Token");
@@ -50,6 +60,34 @@ public sealed class BotClient : IDisposable
         var body = new { lineup };
         var response = await _http.PostAsJsonAsync($"api/games/{gameId}/join", body, ct);
         return await ReadResponseAsync<JoinResponse>(response, "JoinGame");
+    }
+
+    // ── Tournament joining ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Registers this bot for a tournament (self-registration, no admin key required).
+    /// Call this while the tournament is in <c>Pending</c> state.
+    /// <c>POST /api/tournament/{tournamentId}/join</c>
+    /// Returns <c>true</c> on success (204 No Content), <c>false</c> on error.
+    /// </summary>
+    public async Task<bool> JoinTournamentAsync(
+        Guid tournamentId,
+        Guid botId,
+        string botName,
+        IReadOnlyList<string> lineup,
+        CancellationToken ct = default)
+    {
+        var body = new { botId, botName, lineup };
+        var response = await _http.PostAsJsonAsync($"api/tournament/{tournamentId}/join", body, ct);
+
+        if (response.IsSuccessStatusCode)
+        {
+            Console.WriteLine($"[Tournament] Registered as '{botName}' (BotId: {botId})");
+            return true;
+        }
+
+        await PrintApiErrorAsync(response, "JoinTournament");
+        return false;
     }
 
     /// <summary>
@@ -171,6 +209,22 @@ public sealed class BotClient : IDisposable
         return await ReadResponseAsync<MoveResponse>(response, "MovePiece");
     }
 
+    // ── Tournament game discovery ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns all games (and tokens) assigned to this bot in the tournament.
+    /// Call this after the tournament starts; poll until your next game appears.
+    /// <c>GET /api/tournament/{tournamentId}/bots/{botId}/games</c>
+    /// </summary>
+    public async Task<List<BotGameInfo>?> GetBotGamesAsync(
+        Guid tournamentId,
+        Guid botId,
+        CancellationToken ct = default)
+    {
+        var response = await _http.GetAsync(BuildUri($"api/tournament/{tournamentId}/bots/{botId}/games"), ct);
+        return await ReadResponseAsync<List<BotGameInfo>>(response, "GetBotGames");
+    }
+
     // ── Game result ───────────────────────────────────────────────────────────
 
     /// <summary>
@@ -184,7 +238,7 @@ public sealed class BotClient : IDisposable
 
         if (response.StatusCode == HttpStatusCode.Conflict)
         {
-            // Game not finished yet
+            //The game isn't finished yet
             return null;
         }
 

--- a/samples/ScrambleCoin.StarterBot/GameLoop.cs
+++ b/samples/ScrambleCoin.StarterBot/GameLoop.cs
@@ -1,9 +1,13 @@
+using Microsoft.AspNetCore.SignalR.Client;
+using System.Threading.Channels;
 using ScrambleCoin.StarterBot.Models;
 
 namespace ScrambleCoin.StarterBot;
 
 /// <summary>
-/// Main game loop: join → poll → decide → submit → repeat until the game ends.
+/// Main game loop: join → react to SignalR events → decide → submit → repeat until the game ends.
+/// Replaces the old polling loop with a push-driven model: the server notifies the bot whenever
+/// the board state changes, so the bot only calls REST when it actually needs to act.
 /// </summary>
 public sealed class GameLoop
 {
@@ -11,10 +15,11 @@ public sealed class GameLoop
     private readonly IStrategy _strategy;
     private readonly string _botName;
 
-    // How long to wait between state polls
-    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(1);
+    // Fallback: if no SignalR event arrives within this window, do a one-off REST poll
+    // to recover from a potentially missed event (e.g. after a brief reconnect).
+    private static readonly TimeSpan FallbackPollTimeout = TimeSpan.FromSeconds(30);
 
-    // How long to wait between matchmaking queue polls
+    // How long to wait between matchmaking queue polls (unchanged)
     private static readonly TimeSpan QueuePollInterval = TimeSpan.FromSeconds(2);
 
     public GameLoop(BotClient client, IStrategy strategy, string botName)
@@ -27,114 +32,154 @@ public sealed class GameLoop
     // ── Entry point ───────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Runs the bot for a single game.
-    /// Call this once per game; it returns when the game ends or the token is cancelled.
+    /// Runs the bot for a single game via SignalR push events.
+    /// Returns when the game ends or the token is cancelled.
     /// </summary>
     public async Task RunAsync(Guid gameId, Guid playerId, CancellationToken ct = default)
     {
         Console.WriteLine($"[{_botName}] Game started — GameId: {gameId} | PlayerId: {playerId}");
         Console.WriteLine("──────────────────────────────────────────────────────────");
 
-        // Track which placement actions we've already submitted this turn
-        // to avoid re-submitting after a successful placement.
-        var placedThisTurn = new HashSet<Guid>();
-        var movedThisTurn = new HashSet<Guid>();
-        var lastTurn = -1;
-        var lastPhase = "";
-        var waitingForOpponentPolls = 0; // counts silent polls while waiting for opponent to place
+        // ── SignalR connection ─────────────────────────────────────────────────
+        var hub = new HubConnectionBuilder()
+            .WithUrl(_client.HubUrl)
+            .WithAutomaticReconnect()
+            .Build();
 
-        while (!ct.IsCancellationRequested)
+        // Channel bridges SignalR callbacks (background thread) into the async loop below.
+        var events = Channel.CreateUnbounded<string>(new UnboundedChannelOptions { SingleReader = true });
+
+        void Push(string reason) => events.Writer.TryWrite(reason);
+
+        hub.On("BoardStateUpdated", (object _) => Push("board-updated"));
+        hub.On("PhaseChanged",      (object _) => Push("phase-changed"));
+        hub.On("GameEnded",         (object _) => Push("game-ended"));
+
+        hub.Reconnected += _ => { Push("reconnected"); return Task.CompletedTask; };
+        hub.Closed      += ex =>
         {
-            BoardState? state;
-            try
-            {
-                state = await _client.GetStateAsync(gameId, ct);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-            catch (HttpRequestException ex)
-            {
-                Console.WriteLine($"[ERROR] Connection failed: {ex.Message} — retrying in 3 s…");
-                await Task.Delay(TimeSpan.FromSeconds(3), ct);
-                continue;
-            }
+            Console.WriteLine($"[{_botName}]  ⚠ SignalR disconnected: {ex?.Message}");
+            Push("disconnected");
+            return Task.CompletedTask;
+        };
 
-            if (state is null)
-            {
-                await Task.Delay(PollInterval, ct);
-                continue;
-            }
+        try
+        {
+            await hub.StartAsync(ct);
+            await hub.InvokeAsync("JoinGame", gameId.ToString(), ct);
+            Console.WriteLine($"[{_botName}]  🔔 SignalR connected — listening for events…");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[{_botName}]  ⚠ SignalR unavailable ({ex.Message}) — falling back to polling.");
+            await hub.DisposeAsync();
+            await RunPollingFallbackAsync(gameId, playerId, ct);
+            return;
+        }
 
-            // Reset per-turn tracking when a new turn starts
-            if (state.Turn != lastTurn)
-            {
-                placedThisTurn.Clear();
-                movedThisTurn.Clear();
-                waitingForOpponentPolls = 0;
-                lastTurn = state.Turn;
-                Console.WriteLine();
-                Console.WriteLine($"[Turn {state.Turn}] Phase: {state.Phase ?? "(waiting/ended)"} | Score: {state.YourScore} vs {state.OpponentScore}");
-                lastPhase = state.Phase ?? "";
-            }
-            else if (state.Phase != lastPhase)
-            {
-                waitingForOpponentPolls = 0;
-                Console.WriteLine();
-                Console.WriteLine($"[Turn {state.Turn}] Phase: {state.Phase ?? "(waiting/ended)"} | Score: {state.YourScore} vs {state.OpponentScore}");
-                lastPhase = state.Phase ?? "";
-            }
+        // Track which actions we've already submitted this turn
+        var placedThisTurn = new HashSet<Guid>();
+        var movedThisTurn  = new HashSet<Guid>();
+        var lastTurn       = -1;
+        var lastPhase      = "";
 
-            // ── Game isn't yet started ──────────────────────────────────────────
-            if (state.Phase is null && state.Turn == 0)
-            {
-                Console.WriteLine("  Waiting for game to start…");
-                await Task.Delay(PollInterval, ct);
-                continue;
-            }
+        // Seed the channel so we do an immediate state fetch on startup.
+        Push("init");
 
-            // ── Game ended ────────────────────────────────────────────────────
-            if (state.Phase is null && state.Turn > 0)
+        try
+        {
+            while (!ct.IsCancellationRequested)
             {
-                await PrintFinalResultAsync(gameId, playerId, state, ct);
-                return;
-            }
+                // Wait for the next event, but time out to handle missed events.
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                timeoutCts.CancelAfter(FallbackPollTimeout);
 
-            // ── CoinSpawn phase ───────────────────────────────────────────────
-            if (state.Phase == "CoinSpawn")
-            {
-                Console.WriteLine("  CoinSpawn — waiting for coins to be placed…");
-                await Task.Delay(PollInterval, ct);
-                continue;
-            }
-
-            // ── PlacePhase ────────────────────────────────────────────────────
-            if (state.Phase == "PlacePhase")
-            {
-                if (placedThisTurn.Any())
+                string signal;
+                try
                 {
-                    waitingForOpponentPolls++;
-                    if (waitingForOpponentPolls % 5 == 1)
-                        Console.WriteLine($"  ⏳ Waiting for opponent to place… ({waitingForOpponentPolls}s)");
-                    await Task.Delay(PollInterval, ct);
+                    signal = await events.Reader.ReadAsync(timeoutCts.Token);
+                }
+                catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+                {
+                    // Timeout — no event in 30 s; poll once as a safety net.
+                    Console.WriteLine($"[{_botName}]  ⏱ No SignalR event for 30 s — polling once.");
+                    signal = "timeout-poll";
+                }
+
+                // Fetch fresh player-specific state via REST (the SignalR payload is spectator-only).
+                BoardState? state;
+                try
+                {
+                    state = await _client.GetStateAsync(gameId, ct);
+                }
+                catch (OperationCanceledException) { break; }
+                catch (HttpRequestException ex)
+                {
+                    Console.WriteLine($"[{_botName}]  [ERROR] Connection failed: {ex.Message}");
                     continue;
                 }
-                await HandlePlacePhaseAsync(gameId, state, placedThisTurn, ct);
-                await Task.Delay(PollInterval, ct);
-                continue;
-            }
 
-            // ── MovePhase ─────────────────────────────────────────────────────
-            if (state.Phase == "MovePhase")
-            {
-                await HandleMovePhaseAsync(gameId, playerId, state, movedThisTurn, ct);
-                await Task.Delay(PollInterval, ct);
-                continue;
-            }
+                if (state is null) continue;
 
-            // Unknown phase — just wait
-            await Task.Delay(PollInterval, ct);
+                // ── Turn / phase tracking ──────────────────────────────────────
+                if (state.Turn != lastTurn)
+                {
+                    placedThisTurn.Clear();
+                    movedThisTurn.Clear();
+                    lastTurn = state.Turn;
+                    Console.WriteLine();
+                    Console.WriteLine($"[{_botName}] [Turn {state.Turn}] Phase: {state.Phase ?? "(waiting/ended)"} | Score: {state.YourScore} vs {state.OpponentScore}");
+                    lastPhase = state.Phase ?? "";
+                }
+                else if (state.Phase != lastPhase)
+                {
+                    Console.WriteLine();
+                    Console.WriteLine($"[{_botName}] [Turn {state.Turn}] Phase: {state.Phase ?? "(waiting/ended)"} | Score: {state.YourScore} vs {state.OpponentScore}");
+                    lastPhase = state.Phase ?? "";
+                }
+
+                // ── Game not started yet ───────────────────────────────────────
+                if (state.Phase is null && state.Turn == 0)
+                {
+                    Console.WriteLine($"[{_botName}]  Waiting for game to start…");
+                    continue; // wait for next SignalR event
+                }
+
+                // ── Game ended ────────────────────────────────────────────────
+                if (state.Phase is null && state.Turn > 0)
+                {
+                    await PrintFinalResultAsync(gameId, playerId, state, ct);
+                    return;
+                }
+
+                // ── CoinSpawn ─────────────────────────────────────────────────
+                if (state.Phase == "CoinSpawn")
+                {
+                    // Server handles this; next SignalR event will show PlacePhase.
+                    continue;
+                }
+
+                // ── PlacePhase ────────────────────────────────────────────────
+                if (state.Phase == "PlacePhase")
+                {
+                    if (!placedThisTurn.Any())
+                        await HandlePlacePhaseAsync(gameId, state, placedThisTurn, ct);
+                    // If already placed, just wait for the next event (opponent placing).
+                    continue;
+                }
+
+                // ── MovePhase ─────────────────────────────────────────────────
+                if (state.Phase == "MovePhase")
+                {
+                    await HandleMovePhaseAsync(gameId, playerId, state, movedThisTurn, ct);
+                    continue;
+                }
+            }
+        }
+        finally
+        {
+            await hub.StopAsync(CancellationToken.None);
+            await hub.DisposeAsync();
         }
     }
 
@@ -148,49 +193,45 @@ public sealed class GameLoop
         HashSet<Guid> placedThisTurn,
         CancellationToken ct)
     {
-        // Already submitted a placement action this turn — caller handles waiting log
-        if (placedThisTurn.Any())
-            return;
+        if (placedThisTurn.Any()) return;
 
         var piecesOnBoard = state.YourPieces.Count(p => p.IsOnBoard);
 
-        // Already at the 3-piece limit — must skip, cannot place another
         if (piecesOnBoard >= MaxPiecesOnBoard)
         {
-            Console.WriteLine($"  → Already at max pieces ({MaxPiecesOnBoard}) on board — skipping placement");
+            Console.WriteLine($"[{_botName}]  → Already at max pieces ({MaxPiecesOnBoard}) on board — skipping placement");
             var r = await _client.SkipPlacementAsync(gameId, ct);
             if (r is not null)
             {
-                placedThisTurn.Add(Guid.Empty); // sentinel: marks that we have acted this turn
-                Console.WriteLine($"  ✓ Placement skipped. Phase after: {r.Phase ?? "ended"}");
+                placedThisTurn.Add(Guid.Empty);
+                Console.WriteLine($"[{_botName}]  ✓ Placement skipped. Phase after: {r.Phase ?? "ended"}");
             }
             return;
         }
 
         var unplaced = state.YourPieces.Where(p => !p.IsOnBoard).ToList();
 
-        // No pieces left in hand (shouldn't normally happen, but be safe)
         if (unplaced.Count == 0)
         {
-            Console.WriteLine("  → No pieces in hand — skipping placement");
+            Console.WriteLine($"[{_botName}]  → No pieces in hand — skipping placement");
             var r = await _client.SkipPlacementAsync(gameId, ct);
             if (r is not null)
             {
                 placedThisTurn.Add(Guid.Empty);
-                Console.WriteLine($"  ✓ Placement skipped. Phase after: {r.Phase ?? "ended"}");
+                Console.WriteLine($"[{_botName}]  ✓ Placement skipped. Phase after: {r.Phase ?? "ended"}");
             }
             return;
         }
 
         var currentState = state;
-        var piece = unplaced.First();
+        var piece        = unplaced.First();
         const int maxRetries = 5;
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
             if (ct.IsCancellationRequested) break;
 
-            Console.WriteLine($"  Placing piece: {piece.Name} ({piece.PieceId})");
+            Console.WriteLine($"[{_botName}]  Placing piece: {piece.Name} ({piece.PieceId})");
             var decision = _strategy.DecidePlacement(currentState, piece);
 
             var result = decision switch
@@ -203,12 +244,11 @@ public sealed class GameLoop
             if (result is not null)
             {
                 placedThisTurn.Add(piece.PieceId);
-                Console.WriteLine($"  ✓ Placement submitted. Phase after: {result.Phase ?? "ended"}");
-                break;
+                Console.WriteLine($"[{_botName}]  ✓ Placement submitted. Phase after: {result.Phase ?? "ended"}");
+                return;
             }
 
-            // Failed — re-fetch fresh state and retry with updated occupancy
-            Console.WriteLine($"  ↩ Placement failed, refreshing state (attempt {attempt + 1}/{maxRetries})…");
+            Console.WriteLine($"[{_botName}]  ↩ Placement failed, refreshing state (attempt {attempt + 1}/{maxRetries})…");
             await Task.Delay(TimeSpan.FromMilliseconds(200), ct);
             currentState = await _client.GetStateAsync(gameId, ct) ?? currentState;
         }
@@ -221,10 +261,10 @@ public sealed class GameLoop
         HashSet<Guid> movedThisTurn,
         CancellationToken ct)
     {
-        // Only act when it is our turn
-        if (state.ActivePlayer is null || !state.ActivePlayer.Equals(playerId.ToString(), StringComparison.OrdinalIgnoreCase))
+        if (state.ActivePlayer is null ||
+            !state.ActivePlayer.Equals(playerId.ToString(), StringComparison.OrdinalIgnoreCase))
         {
-            Console.WriteLine($"  Waiting for our turn… (active: {state.ActivePlayer ?? "none"})");
+            Console.WriteLine($"[{_botName}]  Waiting for our turn… (active: {state.ActivePlayer ?? "none"})");
             return;
         }
 
@@ -232,23 +272,17 @@ public sealed class GameLoop
             .Where(p => p.IsOnBoard && !movedThisTurn.Contains(p.PieceId))
             .ToList();
 
-        if (piecesToMove.Count == 0)
-        {
-            // All pieces moved this turn
-            return;
-        }
+        if (piecesToMove.Count == 0) return;
 
-        // Move one piece at a time (re-poll between each move to get a fresh state)
-        var piece = piecesToMove.First();
-        Console.WriteLine($"  Moving piece: {piece.Name} at {piece.Position} ({piece.PieceId})");
+        var piece    = piecesToMove.First();
         var decision = _strategy.DecideMove(state, piece);
+        Console.WriteLine($"[{_botName}]  Moving piece: {piece.Name} at {piece.Position} ({piece.PieceId})");
 
         var result = await _client.MovePieceAsync(gameId, decision.PieceId, decision.Segments, ct);
-
         if (result is not null)
         {
             movedThisTurn.Add(piece.PieceId);
-            Console.WriteLine($"  ✓ Move submitted. Phase after: {result.Phase ?? "ended"} | Score: {result.YourScore} vs {result.OpponentScore}");
+            Console.WriteLine($"[{_botName}]  ✓ Move submitted. Phase after: {result.Phase ?? "ended"} | Score: {result.YourScore} vs {result.OpponentScore}");
         }
     }
 
@@ -270,8 +304,7 @@ public sealed class GameLoop
 
         if (result is null)
         {
-            // Fall back to last known state scores
-            Console.WriteLine($"Final score (from last state): {lastState.YourScore} vs {lastState.OpponentScore}");
+            Console.WriteLine($"[{_botName}] Final score (from last state): {lastState.YourScore} vs {lastState.OpponentScore}");
         }
         else
         {
@@ -295,6 +328,72 @@ public sealed class GameLoop
         Console.WriteLine("══════════════════════════════════════════════════════════");
     }
 
+    // ── Polling fallback ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Legacy polling loop used when SignalR is unavailable.
+    /// Identical in behaviour to the old <c>GameLoop</c> but without the 1-second fixed wait.
+    /// </summary>
+    private async Task RunPollingFallbackAsync(Guid gameId, Guid playerId, CancellationToken ct)
+    {
+        var placedThisTurn = new HashSet<Guid>();
+        var movedThisTurn  = new HashSet<Guid>();
+        var lastTurn       = -1;
+        var lastPhase      = "";
+
+        while (!ct.IsCancellationRequested)
+        {
+            BoardState? state;
+            try { state = await _client.GetStateAsync(gameId, ct); }
+            catch (OperationCanceledException) { break; }
+            catch (HttpRequestException ex)
+            {
+                Console.WriteLine($"[{_botName}] [ERROR] {ex.Message} — retrying in 3 s…");
+                await Task.Delay(TimeSpan.FromSeconds(3), ct);
+                continue;
+            }
+
+            if (state is null) { await Task.Delay(TimeSpan.FromSeconds(1), ct); continue; }
+
+            if (state.Turn != lastTurn)
+            {
+                placedThisTurn.Clear();
+                movedThisTurn.Clear();
+                lastTurn = state.Turn;
+                Console.WriteLine();
+                Console.WriteLine($"[{_botName}] [Turn {state.Turn}] Phase: {state.Phase ?? "(waiting/ended)"} | Score: {state.YourScore} vs {state.OpponentScore}");
+                lastPhase = state.Phase ?? "";
+            }
+            else if (state.Phase != lastPhase)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"[{_botName}] [Turn {state.Turn}] Phase: {state.Phase ?? "(waiting/ended)"} | Score: {state.YourScore} vs {state.OpponentScore}");
+                lastPhase = state.Phase ?? "";
+            }
+
+            if (state.Phase is null && state.Turn == 0) { await Task.Delay(TimeSpan.FromSeconds(1), ct); continue; }
+            if (state.Phase is null && state.Turn > 0)  { await PrintFinalResultAsync(gameId, playerId, state, ct); return; }
+            if (state.Phase == "CoinSpawn")              { await Task.Delay(TimeSpan.FromSeconds(1), ct); continue; }
+
+            if (state.Phase == "PlacePhase")
+            {
+                if (!placedThisTurn.Any())
+                    await HandlePlacePhaseAsync(gameId, state, placedThisTurn, ct);
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+                continue;
+            }
+
+            if (state.Phase == "MovePhase")
+            {
+                await HandleMovePhaseAsync(gameId, playerId, state, movedThisTurn, ct);
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+                continue;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), ct);
+        }
+    }
+
     // ── Matchmaking ───────────────────────────────────────────────────────────
 
     /// <summary>
@@ -309,14 +408,12 @@ public sealed class GameLoop
         var queueResponse = await _client.EnqueueAsync(lineup, ct);
         if (queueResponse is null) return null;
 
-        // Matched immediately — server returns { gameId, playerId, token } with no "status" field
         if (queueResponse is { GameId: not null, PlayerId: not null, Token: not null })
         {
             Console.WriteLine($"Matched immediately! GameId: {queueResponse.GameId}");
             return (queueResponse.GameId.Value, queueResponse.PlayerId.Value, queueResponse.Token.Value);
         }
 
-        // Waiting — poll until matched
         if (queueResponse is { Status: "waiting", QueueId: not null })
         {
             var queueId = queueResponse.QueueId.Value;

--- a/samples/ScrambleCoin.StarterBot/GameLoop.cs
+++ b/samples/ScrambleCoin.StarterBot/GameLoop.cs
@@ -17,7 +17,7 @@ public sealed class GameLoop
 
     // Fallback: if no SignalR event arrives within this window, do a one-off REST poll
     // to recover from a potentially missed event (e.g. after a brief reconnect).
-    private static readonly TimeSpan FallbackPollTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan FallbackPollTimeout = TimeSpan.FromSeconds(5);
 
     // How long to wait between matchmaking queue polls (unchanged)
     private static readonly TimeSpan QueuePollInterval = TimeSpan.FromSeconds(2);

--- a/samples/ScrambleCoin.StarterBot/GameLoop.cs
+++ b/samples/ScrambleCoin.StarterBot/GameLoop.cs
@@ -41,6 +41,7 @@ public sealed class GameLoop
         var movedThisTurn = new HashSet<Guid>();
         var lastTurn = -1;
         var lastPhase = "";
+        var waitingForOpponentPolls = 0; // counts silent polls while waiting for opponent to place
 
         while (!ct.IsCancellationRequested)
         {
@@ -71,6 +72,7 @@ public sealed class GameLoop
             {
                 placedThisTurn.Clear();
                 movedThisTurn.Clear();
+                waitingForOpponentPolls = 0;
                 lastTurn = state.Turn;
                 Console.WriteLine();
                 Console.WriteLine($"[Turn {state.Turn}] Phase: {state.Phase ?? "(waiting/ended)"} | Score: {state.YourScore} vs {state.OpponentScore}");
@@ -78,12 +80,13 @@ public sealed class GameLoop
             }
             else if (state.Phase != lastPhase)
             {
+                waitingForOpponentPolls = 0;
                 Console.WriteLine();
                 Console.WriteLine($"[Turn {state.Turn}] Phase: {state.Phase ?? "(waiting/ended)"} | Score: {state.YourScore} vs {state.OpponentScore}");
                 lastPhase = state.Phase ?? "";
             }
 
-            // ── Game not yet started ──────────────────────────────────────────
+            // ── Game isn't yet started ──────────────────────────────────────────
             if (state.Phase is null && state.Turn == 0)
             {
                 Console.WriteLine("  Waiting for game to start…");
@@ -109,6 +112,14 @@ public sealed class GameLoop
             // ── PlacePhase ────────────────────────────────────────────────────
             if (state.Phase == "PlacePhase")
             {
+                if (placedThisTurn.Any())
+                {
+                    waitingForOpponentPolls++;
+                    if (waitingForOpponentPolls % 5 == 1)
+                        Console.WriteLine($"  ⏳ Waiting for opponent to place… ({waitingForOpponentPolls}s)");
+                    await Task.Delay(PollInterval, ct);
+                    continue;
+                }
                 await HandlePlacePhaseAsync(gameId, state, placedThisTurn, ct);
                 await Task.Delay(PollInterval, ct);
                 continue;
@@ -129,17 +140,45 @@ public sealed class GameLoop
 
     // ── Phase handlers ────────────────────────────────────────────────────────
 
+    private const int MaxPiecesOnBoard = 3;
+
     private async Task HandlePlacePhaseAsync(
         Guid gameId,
         BoardState state,
         HashSet<Guid> placedThisTurn,
         CancellationToken ct)
     {
-        var unplaced = state.YourPieces.Where(p => !p.IsOnBoard && !placedThisTurn.Contains(p.PieceId)).ToList();
+        // Already submitted a placement action this turn — caller handles waiting log
+        if (placedThisTurn.Any())
+            return;
 
+        var piecesOnBoard = state.YourPieces.Count(p => p.IsOnBoard);
+
+        // Already at the 3-piece limit — must skip, cannot place another
+        if (piecesOnBoard >= MaxPiecesOnBoard)
+        {
+            Console.WriteLine($"  → Already at max pieces ({MaxPiecesOnBoard}) on board — skipping placement");
+            var r = await _client.SkipPlacementAsync(gameId, ct);
+            if (r is not null)
+            {
+                placedThisTurn.Add(Guid.Empty); // sentinel: marks that we have acted this turn
+                Console.WriteLine($"  ✓ Placement skipped. Phase after: {r.Phase ?? "ended"}");
+            }
+            return;
+        }
+
+        var unplaced = state.YourPieces.Where(p => !p.IsOnBoard).ToList();
+
+        // No pieces left in hand (shouldn't normally happen, but be safe)
         if (unplaced.Count == 0)
         {
-            // All pieces placed — nothing more to do this phase
+            Console.WriteLine("  → No pieces in hand — skipping placement");
+            var r = await _client.SkipPlacementAsync(gameId, ct);
+            if (r is not null)
+            {
+                placedThisTurn.Add(Guid.Empty);
+                Console.WriteLine($"  ✓ Placement skipped. Phase after: {r.Phase ?? "ended"}");
+            }
             return;
         }
 
@@ -161,7 +200,13 @@ public sealed class GameLoop
             {
                 placedThisTurn.Add(piece.PieceId);
                 Console.WriteLine($"  ✓ Placement submitted. Phase after: {result.Phase ?? "ended"}");
-                break; // Only one placement per player per PlacePhase round
+                break; // Only one placement action per player per PlacePhase
+            }
+            else
+            {
+                // Placement failed (e.g. tile occupied by opponent who placed concurrently).
+                // Stop retrying now — state is stale. The next poll will refresh it.
+                break;
             }
         }
     }
@@ -190,7 +235,7 @@ public sealed class GameLoop
             return;
         }
 
-        // Move one piece at a time (re-poll between each move to get fresh state)
+        // Move one piece at a time (re-poll between each move to get a fresh state)
         var piece = piecesToMove.First();
         Console.WriteLine($"  Moving piece: {piece.Name} at {piece.Position} ({piece.PieceId})");
         var decision = _strategy.DecideMove(state, piece);
@@ -262,16 +307,14 @@ public sealed class GameLoop
         if (queueResponse is null) return null;
 
         // Matched immediately — server returns { gameId, playerId, token } with no "status" field
-        if (queueResponse.GameId.HasValue &&
-            queueResponse.PlayerId.HasValue &&
-            queueResponse.Token.HasValue)
+        if (queueResponse is { GameId: not null, PlayerId: not null, Token: not null })
         {
             Console.WriteLine($"Matched immediately! GameId: {queueResponse.GameId}");
             return (queueResponse.GameId.Value, queueResponse.PlayerId.Value, queueResponse.Token.Value);
         }
 
         // Waiting — poll until matched
-        if (queueResponse.Status == "waiting" && queueResponse.QueueId.HasValue)
+        if (queueResponse is { Status: "waiting", QueueId: not null })
         {
             var queueId = queueResponse.QueueId.Value;
             Console.WriteLine($"Waiting in queue (QueueId: {queueId})…");
@@ -284,10 +327,7 @@ public sealed class GameLoop
 
                 Console.WriteLine($"  Queue status: {poll.Status}");
 
-                if (poll.Status == "matched" &&
-                    poll.GameId.HasValue &&
-                    poll.PlayerId.HasValue &&
-                    poll.Token.HasValue)
+                if (poll is { Status: "matched", GameId: not null, PlayerId: not null, Token: not null })
                 {
                     Console.WriteLine($"Matched! GameId: {poll.GameId}");
                     return (poll.GameId.Value, poll.PlayerId.Value, poll.Token.Value);

--- a/samples/ScrambleCoin.StarterBot/GameLoop.cs
+++ b/samples/ScrambleCoin.StarterBot/GameLoop.cs
@@ -182,12 +182,16 @@ public sealed class GameLoop
             return;
         }
 
-        foreach (var piece in unplaced)
+        var currentState = state;
+        var piece = unplaced.First();
+        const int maxRetries = 5;
+
+        for (var attempt = 0; attempt < maxRetries; attempt++)
         {
             if (ct.IsCancellationRequested) break;
 
             Console.WriteLine($"  Placing piece: {piece.Name} ({piece.PieceId})");
-            var decision = _strategy.DecidePlacement(state, piece);
+            var decision = _strategy.DecidePlacement(currentState, piece);
 
             var result = decision switch
             {
@@ -200,14 +204,13 @@ public sealed class GameLoop
             {
                 placedThisTurn.Add(piece.PieceId);
                 Console.WriteLine($"  ✓ Placement submitted. Phase after: {result.Phase ?? "ended"}");
-                break; // Only one placement action per player per PlacePhase
-            }
-            else
-            {
-                // Placement failed (e.g. tile occupied by opponent who placed concurrently).
-                // Stop retrying now — state is stale. The next poll will refresh it.
                 break;
             }
+
+            // Failed — re-fetch fresh state and retry with updated occupancy
+            Console.WriteLine($"  ↩ Placement failed, refreshing state (attempt {attempt + 1}/{maxRetries})…");
+            await Task.Delay(TimeSpan.FromMilliseconds(200), ct);
+            currentState = await _client.GetStateAsync(gameId, ct) ?? currentState;
         }
     }
 

--- a/samples/ScrambleCoin.StarterBot/GameLoop.cs
+++ b/samples/ScrambleCoin.StarterBot/GameLoop.cs
@@ -55,7 +55,17 @@ public sealed class GameLoop
         hub.On("ActionRequired", (object _) => Push("action-required"));
         hub.On("GameEnded",      (object _) => Push("game-ended"));
 
-        hub.Reconnected += _ => { Push("reconnected"); return Task.CompletedTask; };
+        hub.Reconnected += async _ =>
+        {
+            Push("reconnected");
+            // Re-join groups — auto-reconnect creates a new connection that has left all groups.
+            try
+            {
+                await hub.InvokeAsync("JoinGame",         gameId.ToString());
+                await hub.InvokeAsync("RegisterAsPlayer", gameId.ToString(),   playerId.ToString());
+            }
+            catch { /* best-effort: may fail if the hub is still settling */ }
+        };
         hub.Closed      += ex =>
         {
             Console.WriteLine($"[{_botName}]  ⚠ SignalR disconnected: {ex?.Message}");
@@ -104,8 +114,14 @@ public sealed class GameLoop
                 }
                 catch (OperationCanceledException) when (!ct.IsCancellationRequested)
                 {
-                    // Timeout — no event in 30 s; poll once as a safety net.
-                    Console.WriteLine($"[{_botName}]  ⏱ No SignalR event for 30 s — polling once.");
+                    // Timeout — no event in 5 s; poll once as a safety net.
+                    Console.WriteLine($"[{_botName}]  ⏱ No SignalR event for 5 s — polling once.");
+                    // Re-register in case a reconnect silently dropped us from the player group.
+                    try
+                    {
+                        await hub.InvokeAsync("RegisterAsPlayer", gameId.ToString(), playerId.ToString(), ct);
+                    }
+                    catch { /* best-effort: hub may be reconnecting */ }
                     signal = "timeout-poll";
                 }
 

--- a/samples/ScrambleCoin.StarterBot/GameLoop.cs
+++ b/samples/ScrambleCoin.StarterBot/GameLoop.cs
@@ -51,9 +51,9 @@ public sealed class GameLoop
 
         void Push(string reason) => events.Writer.TryWrite(reason);
 
-        hub.On("BoardStateUpdated", (object _) => Push("board-updated"));
-        hub.On("PhaseChanged",      (object _) => Push("phase-changed"));
-        hub.On("GameEnded",         (object _) => Push("game-ended"));
+        // ActionRequired is sent only to THIS player's private group — zero noise from opponent actions.
+        hub.On("ActionRequired", (object _) => Push("action-required"));
+        hub.On("GameEnded",      (object _) => Push("game-ended"));
 
         hub.Reconnected += _ => { Push("reconnected"); return Task.CompletedTask; };
         hub.Closed      += ex =>
@@ -66,8 +66,11 @@ public sealed class GameLoop
         try
         {
             await hub.StartAsync(ct);
+            // Join the public spectator group (for GameEnded)
             await hub.InvokeAsync("JoinGame", gameId.ToString(), ct);
-            Console.WriteLine($"[{_botName}]  🔔 SignalR connected — listening for events…");
+            // Join the private player group (for ActionRequired — only our turn notifications)
+            await hub.InvokeAsync("RegisterAsPlayer", gameId.ToString(), playerId.ToString(), ct);
+            Console.WriteLine($"[{_botName}]  🔔 SignalR connected — waiting for ActionRequired events…");
         }
         catch (Exception ex)
         {

--- a/samples/ScrambleCoin.StarterBot/GreedyStrategy.cs
+++ b/samples/ScrambleCoin.StarterBot/GreedyStrategy.cs
@@ -9,7 +9,7 @@ namespace ScrambleCoin.StarterBot;
 ///   <item><b>MovePhase</b>: move each piece one step toward the nearest coin.
 ///   If no coins remain, the piece stays still.</item>
 /// </list>
-/// Replace this class (or implement <see cref="IStrategy"/>) to customise the bot.
+/// Replace this class (or implement <see cref="IStrategy"/>) to customize the bot.
 /// </summary>
 public sealed class GreedyStrategy : IStrategy
 {
@@ -58,7 +58,7 @@ public sealed class GreedyStrategy : IStrategy
             ["Fairy Godmother"] = "Anywhere",
             ["Ursula"]          = "Anywhere",
             ["Rapunzel"]        = "Anywhere",
-            ["Forky"]           = "Anywhere",
+            ["Forky"]           = "Anywhere"
         };
 
     // ── PlacePhase ────────────────────────────────────────────────────────────
@@ -66,7 +66,7 @@ public sealed class GreedyStrategy : IStrategy
     /// <inheritdoc />
     public PlacementDecision DecidePlacement(BoardState state, PieceState piece)
     {
-        // Collect all occupied positions (obstacles, pieces, coins)
+        // Collect all positions blocked by obstacles or existing pieces (coins are NOT blocking)
         var occupied = GetOccupiedPositions(state);
 
         // Choose candidate tiles based on the piece's entry-point type
@@ -105,7 +105,7 @@ public sealed class GreedyStrategy : IStrategy
             if (step is not null)
             {
                 segments.Add(new List<Position> { step }.AsReadOnly());
-                currentPos = step; // Update position for next segment
+                currentPos = step; // Update position for the next segment
                 blocked.Add((step.Row, step.Col)); // Treat destination as blocked for subsequent segments
             }
             else
@@ -125,14 +125,14 @@ public sealed class GreedyStrategy : IStrategy
         if (state.AvailableCoins.Count == 0)
             return null; // No coins — stay still
 
-        // Find nearest coin (by Euclidean distance)
+        // Find the nearest coin (by Euclidean distance)
         var target = state.AvailableCoins
             .OrderBy(c => from.DistanceTo(c.Position))
             .First().Position;
 
         Console.WriteLine($"    {piece.Name} at {from} → nearest coin at {target}");
 
-        // Generate candidate steps based on movement type
+        // Generate candidate steps based on a movement type
         var candidates = GetMoveCandidates(from, piece.MovementType);
 
         // Filter: stay on board, not blocked
@@ -182,7 +182,7 @@ public sealed class GreedyStrategy : IStrategy
         OrthogonalNeighbours(p).Concat(DiagonalNeighbours(p));
 
     /// <summary>
-    /// Returns tiles the piece may be placed on, filtered to its entry-point type and ordered
+    /// Returns tiles the piece may be placed on, filtered to its entry-point type, and ordered
     /// so that the most preferred tile comes first.
     /// <list type="bullet">
     ///   <item><b>Borders</b>: non-corner border tiles only (a Borders piece cannot use corners).</item>
@@ -192,7 +192,7 @@ public sealed class GreedyStrategy : IStrategy
     /// </summary>
     private static IEnumerable<Position> GetCandidateTiles(BoardState state, PieceState piece)
     {
-        var entryType = PieceEntryPoints.TryGetValue(piece.Name, out var et) ? et : "Borders";
+        var entryType = PieceEntryPoints.GetValueOrDefault(piece.Name, "Borders");
 
         var corners = new[]
         {
@@ -242,14 +242,9 @@ public sealed class GreedyStrategy : IStrategy
         return blocked;
     }
 
-    /// <summary>All positions currently occupied (obstacles, pieces, coins).</summary>
-    private static HashSet<(int, int)> GetOccupiedPositions(BoardState state)
-    {
-        var occupied = GetBlockedPositions(state);
-        foreach (var coin in state.AvailableCoins)
-            occupied.Add((coin.Position.Row, coin.Position.Col));
-        return occupied;
-    }
+    /// <summary>All positions currently occupied by obstacles or pieces (coins are collectible, not blocking).</summary>
+    private static HashSet<(int, int)> GetOccupiedPositions(BoardState state) =>
+        GetBlockedPositions(state);
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 

--- a/samples/ScrambleCoin.StarterBot/Models/ApiModels.cs
+++ b/samples/ScrambleCoin.StarterBot/Models/ApiModels.cs
@@ -241,3 +241,24 @@ public sealed class MoveResponse
     [JsonPropertyName("opponentScore")]
     public int OpponentScore { get; set; }
 }
+
+public sealed class BotGameInfo
+{
+    [JsonPropertyName("matchId")]
+    public Guid MatchId { get; set; }
+
+    [JsonPropertyName("stage")]
+    public string Stage { get; set; } = "";
+
+    [JsonPropertyName("round")]
+    public int? Round { get; set; }
+
+    [JsonPropertyName("gameId")]
+    public Guid GameId { get; set; }
+
+    [JsonPropertyName("token")]
+    public Guid Token { get; set; }
+
+    [JsonPropertyName("playerId")]
+    public Guid PlayerId { get; set; }
+}

--- a/samples/ScrambleCoin.StarterBot/Program.cs
+++ b/samples/ScrambleCoin.StarterBot/Program.cs
@@ -2,7 +2,7 @@ using ScrambleCoin.StarterBot;
 
 // ── Configuration ─────────────────────────────────────────────────────────────
 
-var baseUrl  = Environment.GetEnvironmentVariable("BASE_URL")  ?? "http://localhost:5000";
+var baseUrl  = Environment.GetEnvironmentVariable("BASE_URL")  ?? "http://localhost:5001";
 var botName  = Environment.GetEnvironmentVariable("BOT_NAME")  ?? "StarterBot";
 var gameIdEnv = Environment.GetEnvironmentVariable("GAME_ID");
 

--- a/samples/ScrambleCoin.StarterBot/ScrambleCoin.StarterBot.csproj
+++ b/samples/ScrambleCoin.StarterBot/ScrambleCoin.StarterBot.csproj
@@ -17,4 +17,8 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/samples/ScrambleCoin.TournamentHarness/Program.cs
+++ b/samples/ScrambleCoin.TournamentHarness/Program.cs
@@ -43,7 +43,7 @@ var createResp = await adminHttp.PostAsJsonAsync("api/tournament", new
 {
     name            = tourneyName,
     maxParticipants = numBots,
-    topN            = Math.Min(numBots, 4)
+    topN            = numBots
 });
 
 if (!createResp.IsSuccessStatusCode)

--- a/samples/ScrambleCoin.TournamentHarness/Program.cs
+++ b/samples/ScrambleCoin.TournamentHarness/Program.cs
@@ -11,21 +11,23 @@ using ScrambleCoin.StarterBot.Models;
 //
 //  What it does:
 //    1. Creates a tournament via the admin API
-//    2. Registers <numBots> bots (self-registration, no admin key needed)
+//    2. Registers <numBots> bots (self-registration)
 //    3. Starts the tournament
-//    4. Runs all bots in parallel — each bot polls for its assigned game,
-//       plays it, then polls again for knockout games, until done
+//    4. Each bot monitors for assigned games via polling and spins up a
+//       dedicated GameLoop for EACH game as soon as it appears — games run
+//       concurrently so a slow opponent in one game never blocks a bot from
+//       playing another.
 // ─────────────────────────────────────────────────────────────────────────────
 
-var baseUrl  = args.Length > 0 ? args[0]               : "http://localhost:5001";
-var numBots  = args.Length > 1 && int.TryParse(args[1], out var n) ? n : 4;
+var baseUrl      = args.Length > 0 ? args[0]                                : "http://localhost:5001";
+var numBots      = args.Length > 1 && int.TryParse(args[1], out var n) ? n : 4;
 const string adminKey    = "scramblecoin-admin";
 const string tourneyName = "Harness Tournament";
 
 // Deterministic bot IDs so reruns are reproducible
 var bots = Enumerable.Range(1, numBots)
     .Select(i => (
-        Id:   new Guid(i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),  // Guid from seed
+        Id:   new Guid(i, 0, 0, new byte[8]),
         Name: $"HarnessBot-{i}"
     ))
     .ToList();
@@ -36,7 +38,7 @@ var lineup = new[] { "Mickey", "Minnie", "Donald", "Goofy", "Scrooge" };
 using var adminHttp = new HttpClient { BaseAddress = new Uri(baseUrl.TrimEnd('/') + '/') };
 adminHttp.DefaultRequestHeaders.Add("X-Admin-Key", adminKey);
 
-Print("🏆 Creating tournament…");
+Log("🏆 Creating tournament…");
 var createResp = await adminHttp.PostAsJsonAsync("api/tournament", new
 {
     name            = tourneyName,
@@ -46,138 +48,175 @@ var createResp = await adminHttp.PostAsJsonAsync("api/tournament", new
 
 if (!createResp.IsSuccessStatusCode)
 {
-    var err = await createResp.Content.ReadAsStringAsync();
-    Print($"❌ Failed to create tournament: {(int)createResp.StatusCode} {err}");
+    Log($"❌ Failed to create tournament: {(int)createResp.StatusCode} {await createResp.Content.ReadAsStringAsync()}");
     return;
 }
 
 var createBody   = await createResp.Content.ReadFromJsonAsync<JsonElement>();
 var tournamentId = createBody.GetProperty("tournamentId").GetGuid();
-Print($"   Tournament ID: {tournamentId}");
+Log($"   Tournament ID: {tournamentId}");
 
 // ── 2. Register bots ─────────────────────────────────────────────────────────
-Print($"\n👥 Registering {numBots} bots…");
+Log($"\n👥 Registering {numBots} bots…");
 
-foreach (var (id, name) in bots)
+foreach (var bot in bots)
 {
     using var client = new BotClient(baseUrl);
-    var ok = await client.JoinTournamentAsync(tournamentId, id, name, lineup);
-    if (!ok)
+    if (!await client.JoinTournamentAsync(tournamentId, bot.Id, bot.Name, lineup))
     {
-        Print($"❌ {name} failed to join. Aborting.");
+        Log($"❌ {bot.Name} failed to join. Aborting.");
         return;
     }
-    Print($"   ✓ {name} joined");
+    Log($"   ✓ {bot.Name} joined");
 }
 
 // ── 3. Start tournament ───────────────────────────────────────────────────────
-Print("\n🚀 Starting tournament…");
-var startResp = await adminHttp.PostAsync(new Uri(adminHttp.BaseAddress!, $"api/tournament/{tournamentId}/start"), null);
+Log("\n🚀 Starting tournament…");
+var startResp = await adminHttp.PostAsync(
+    new Uri(adminHttp.BaseAddress!, $"api/tournament/{tournamentId}/start"), null);
 
 if (!startResp.IsSuccessStatusCode)
 {
-    var err = await startResp.Content.ReadAsStringAsync();
-    Print($"❌ Failed to start tournament: {(int)startResp.StatusCode} {err}");
+    Log($"❌ Failed to start tournament: {(int)startResp.StatusCode} {await startResp.Content.ReadAsStringAsync()}");
     return;
 }
-Print("   Tournament started!");
-Print($"\n🌐 Watch it live → {baseUrl}/tournament/{tournamentId}\n");
-Print(new string('─', 60));
+
+Log("   Tournament started!");
+Log($"\n🌐 Watch it live → {baseUrl}/tournament/{tournamentId}\n");
+Log(new string('─', 60));
 
 // ── 4. Run all bots in parallel ───────────────────────────────────────────────
-using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(30)); // safety timeout
+// Global safety timeout — no tournament should run longer than 30 minutes.
+using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(30));
 
-var botTasks = bots.Select(bot =>
-    RunBotUntilDoneAsync(baseUrl, tournamentId, bot.Id, bot.Name, lineup, cts.Token)
-).ToList();
+await Task.WhenAll(bots.Select(bot =>
+    RunBotAsync(baseUrl, tournamentId, bot.Id, bot.Name, cts.Token)));
 
-await Task.WhenAll(botTasks);
-
-Print(new string('─', 60));
-Print("🎉 All bots finished. Check the tournament page for results!");
+Log(new string('─', 60));
+Log("🎉 All bots finished. Check the tournament page for results!");
 
 // ─────────────────────────────────────────────────────────────────────────────
-//  Per-bot runner — polls for games, plays each one, handles knockout rounds
+//  Per-bot runner
+//
+//  Polls for game assignments every 2 seconds and immediately starts a
+//  concurrent GameLoop for each new game.  This means a bot can play two
+//  games simultaneously — which happens naturally in round-robin tournaments
+//  where the scheduler assigns the next round before a slow game from the
+//  current round ends.
 // ─────────────────────────────────────────────────────────────────────────────
 
-static async Task RunBotUntilDoneAsync(
-    string       baseUrl,
-    Guid         tournamentId,
-    Guid         botId,
-    string       botName,
-    string[]     lineup,
+static async Task RunBotAsync(
+    string            baseUrl,
+    Guid              tournamentId,
+    Guid              botId,
+    string            botName,
     CancellationToken ct)
 {
-    using var client   = new BotClient(baseUrl);
-    var strategy       = new GreedyStrategy();
-    var playedGames    = new HashSet<Guid>();
-    var noGameStreak   = 0;
-    const int maxNoGamePolls = 30;  // ~60s of no new games → assume done
+    using var discoveryClient = new BotClient(baseUrl);
 
-    Print($"[{botName}] Starting…");
+    // gameId → running task (never double-start the same game)
+    var activeGames  = new Dictionary<Guid, Task>();
+    var noNewStreak  = 0;
+    const int maxNoNew = 15; // 15 × 2 s = 30 s with no new games + no active games → done
+
+    Log($"[{botName}] Ready — watching for game assignments…");
 
     while (!ct.IsCancellationRequested)
     {
-        // Poll for assigned games
-        var games = await client.GetBotGamesAsync(tournamentId, botId, ct);
+        // Remove completed game tasks and log any faults.
+        foreach (var id in activeGames.Keys
+                     .Where(id => activeGames[id].IsCompleted)
+                     .ToList())
+        {
+            if (activeGames[id].IsFaulted)
+                Log($"[{botName}] ⚠  Game {id} faulted: {activeGames[id].Exception?.GetBaseException().Message}");
+            activeGames.Remove(id);
+        }
 
+        var games = await discoveryClient.GetBotGamesAsync(tournamentId, botId, ct);
         if (games is null)
         {
-            // API error — back off and retry
             await Task.Delay(TimeSpan.FromSeconds(3), ct);
             continue;
         }
 
-        var newGames = games.Where(g => !playedGames.Contains(g.GameId)).ToList();
+        var newGames = games
+            .Where(g => !activeGames.ContainsKey(g.GameId))
+            .ToList();
 
         if (newGames.Count == 0)
         {
-            noGameStreak++;
-            if (noGameStreak >= maxNoGamePolls)
+            // Exit only when there are no active games and no new ones for a while.
+            if (activeGames.Count == 0 && ++noNewStreak >= maxNoNew)
             {
-                Print($"[{botName}] No new games for {maxNoGamePolls * 2}s — assuming tournament complete.");
+                Log($"[{botName}] No new or active games for ~{maxNoNew * 2} s — done.");
                 break;
             }
-            // Log every 10 polls (~20s) so user knows bot is still alive
-            if (noGameStreak % 10 == 1)
-                Print($"[{botName}] ⏳ Waiting for next game… ({noGameStreak * 2}s elapsed)");
-            await Task.Delay(TimeSpan.FromSeconds(2), ct);
-            continue;
         }
-
-        noGameStreak = 0;
-
-        foreach (var game in newGames)
+        else
         {
-            playedGames.Add(game.GameId);
-            Print($"[{botName}] 🎮 Playing {game.Stage} game — GameId: {game.GameId}");
+            noNewStreak = 0;
 
-            // Each game needs the correct token
-            client.SetBotToken(game.Token);
-            var loop = new GameLoop(client, strategy, $"{botName}");
-
-            try
+            foreach (var game in newGames)
             {
-                await loop.RunAsync(game.GameId, game.PlayerId, ct);
-                Print($"[{botName}] ✅ Game {game.GameId} finished");
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                Print($"[{botName}] ⚠️  Cancelled during game {game.GameId}");
-                return;
-            }
-            catch (Exception ex)
-            {
-                Print($"[{botName}] ❌ Error in game {game.GameId}: {ex.Message}");
+                Log($"[{botName}] 🎮 {game.Stage} game assigned — {game.GameId}");
+                var g = game; // capture for lambda
+                activeGames[g.GameId] = Task.Run(() => PlayGameAsync(baseUrl, botName, g, ct), ct);
             }
         }
 
-        // Wait before polling for next (knockout) game
         await Task.Delay(TimeSpan.FromSeconds(2), ct);
+    }
+
+    // Wait for any in-flight games before returning.
+    if (activeGames.Count > 0)
+    {
+        Log($"[{botName}] ⏳ Waiting for {activeGames.Count} in-flight game(s)…");
+        try { await Task.WhenAll(activeGames.Values).WaitAsync(TimeSpan.FromMinutes(10), ct); }
+        catch (OperationCanceledException) { /* shutdown */ }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Plays a single game end-to-end.
+//  Each invocation gets its own BotClient so token and SignalR state are
+//  fully isolated — concurrent games for the same bot don't interfere.
+// ─────────────────────────────────────────────────────────────────────────────
+
+static async Task PlayGameAsync(
+    string            baseUrl,
+    string            botName,
+    BotGameInfo       game,
+    CancellationToken ct)
+{
+    using var gameCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+    gameCts.CancelAfter(TimeSpan.FromMinutes(10)); // per-game safety timeout
+
+    using var gameClient = new BotClient(baseUrl);
+    gameClient.SetBotToken(game.Token);
+
+    var loop = new GameLoop(gameClient, new GreedyStrategy(), botName);
+
+    try
+    {
+        await loop.RunAsync(game.GameId, game.PlayerId, gameCts.Token);
+        Log($"[{botName}] ✅ {game.Stage} game {game.GameId} complete");
+    }
+    catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+    {
+        Log($"[{botName}] ⏱  Game {game.GameId} timed out after 10 min — skipping.");
+    }
+    catch (OperationCanceledException)
+    {
+        // Global cancellation — swallow, parent will log.
+    }
+    catch (Exception ex)
+    {
+        Log($"[{botName}] ❌ Game {game.GameId}: {ex.Message}");
     }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-static void Print(string msg) =>
+static void Log(string msg) =>
     Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] {msg}");

--- a/samples/ScrambleCoin.TournamentHarness/Program.cs
+++ b/samples/ScrambleCoin.TournamentHarness/Program.cs
@@ -115,7 +115,8 @@ static async Task RunBotAsync(
     using var discoveryClient = new BotClient(baseUrl);
 
     // gameId → running task (never double-start the same game)
-    var activeGames  = new Dictionary<Guid, Task>();
+    var activeGames    = new Dictionary<Guid, Task>();
+    var completedGames = new HashSet<Guid>(); // never restart a finished game
     var noNewStreak  = 0;
     const int maxNoNew = 15; // 15 × 2 s = 30 s with no new games + no active games → done
 
@@ -130,6 +131,7 @@ static async Task RunBotAsync(
         {
             if (activeGames[id].IsFaulted)
                 Log($"[{botName}] ⚠  Game {id} faulted: {activeGames[id].Exception?.GetBaseException().Message}");
+            completedGames.Add(id);
             activeGames.Remove(id);
         }
 
@@ -141,7 +143,7 @@ static async Task RunBotAsync(
         }
 
         var newGames = games
-            .Where(g => !activeGames.ContainsKey(g.GameId))
+            .Where(g => !activeGames.ContainsKey(g.GameId) && !completedGames.Contains(g.GameId))
             .ToList();
 
         if (newGames.Count == 0)

--- a/samples/ScrambleCoin.TournamentHarness/Program.cs
+++ b/samples/ScrambleCoin.TournamentHarness/Program.cs
@@ -35,7 +35,8 @@ var bots = Enumerable.Range(1, numBots)
 var lineup = new[] { "Mickey", "Minnie", "Donald", "Goofy", "Scrooge" };
 
 // ── 1. Create tournament ──────────────────────────────────────────────────────
-using var adminHttp = new HttpClient { BaseAddress = new Uri(baseUrl.TrimEnd('/') + '/') };
+using var adminHttp = new HttpClient();
+adminHttp.BaseAddress = new Uri(baseUrl.TrimEnd('/') + '/');
 adminHttp.DefaultRequestHeaders.Add("X-Admin-Key", adminKey);
 
 Log("🏆 Creating tournament…");
@@ -94,6 +95,7 @@ await Task.WhenAll(bots.Select(bot =>
 
 Log(new string('─', 60));
 Log("🎉 All bots finished. Check the tournament page for results!");
+return;
 
 // ─────────────────────────────────────────────────────────────────────────────
 //  Per-bot runner

--- a/samples/ScrambleCoin.TournamentHarness/Program.cs
+++ b/samples/ScrambleCoin.TournamentHarness/Program.cs
@@ -1,0 +1,183 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using ScrambleCoin.StarterBot;
+using ScrambleCoin.StarterBot.Models;
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  ScrambleCoin Tournament Harness
+//
+//  Usage: dotnet run -- [baseUrl] [numBots]
+//  Defaults: http://localhost:5001  4
+//
+//  What it does:
+//    1. Creates a tournament via the admin API
+//    2. Registers <numBots> bots (self-registration, no admin key needed)
+//    3. Starts the tournament
+//    4. Runs all bots in parallel — each bot polls for its assigned game,
+//       plays it, then polls again for knockout games, until done
+// ─────────────────────────────────────────────────────────────────────────────
+
+var baseUrl  = args.Length > 0 ? args[0]               : "http://localhost:5001";
+var numBots  = args.Length > 1 && int.TryParse(args[1], out var n) ? n : 4;
+const string adminKey    = "scramblecoin-admin";
+const string tourneyName = "Harness Tournament";
+
+// Deterministic bot IDs so reruns are reproducible
+var bots = Enumerable.Range(1, numBots)
+    .Select(i => (
+        Id:   new Guid(i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),  // Guid from seed
+        Name: $"HarnessBot-{i}"
+    ))
+    .ToList();
+
+var lineup = new[] { "Mickey", "Minnie", "Donald", "Goofy", "Scrooge" };
+
+// ── 1. Create tournament ──────────────────────────────────────────────────────
+using var adminHttp = new HttpClient { BaseAddress = new Uri(baseUrl.TrimEnd('/') + '/') };
+adminHttp.DefaultRequestHeaders.Add("X-Admin-Key", adminKey);
+
+Print("🏆 Creating tournament…");
+var createResp = await adminHttp.PostAsJsonAsync("api/tournament", new
+{
+    name            = tourneyName,
+    maxParticipants = numBots,
+    topN            = Math.Min(numBots, 4)
+});
+
+if (!createResp.IsSuccessStatusCode)
+{
+    var err = await createResp.Content.ReadAsStringAsync();
+    Print($"❌ Failed to create tournament: {(int)createResp.StatusCode} {err}");
+    return;
+}
+
+var createBody   = await createResp.Content.ReadFromJsonAsync<JsonElement>();
+var tournamentId = createBody.GetProperty("tournamentId").GetGuid();
+Print($"   Tournament ID: {tournamentId}");
+
+// ── 2. Register bots ─────────────────────────────────────────────────────────
+Print($"\n👥 Registering {numBots} bots…");
+
+foreach (var (id, name) in bots)
+{
+    using var client = new BotClient(baseUrl);
+    var ok = await client.JoinTournamentAsync(tournamentId, id, name, lineup);
+    if (!ok)
+    {
+        Print($"❌ {name} failed to join. Aborting.");
+        return;
+    }
+    Print($"   ✓ {name} joined");
+}
+
+// ── 3. Start tournament ───────────────────────────────────────────────────────
+Print("\n🚀 Starting tournament…");
+var startResp = await adminHttp.PostAsync(new Uri(adminHttp.BaseAddress!, $"api/tournament/{tournamentId}/start"), null);
+
+if (!startResp.IsSuccessStatusCode)
+{
+    var err = await startResp.Content.ReadAsStringAsync();
+    Print($"❌ Failed to start tournament: {(int)startResp.StatusCode} {err}");
+    return;
+}
+Print("   Tournament started!");
+Print($"\n🌐 Watch it live → {baseUrl}/tournament/{tournamentId}\n");
+Print(new string('─', 60));
+
+// ── 4. Run all bots in parallel ───────────────────────────────────────────────
+using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(30)); // safety timeout
+
+var botTasks = bots.Select(bot =>
+    RunBotUntilDoneAsync(baseUrl, tournamentId, bot.Id, bot.Name, lineup, cts.Token)
+).ToList();
+
+await Task.WhenAll(botTasks);
+
+Print(new string('─', 60));
+Print("🎉 All bots finished. Check the tournament page for results!");
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Per-bot runner — polls for games, plays each one, handles knockout rounds
+// ─────────────────────────────────────────────────────────────────────────────
+
+static async Task RunBotUntilDoneAsync(
+    string       baseUrl,
+    Guid         tournamentId,
+    Guid         botId,
+    string       botName,
+    string[]     lineup,
+    CancellationToken ct)
+{
+    using var client   = new BotClient(baseUrl);
+    var strategy       = new GreedyStrategy();
+    var playedGames    = new HashSet<Guid>();
+    var noGameStreak   = 0;
+    const int maxNoGamePolls = 30;  // ~60s of no new games → assume done
+
+    Print($"[{botName}] Starting…");
+
+    while (!ct.IsCancellationRequested)
+    {
+        // Poll for assigned games
+        var games = await client.GetBotGamesAsync(tournamentId, botId, ct);
+
+        if (games is null)
+        {
+            // API error — back off and retry
+            await Task.Delay(TimeSpan.FromSeconds(3), ct);
+            continue;
+        }
+
+        var newGames = games.Where(g => !playedGames.Contains(g.GameId)).ToList();
+
+        if (newGames.Count == 0)
+        {
+            noGameStreak++;
+            if (noGameStreak >= maxNoGamePolls)
+            {
+                Print($"[{botName}] No new games for {maxNoGamePolls * 2}s — assuming tournament complete.");
+                break;
+            }
+            // Log every 10 polls (~20s) so user knows bot is still alive
+            if (noGameStreak % 10 == 1)
+                Print($"[{botName}] ⏳ Waiting for next game… ({noGameStreak * 2}s elapsed)");
+            await Task.Delay(TimeSpan.FromSeconds(2), ct);
+            continue;
+        }
+
+        noGameStreak = 0;
+
+        foreach (var game in newGames)
+        {
+            playedGames.Add(game.GameId);
+            Print($"[{botName}] 🎮 Playing {game.Stage} game — GameId: {game.GameId}");
+
+            // Each game needs the correct token
+            client.SetBotToken(game.Token);
+            var loop = new GameLoop(client, strategy, $"{botName}");
+
+            try
+            {
+                await loop.RunAsync(game.GameId, game.PlayerId, ct);
+                Print($"[{botName}] ✅ Game {game.GameId} finished");
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                Print($"[{botName}] ⚠️  Cancelled during game {game.GameId}");
+                return;
+            }
+            catch (Exception ex)
+            {
+                Print($"[{botName}] ❌ Error in game {game.GameId}: {ex.Message}");
+            }
+        }
+
+        // Wait before polling for next (knockout) game
+        await Task.Delay(TimeSpan.FromSeconds(2), ct);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+static void Print(string msg) =>
+    Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] {msg}");

--- a/samples/ScrambleCoin.TournamentHarness/ScrambleCoin.TournamentHarness.csproj
+++ b/samples/ScrambleCoin.TournamentHarness/ScrambleCoin.TournamentHarness.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>ScrambleCoin.TournamentHarness</RootNamespace>
+    <AssemblyName>ScrambleCoin.TournamentHarness</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ScrambleCoin.StarterBot\ScrambleCoin.StarterBot.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ScrambleCoin.Api/Endpoints/GameEndpoints.cs
+++ b/src/ScrambleCoin.Api/Endpoints/GameEndpoints.cs
@@ -131,28 +131,20 @@ public static class GameEndpoints
                 title: "Invalid Lineup");
         }
 
-        if (entry.Status == "conflict")
+        return entry.Status switch
         {
-            return Results.Problem(
-                detail: "Bot is already waiting in the queue or has an active game in progress.",
-                statusCode: StatusCodes.Status409Conflict,
-                title: "Conflict");
-        }
-
-        if (entry.Status == "matched")
-        {
-            return Results.Ok(new
+            "conflict" => Results.Problem(detail: "Bot is already waiting in the queue or has an active game in progress.", statusCode: StatusCodes.Status409Conflict, title: "Conflict"),
+            "matched" => Results.Ok(new
             {
-                gameId = entry.GameId,
-                playerId = entry.PlayerId,
-                token = entry.Token
-            });
-        }
+                gameId = entry.GameId, playerId = entry.PlayerId, token = entry.Token
+            }),
+            _ => Results.Accepted($"/api/games/queue/{entry.QueueId}", new
+            {
+                queueId = entry.QueueId
+            })
+        };
 
         // 202 Accepted — bot is waiting in the queue
-        return Results.Accepted(
-            $"/api/games/queue/{entry.QueueId}",
-            new { queueId = entry.QueueId });
     }
 
     /// <summary>Polls a queue entry for matchmaking status.</summary>

--- a/src/ScrambleCoin.Api/Endpoints/TournamentEndpoints.cs
+++ b/src/ScrambleCoin.Api/Endpoints/TournamentEndpoints.cs
@@ -28,6 +28,15 @@ public static class TournamentEndpoints
                 "Bots can be registered via POST /api/tournament/{id}/participants.")
             .WithTags("Tournament");
 
+        // POST /api/tournament/{id}/join — bot self-registers (no admin key required)
+        app.MapPost("/api/tournament/{id:guid}/join", JoinTournament)
+            .WithName("JoinTournament")
+            .WithSummary("Self-register a bot for the tournament")
+            .WithDescription(
+                "Bots call this to register themselves before the tournament starts. " +
+                "No admin key required. Supply botId, botName, and lineup.")
+            .WithTags("Tournament");
+
         // POST /api/tournament/{id}/participants — register a bot
         app.MapPost("/api/tournament/{id:guid}/participants", AddParticipant)
             .WithName("AddTournamentParticipant")
@@ -114,6 +123,44 @@ public static class TournamentEndpoints
                 ct);
 
             return Results.Created($"/api/tournament/{result.TournamentId}", new { tournamentId = result.TournamentId });
+        }
+        catch (DomainException ex)
+        {
+            return Results.Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Bad Request");
+        }
+    }
+
+    /// <summary>Bot self-registers for the tournament. No admin key required.</summary>
+    private static async Task<IResult> JoinTournament(
+        Guid id,
+        AddParticipantRequest body,
+        ISender sender,
+        CancellationToken ct)
+    {
+        try
+        {
+            await sender.Send(
+                new AddTournamentParticipantCommand(id, body.BotId, body.BotName, body.Lineup),
+                ct);
+
+            return Results.NoContent();
+        }
+        catch (TournamentNotFoundException ex)
+        {
+            return Results.Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Not Found");
+        }
+        catch (TournamentInvalidStateException ex)
+        {
+            return Results.Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status409Conflict,
+                title: "Conflict");
         }
         catch (DomainException ex)
         {

--- a/src/ScrambleCoin.Api/Hubs/GameBroadcaster.cs
+++ b/src/ScrambleCoin.Api/Hubs/GameBroadcaster.cs
@@ -1,0 +1,85 @@
+using MediatR;
+using Microsoft.AspNetCore.SignalR;
+using ScrambleCoin.Application.Abstractions;
+using ScrambleCoin.Application.Games.GetBoardState;
+
+namespace ScrambleCoin.Api.Hubs;
+
+/// <summary>
+/// <see cref="IGameBroadcaster"/> implementation for the <c>ScrambleCoin.Api</c> host.
+/// Identical logic to the one in <c>ScrambleCoin.Web</c> but wired to
+/// <see cref="GameHub"/> (the Api project's own hub type).
+/// </summary>
+public sealed class GameBroadcaster : IGameBroadcaster
+{
+    private const string GameGroupPrefix   = "game-";
+    private const string PlayerGroupPrefix = "player-";
+
+    private readonly IHubContext<GameHub> _hubContext;
+    private readonly ISender _sender;
+
+    public GameBroadcaster(IHubContext<GameHub> hubContext, ISender sender)
+    {
+        _hubContext = hubContext;
+        _sender     = sender;
+    }
+
+    public async Task BroadcastBoardStateAsync(Guid gameId, CancellationToken ct = default)
+    {
+        var boardState = await _sender.Send(new GetSpectatorBoardStateQuery(gameId), ct);
+        await _hubContext.Clients.Group(GameGroupPrefix + gameId)
+            .SendAsync("BoardStateUpdated", boardState, ct);
+    }
+
+    public async Task BroadcastPhaseChangedAsync(
+        Guid gameId, int turn, string? previousPhase, string? newPhase,
+        CancellationToken ct = default)
+    {
+        await _hubContext.Clients.Group(GameGroupPrefix + gameId)
+            .SendAsync("PhaseChanged", new
+            {
+                GameId        = gameId,
+                Turn          = turn,
+                PreviousPhase = previousPhase,
+                NewPhase      = newPhase
+            }, ct);
+    }
+
+    public async Task BroadcastGameEndedAsync(
+        Guid gameId, int playerOneScore, int playerTwoScore, Guid? winnerId, bool isDraw,
+        CancellationToken ct = default)
+    {
+        await _hubContext.Clients.Group(GameGroupPrefix + gameId)
+            .SendAsync("GameEnded", new
+            {
+                GameId         = gameId,
+                PlayerOneScore = playerOneScore,
+                PlayerTwoScore = playerTwoScore,
+                WinnerId       = winnerId,
+                IsDraw         = isDraw
+            }, ct);
+    }
+
+    public async Task NotifyActivePlayersAsync(Guid gameId, CancellationToken ct = default)
+    {
+        var info = await _sender.Send(new GetGamePlayerIdsQuery(gameId), ct);
+
+        switch (info.Phase)
+        {
+            case "PlacePhase":
+                await SendActionRequiredAsync(gameId, info.PlayerOne, "PlacePhase", ct);
+                await SendActionRequiredAsync(gameId, info.PlayerTwo, "PlacePhase", ct);
+                break;
+
+            case "MovePhase" when info.ActiveMover is { } activeId:
+                await SendActionRequiredAsync(gameId, activeId, "MovePhase", ct);
+                break;
+        }
+    }
+
+    private Task SendActionRequiredAsync(Guid gameId, Guid playerId, string phase, CancellationToken ct)
+    {
+        var group = _hubContext.Clients.Group(PlayerGroupPrefix + gameId + "-" + playerId);
+        return group.SendAsync("ActionRequired", new { Phase = phase }, ct);
+    }
+}

--- a/src/ScrambleCoin.Api/Hubs/GameHub.cs
+++ b/src/ScrambleCoin.Api/Hubs/GameHub.cs
@@ -56,7 +56,8 @@ public sealed class GameHub : Hub
             };
 
             if (needsToAct)
-                await Clients.Caller.SendAsync("ActionRequired", new { Phase = info.Phase });
+                await Clients.Caller.SendAsync("ActionRequired", new {
+                    info.Phase });
         }
         catch
         {

--- a/src/ScrambleCoin.Api/Hubs/GameHub.cs
+++ b/src/ScrambleCoin.Api/Hubs/GameHub.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace ScrambleCoin.Api.Hubs;
+
+/// <summary>
+/// SignalR hub hosted by the <c>ScrambleCoin.Api</c> project.
+/// Identical in protocol to the one in <c>ScrambleCoin.Web</c> — same group names,
+/// same client-method names — so bots can connect to whichever host they target.
+/// </summary>
+public sealed class GameHub : Hub
+{
+    private const string GameGroupPrefix   = "game-";
+    private const string PlayerGroupPrefix = "player-";
+
+    /// <summary>Adds the caller to the spectator group for <paramref name="gameId"/>.</summary>
+    public async Task JoinGame(string gameId) =>
+        await Groups.AddToGroupAsync(Context.ConnectionId, GameGroupPrefix + gameId);
+
+    /// <summary>Removes the caller from the spectator group for <paramref name="gameId"/>.</summary>
+    public async Task LeaveGame(string gameId) =>
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, GameGroupPrefix + gameId);
+
+    /// <summary>
+    /// Registers the caller as an active player so they receive <c>ActionRequired</c>
+    /// events only when it is their turn to act.
+    /// </summary>
+    public async Task RegisterAsPlayer(string gameId, string playerId) =>
+        await Groups.AddToGroupAsync(
+            Context.ConnectionId,
+            PlayerGroupPrefix + gameId + "-" + playerId);
+}

--- a/src/ScrambleCoin.Api/Hubs/GameHub.cs
+++ b/src/ScrambleCoin.Api/Hubs/GameHub.cs
@@ -1,4 +1,6 @@
+using MediatR;
 using Microsoft.AspNetCore.SignalR;
+using ScrambleCoin.Application.Games.GetBoardState;
 
 namespace ScrambleCoin.Api.Hubs;
 
@@ -12,6 +14,13 @@ public sealed class GameHub : Hub
     private const string GameGroupPrefix   = "game-";
     private const string PlayerGroupPrefix = "player-";
 
+    private readonly ISender _sender;
+
+    public GameHub(ISender sender)
+    {
+        _sender = sender;
+    }
+
     /// <summary>Adds the caller to the spectator group for <paramref name="gameId"/>.</summary>
     public async Task JoinGame(string gameId) =>
         await Groups.AddToGroupAsync(Context.ConnectionId, GameGroupPrefix + gameId);
@@ -23,9 +32,35 @@ public sealed class GameHub : Hub
     /// <summary>
     /// Registers the caller as an active player so they receive <c>ActionRequired</c>
     /// events only when it is their turn to act.
+    /// A catch-up <c>ActionRequired</c> is sent immediately if the player needs to act right now,
+    /// so bots that connect after the initial event was broadcast don't stall.
     /// </summary>
-    public async Task RegisterAsPlayer(string gameId, string playerId) =>
+    public async Task RegisterAsPlayer(string gameId, string playerId)
+    {
+        if (!Guid.TryParse(gameId, out var gameGuid) || !Guid.TryParse(playerId, out var playerGuid))
+            return;
+
         await Groups.AddToGroupAsync(
             Context.ConnectionId,
             PlayerGroupPrefix + gameId + "-" + playerId);
+
+        // Catch-up: if the player needs to act right now, send ActionRequired immediately.
+        try
+        {
+            var info = await _sender.Send(new GetGamePlayerIdsQuery(gameGuid));
+            var needsToAct = info.Phase switch
+            {
+                "PlacePhase" => info.PlayerOne == playerGuid || info.PlayerTwo == playerGuid,
+                "MovePhase"  => info.ActiveMover == playerGuid,
+                _            => false
+            };
+
+            if (needsToAct)
+                await Clients.Caller.SendAsync("ActionRequired", new { Phase = info.Phase });
+        }
+        catch
+        {
+            // Best-effort catch-up — don't fail the registration itself.
+        }
+    }
 }

--- a/src/ScrambleCoin.Api/Program.cs
+++ b/src/ScrambleCoin.Api/Program.cs
@@ -50,7 +50,7 @@ builder.Services.AddMediatR(cfg =>
 
 // ── Application services ──────────────────────────────────────────────────────
 builder.Services.AddSingleton(Random.Shared);
-builder.Services.AddSingleton<ScrambleCoin.Application.Services.GameLockService>();
+builder.Services.AddSingleton<GameLockService>();
 builder.Services.AddSignalR();
 builder.Services.AddScoped<ScrambleCoin.Application.Abstractions.IGameBroadcaster,
     ScrambleCoin.Api.Hubs.GameBroadcaster>();

--- a/src/ScrambleCoin.Api/Program.cs
+++ b/src/ScrambleCoin.Api/Program.cs
@@ -50,9 +50,9 @@ builder.Services.AddMediatR(cfg =>
 
 // ── Application services ──────────────────────────────────────────────────────
 builder.Services.AddSingleton(Random.Shared);
-// No-op broadcaster: API host has no SignalR hub; the behaviour resolves without error.
+builder.Services.AddSignalR();
 builder.Services.AddScoped<ScrambleCoin.Application.Abstractions.IGameBroadcaster,
-    ScrambleCoin.Application.Abstractions.NullGameBroadcaster>();
+    ScrambleCoin.Api.Hubs.GameBroadcaster>();
 builder.Services.AddScoped<IGameRepository, GameRepository>();
 builder.Services.AddScoped<IBotRegistrationRepository, BotRegistrationRepository>();
 builder.Services.AddScoped<IVillainTreeRepository, VillainTreeRepository>();
@@ -164,6 +164,7 @@ app.MapGet("/health", async (Microsoft.Extensions.Diagnostics.HealthChecks.Healt
 app.MapGameEndpoints();
 app.MapSoloModeEndpoints();
 app.MapTournamentEndpoints();
+app.MapHub<ScrambleCoin.Api.Hubs.GameHub>("/hubs/game");
 
 app.Run();
 

--- a/src/ScrambleCoin.Api/Program.cs
+++ b/src/ScrambleCoin.Api/Program.cs
@@ -43,13 +43,14 @@ builder.Services.AddMediatR(cfg =>
 {
     cfg.RegisterServicesFromAssemblies(
         typeof(ScrambleCoin.Application.Games.CreateGame.CreateGameCommandHandler).Assembly);
-    // Register broadcast behaviour. The NullGameBroadcaster below is a no-op —
-    // spectators must target the ScrambleCoin.Web host for live SignalR updates.
+    // Serialization must wrap everything — register first so it is the outermost behaviour.
+    cfg.AddOpenBehavior(typeof(ScrambleCoin.Application.Behaviours.GameSerializationBehaviour<,>));
     cfg.AddOpenBehavior(typeof(ScrambleCoin.Application.Behaviours.SignalRBroadcastBehaviour<,>));
 });
 
 // ── Application services ──────────────────────────────────────────────────────
 builder.Services.AddSingleton(Random.Shared);
+builder.Services.AddSingleton<ScrambleCoin.Application.Services.GameLockService>();
 builder.Services.AddSignalR();
 builder.Services.AddScoped<ScrambleCoin.Application.Abstractions.IGameBroadcaster,
     ScrambleCoin.Api.Hubs.GameBroadcaster>();

--- a/src/ScrambleCoin.Application/Abstractions/IGameBroadcaster.cs
+++ b/src/ScrambleCoin.Application/Abstractions/IGameBroadcaster.cs
@@ -22,4 +22,15 @@ public interface IGameBroadcaster
     /// to all spectators watching <paramref name="gameId"/>.
     /// </summary>
     Task BroadcastGameEndedAsync(Guid gameId, int playerOneScore, int playerTwoScore, Guid? winnerId, bool isDraw, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sends an <c>ActionRequired</c> message to the player(s) who need to act right now.
+    /// <list type="bullet">
+    ///   <item>During <c>PlacePhase</c> — notifies <em>both</em> players (each must place or skip).</item>
+    ///   <item>During <c>MovePhase</c>  — notifies only the <em>active mover</em>.</item>
+    ///   <item>Other phases — no notification is sent.</item>
+    /// </list>
+    /// Bots register for these targeted messages by calling <c>RegisterAsPlayer</c> on the hub.
+    /// </summary>
+    Task NotifyActivePlayersAsync(Guid gameId, CancellationToken ct = default);
 }

--- a/src/ScrambleCoin.Application/Abstractions/NullGameBroadcaster.cs
+++ b/src/ScrambleCoin.Application/Abstractions/NullGameBroadcaster.cs
@@ -17,4 +17,6 @@ public sealed class NullGameBroadcaster : IGameBroadcaster
     public Task BroadcastPhaseChangedAsync(Guid gameId, int turn, string? previousPhase, string? newPhase, CancellationToken ct = default) => Task.CompletedTask;
 
     public Task BroadcastGameEndedAsync(Guid gameId, int playerOneScore, int playerTwoScore, Guid? winnerId, bool isDraw, CancellationToken ct = default) => Task.CompletedTask;
+
+    public Task NotifyActivePlayersAsync(Guid gameId, CancellationToken ct = default) => Task.CompletedTask;
 }

--- a/src/ScrambleCoin.Application/Behaviours/GameSerializationBehaviour.cs
+++ b/src/ScrambleCoin.Application/Behaviours/GameSerializationBehaviour.cs
@@ -1,0 +1,63 @@
+using MediatR;
+using ScrambleCoin.Application.Games;
+using ScrambleCoin.Application.Services;
+
+namespace ScrambleCoin.Application.Behaviours;
+
+/// <summary>
+/// MediatR pipeline behaviour that serializes concurrent mutations of the same game.
+/// <para>
+/// When two bots submit actions for the same game simultaneously, without this behaviour
+/// both requests read the same game state before either saves — the second write silently
+/// overwrites the first (lost-update race) and the phase never advances.
+/// </para>
+/// <para>
+/// This behaviour acquires a per-game <see cref="System.Threading.SemaphoreSlim"/> before
+/// calling the next handler, so only one <see cref="IGameStateChangingCommand"/> per game
+/// executes at a time. Villain commands dispatched from within a player command (solo mode)
+/// are detected via <see cref="AsyncLocal{T}"/> and skip re-acquisition to avoid deadlock.
+/// </para>
+/// </summary>
+public sealed class GameSerializationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    // Tracks which game IDs the current async call-chain already holds a lock for,
+    // so that re-entrant villain commands don't deadlock.
+    private static readonly AsyncLocal<HashSet<Guid>?> LockedGames = new();
+
+    private readonly GameLockService _lockService;
+
+    public GameSerializationBehaviour(GameLockService lockService)
+    {
+        _lockService = lockService;
+    }
+
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        if (request is not IGameStateChangingCommand gameCommand)
+            return await next(cancellationToken);
+
+        // Initialise the per-context set on first use.
+        LockedGames.Value ??= [];
+
+        // Re-entrant: already locked in this async chain (e.g. villain command inside player handler).
+        if (LockedGames.Value.Contains(gameCommand.GameId))
+            return await next(cancellationToken);
+
+        var semaphore = _lockService.GetLock(gameCommand.GameId);
+        await semaphore.WaitAsync(cancellationToken);
+        LockedGames.Value.Add(gameCommand.GameId);
+        try
+        {
+            return await next(cancellationToken);
+        }
+        finally
+        {
+            LockedGames.Value.Remove(gameCommand.GameId);
+            semaphore.Release();
+        }
+    }
+}

--- a/src/ScrambleCoin.Application/Behaviours/SignalRBroadcastBehaviour.cs
+++ b/src/ScrambleCoin.Application/Behaviours/SignalRBroadcastBehaviour.cs
@@ -41,6 +41,7 @@ public sealed class SignalRBroadcastBehaviour<TRequest, TResponse> : IPipelineBe
         try
         {
             await _broadcaster.BroadcastBoardStateAsync(gameCommand.GameId, cancellationToken);
+            await _broadcaster.NotifyActivePlayersAsync(gameCommand.GameId, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/ScrambleCoin.Application/Games/Admin/ActiveGameSummaryDto.cs
+++ b/src/ScrambleCoin.Application/Games/Admin/ActiveGameSummaryDto.cs
@@ -1,0 +1,23 @@
+namespace ScrambleCoin.Application.Games.Admin;
+
+/// <summary>
+/// Lightweight summary of a game for the admin monitoring panel.
+/// Returned by <see cref="GetAllActiveGamesQuery"/> without loading the full Game aggregate.
+/// </summary>
+/// <param name="GameId">Unique identifier of the game.</param>
+/// <param name="PlayerOne">Player-slot identifier of the first player.</param>
+/// <param name="PlayerTwo">Player-slot identifier of the second player.</param>
+/// <param name="Status">Human-readable game status string (e.g. "InProgress", "WaitingForBots").</param>
+/// <param name="TurnNumber">Current turn number (0 before the game starts).</param>
+/// <param name="Phase">Current phase name, or <c>null</c> when no phase is active.</param>
+/// <param name="ScorePlayerOne">Coin score for <see cref="PlayerOne"/>.</param>
+/// <param name="ScorePlayerTwo">Coin score for <see cref="PlayerTwo"/>.</param>
+public sealed record ActiveGameSummaryDto(
+    Guid GameId,
+    Guid PlayerOne,
+    Guid PlayerTwo,
+    string Status,
+    int TurnNumber,
+    string? Phase,
+    int ScorePlayerOne,
+    int ScorePlayerTwo);

--- a/src/ScrambleCoin.Application/Games/Admin/ActiveGameSummaryDto.cs
+++ b/src/ScrambleCoin.Application/Games/Admin/ActiveGameSummaryDto.cs
@@ -12,6 +12,7 @@ namespace ScrambleCoin.Application.Games.Admin;
 /// <param name="Phase">Current phase name, or <c>null</c> when no phase is active.</param>
 /// <param name="ScorePlayerOne">Coin score for <see cref="PlayerOne"/>.</param>
 /// <param name="ScorePlayerTwo">Coin score for <see cref="PlayerTwo"/>.</param>
+/// <param name="LastMoveAt">UTC timestamp of the last move recorded in this game.</param>
 public sealed record ActiveGameSummaryDto(
     Guid GameId,
     Guid PlayerOne,
@@ -20,4 +21,5 @@ public sealed record ActiveGameSummaryDto(
     int TurnNumber,
     string? Phase,
     int ScorePlayerOne,
-    int ScorePlayerTwo);
+    int ScorePlayerTwo,
+    DateTimeOffset LastMoveAt);

--- a/src/ScrambleCoin.Application/Games/Admin/ForceEndGameCommand.cs
+++ b/src/ScrambleCoin.Application/Games/Admin/ForceEndGameCommand.cs
@@ -1,0 +1,21 @@
+using MediatR;
+
+namespace ScrambleCoin.Application.Games.Admin;
+
+/// <summary>
+/// Command to force-end a stuck or timed-out game.
+/// <para>
+/// If the game is <c>InProgress</c>, <see cref="Domain.Entities.Game.End"/> is called
+/// and the winner is determined by the current coin scores — the timed-out bot will typically
+/// have fewer coins because it missed its moves.
+/// </para>
+/// <para>
+/// If the game is still <c>WaitingForBots</c>, the game is force-cancelled instead
+/// (no ranking points are awarded).
+/// </para>
+/// <para>
+/// Already-finished or cancelled games are silently ignored.
+/// </para>
+/// </summary>
+/// <param name="GameId">The identifier of the game to force-end.</param>
+public sealed record ForceEndGameCommand(Guid GameId) : IRequest;

--- a/src/ScrambleCoin.Application/Games/Admin/ForceEndGameCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/Admin/ForceEndGameCommandHandler.cs
@@ -1,0 +1,75 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Application.Notifications;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Events;
+
+namespace ScrambleCoin.Application.Games.Admin;
+
+/// <summary>
+/// Handles <see cref="ForceEndGameCommand"/>: loads the game, force-ends it, and
+/// publishes <see cref="GameFinished"/> so that ranking points and SignalR notifications
+/// are applied via the existing notification pipeline.
+/// </summary>
+public sealed class ForceEndGameCommandHandler : IRequestHandler<ForceEndGameCommand>
+{
+    private readonly IGameRepository _gameRepository;
+    private readonly IPublisher _publisher;
+    private readonly ILogger<ForceEndGameCommandHandler> _logger;
+
+    public ForceEndGameCommandHandler(
+        IGameRepository gameRepository,
+        IPublisher publisher,
+        ILogger<ForceEndGameCommandHandler> logger)
+    {
+        _gameRepository = gameRepository;
+        _publisher = publisher;
+        _logger = logger;
+    }
+
+    public async Task Handle(ForceEndGameCommand request, CancellationToken cancellationToken)
+    {
+        var game = await _gameRepository.GetByIdAsync(request.GameId, cancellationToken);
+
+        if (game.Status is GameStatus.Finished or GameStatus.Cancelled)
+        {
+            _logger.LogWarning(
+                "Admin requested ForceEnd for game {GameId} which is already {Status}. Skipping.",
+                request.GameId, game.Status);
+            return;
+        }
+
+        GameEnded? gameEndedEvent = null;
+
+        if (game.Status == GameStatus.InProgress)
+        {
+            // End the game by current coin scores.
+            // The timed-out bot will typically have fewer coins because it missed moves.
+            game.End();
+            gameEndedEvent = game.DomainEvents.OfType<GameEnded>().FirstOrDefault();
+        }
+        else
+        {
+            // WaitingForBots — cancel the lobby (no ranking points awarded).
+            game.ForceCancel();
+        }
+
+        // SaveAsync clears domain events — capture the event before saving.
+        await _gameRepository.SaveAsync(game, cancellationToken);
+
+        _logger.LogInformation(
+            "Admin force-ended game {GameId}. WinnerId={WinnerId}, IsDraw={IsDraw}.",
+            request.GameId,
+            gameEndedEvent?.WinnerId?.ToString() ?? "N/A",
+            gameEndedEvent?.IsDraw ?? false);
+
+        if (gameEndedEvent is not null)
+        {
+            // Trigger ranking-points award and SignalR broadcast via existing handlers.
+            await _publisher.Publish(
+                new GameFinished(game.Id, gameEndedEvent.WinnerId, gameEndedEvent.IsDraw),
+                cancellationToken);
+        }
+    }
+}

--- a/src/ScrambleCoin.Application/Games/Admin/GetAllActiveGamesQuery.cs
+++ b/src/ScrambleCoin.Application/Games/Admin/GetAllActiveGamesQuery.cs
@@ -1,0 +1,10 @@
+using MediatR;
+
+namespace ScrambleCoin.Application.Games.Admin;
+
+/// <summary>
+/// Query to retrieve summary information for all active games
+/// (status <c>InProgress</c> or <c>WaitingForBots</c>).
+/// Used by the admin dashboard to monitor live games.
+/// </summary>
+public sealed record GetAllActiveGamesQuery : IRequest<IReadOnlyList<ActiveGameSummaryDto>>;

--- a/src/ScrambleCoin.Application/Games/Admin/GetAllActiveGamesQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Games/Admin/GetAllActiveGamesQueryHandler.cs
@@ -1,0 +1,27 @@
+using MediatR;
+using ScrambleCoin.Application.Interfaces;
+
+namespace ScrambleCoin.Application.Games.Admin;
+
+/// <summary>
+/// Handles <see cref="GetAllActiveGamesQuery"/>: delegates to
+/// <see cref="IGameRepository.GetAllActiveAsync"/> to return lightweight game summaries
+/// without reconstructing full Game aggregates.
+/// </summary>
+public sealed class GetAllActiveGamesQueryHandler
+    : IRequestHandler<GetAllActiveGamesQuery, IReadOnlyList<ActiveGameSummaryDto>>
+{
+    private readonly IGameRepository _gameRepository;
+
+    public GetAllActiveGamesQueryHandler(IGameRepository gameRepository)
+    {
+        _gameRepository = gameRepository;
+    }
+
+    public Task<IReadOnlyList<ActiveGameSummaryDto>> Handle(
+        GetAllActiveGamesQuery request,
+        CancellationToken cancellationToken)
+    {
+        return _gameRepository.GetAllActiveAsync(cancellationToken);
+    }
+}

--- a/src/ScrambleCoin.Application/Games/GetBoardState/GetGamePlayerIdsQuery.cs
+++ b/src/ScrambleCoin.Application/Games/GetBoardState/GetGamePlayerIdsQuery.cs
@@ -1,0 +1,21 @@
+using MediatR;
+
+namespace ScrambleCoin.Application.Games.GetBoardState;
+
+/// <summary>
+/// Returns the two player IDs for a game together with its current phase and active mover.
+/// Used internally (e.g. by <c>GameBroadcaster</c>) to decide which player groups to
+/// send <c>ActionRequired</c> notifications to without fetching the full board state.
+/// </summary>
+public sealed record GetGamePlayerIdsQuery(Guid GameId) : IRequest<GamePlayerIdsDto>;
+
+/// <summary>Minimal game-state projection used for player-targeted SignalR notifications.</summary>
+/// <param name="PlayerOne">The first player's ID.</param>
+/// <param name="PlayerTwo">The second player's ID.</param>
+/// <param name="Phase">Current phase name ("CoinSpawn", "PlacePhase", "MovePhase"), or null.</param>
+/// <param name="ActiveMover">The player whose turn it is in MovePhase, or null outside MovePhase.</param>
+public sealed record GamePlayerIdsDto(
+    Guid PlayerOne,
+    Guid PlayerTwo,
+    string? Phase,
+    Guid? ActiveMover);

--- a/src/ScrambleCoin.Application/Games/GetBoardState/GetGamePlayerIdsQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Games/GetBoardState/GetGamePlayerIdsQueryHandler.cs
@@ -1,0 +1,29 @@
+using MediatR;
+using ScrambleCoin.Application.Interfaces;
+
+namespace ScrambleCoin.Application.Games.GetBoardState;
+
+/// <summary>
+/// Handles <see cref="GetGamePlayerIdsQuery"/>: loads the game and returns its two
+/// participant IDs, current phase, and active mover — without building the full board DTO.
+/// </summary>
+public sealed class GetGamePlayerIdsQueryHandler : IRequestHandler<GetGamePlayerIdsQuery, GamePlayerIdsDto>
+{
+    private readonly IGameRepository _gameRepository;
+
+    public GetGamePlayerIdsQueryHandler(IGameRepository gameRepository)
+    {
+        _gameRepository = gameRepository;
+    }
+
+    public async Task<GamePlayerIdsDto> Handle(GetGamePlayerIdsQuery request, CancellationToken cancellationToken)
+    {
+        var game = await _gameRepository.GetByIdAsync(request.GameId, cancellationToken);
+
+        return new GamePlayerIdsDto(
+            PlayerOne:   game.PlayerOne,
+            PlayerTwo:   game.PlayerTwo,
+            Phase:       game.CurrentPhase?.ToString(),
+            ActiveMover: game.MovePhaseActivePlayer);
+    }
+}

--- a/src/ScrambleCoin.Application/Games/JoinGame/JoinGameCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/JoinGame/JoinGameCommandHandler.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Application.Notifications;
 using DomainBotReg = ScrambleCoin.Domain.BotRegistrations.BotRegistration;
 using ScrambleCoin.Domain.Exceptions;
 using ScrambleCoin.Domain.Factories;
@@ -17,22 +18,25 @@ namespace ScrambleCoin.Application.Games.JoinGame;
 ///   <item>Builds the bot's lineup from piece names using <see cref="PieceFactory"/>.</item>
 ///   <item>Sets the lineup on the game via <c>game.SetLineup</c>.</item>
 ///   <item>Creates and persists a <see cref="BotRegistration"/> containing the bearer token.</item>
-///   <item>If both slots are now filled, calls <c>game.Start()</c>.</item>
+///   <item>If both slots are now filled, calls <c>game.Start()</c> and publishes <see cref="TurnRolledOver"/> to trigger coin spawning.</item>
 /// </list>
 /// </summary>
 public sealed class JoinGameCommandHandler : IRequestHandler<JoinGameCommand, JoinGameResult>
 {
     private readonly IGameRepository _gameRepository;
     private readonly IBotRegistrationRepository _botRegistrationRepository;
+    private readonly IPublisher _publisher;
     private readonly ILogger<JoinGameCommandHandler> _logger;
 
     public JoinGameCommandHandler(
         IGameRepository gameRepository,
         IBotRegistrationRepository botRegistrationRepository,
+        IPublisher publisher,
         ILogger<JoinGameCommandHandler> logger)
     {
         _gameRepository = gameRepository;
         _botRegistrationRepository = botRegistrationRepository;
+        _publisher = publisher;
         _logger = logger;
     }
 
@@ -57,10 +61,11 @@ public sealed class JoinGameCommandHandler : IRequestHandler<JoinGameCommand, Jo
         var lineup = new Lineup(pieces);
         game.SetLineup(assignedPlayerId, lineup);
 
-        // If both lineups are now set, start the game.
+        var gameJustStarted = false;
         if (game.LineupPlayerOne is not null && game.LineupPlayerTwo is not null)
         {
             game.Start();
+            gameJustStarted = true;
             _logger.LogInformation("Game {GameId} started — both players joined. BotId={BotId} Turn={Turn}", game.Id, assignedPlayerId, game.TurnNumber);
         }
 
@@ -76,6 +81,10 @@ public sealed class JoinGameCommandHandler : IRequestHandler<JoinGameCommand, Jo
             game.Id, assignedPlayerId,
             assignedPlayerId == game.PlayerOne ? "PlayerOne" : "PlayerTwo",
             game.TurnNumber);
+
+        // Trigger coin spawn for turn 1 AFTER saving so the handler has a consistent DB state.
+        if (gameJustStarted)
+            await _publisher.Publish(new TurnRolledOver(game.Id), cancellationToken);
 
         return new JoinGameResult(assignedPlayerId, token);
     }

--- a/src/ScrambleCoin.Application/Games/Matchmaking/StartMatchCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/Matchmaking/StartMatchCommandHandler.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Application.Notifications;
 using ScrambleCoin.Domain.Entities;
 using ScrambleCoin.Domain.Factories;
 using ScrambleCoin.Domain.ValueObjects;
@@ -11,24 +12,28 @@ namespace ScrambleCoin.Application.Games.Matchmaking;
 
 /// <summary>
 /// Handles <see cref="StartMatchCommand"/>: creates a game shell, assigns both bot lineups,
-/// starts the game, persists the game and both bot registrations in one atomic operation.
+/// starts the game, persists the game and both bot registrations in one atomic operation,
+/// then publishes <see cref="TurnRolledOver"/> to trigger coin spawning for turn 1.
 /// </summary>
 public sealed class StartMatchCommandHandler : IRequestHandler<StartMatchCommand, StartMatchResult>
 {
     private readonly IGameRepository _gameRepository;
     private readonly IBotRegistrationRepository _botRegistrationRepository;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IPublisher _publisher;
     private readonly ILogger<StartMatchCommandHandler> _logger;
 
     public StartMatchCommandHandler(
         IGameRepository gameRepository,
         IBotRegistrationRepository botRegistrationRepository,
         IUnitOfWork unitOfWork,
+        IPublisher publisher,
         ILogger<StartMatchCommandHandler> logger)
     {
         _gameRepository = gameRepository;
         _botRegistrationRepository = botRegistrationRepository;
         _unitOfWork = unitOfWork;
+        _publisher = publisher;
         _logger = logger;
     }
 
@@ -53,7 +58,7 @@ public sealed class StartMatchCommandHandler : IRequestHandler<StartMatchCommand
         var regOne = new DomainBotReg(tokenOne, game.PlayerOne, game.Id);
         var regTwo = new DomainBotReg(tokenTwo, game.PlayerTwo, game.Id);
 
-        // Stage all changes on the shared DbContext, then commit once (Fix 4).
+        // Stage all changes on the shared DbContext, then commit once.
         await _gameRepository.StageAsync(game, cancellationToken);
         await _botRegistrationRepository.StageAsync(regOne, cancellationToken);
         await _botRegistrationRepository.StageAsync(regTwo, cancellationToken);
@@ -65,6 +70,9 @@ public sealed class StartMatchCommandHandler : IRequestHandler<StartMatchCommand
         _logger.LogInformation(
             "Match started via StartMatchCommand: GameId={GameId}, P1={PlayerOne}, P2={PlayerTwo}",
             game.Id, game.PlayerOne, game.PlayerTwo);
+
+        // Trigger coin spawn for turn 1 AFTER saving so the handler has a consistent DB state.
+        await _publisher.Publish(new TurnRolledOver(game.Id), cancellationToken);
 
         return new StartMatchResult(
             game.Id,

--- a/src/ScrambleCoin.Application/Interfaces/IBotUnlocksRepository.cs
+++ b/src/ScrambleCoin.Application/Interfaces/IBotUnlocksRepository.cs
@@ -22,4 +22,10 @@ public interface IBotUnlocksRepository
 
     /// <summary>Checks if a bot has already defeated a specific villain.</summary>
     Task<bool> HasDefeatedVillainAsync(Guid botId, string villainId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all bot-unlock records across every bot, used by the admin panel
+    /// to render the global solo-mode progress view.
+    /// </summary>
+    Task<IEnumerable<BotUnlock>> GetAllAsync(CancellationToken cancellationToken = default);
 }

--- a/src/ScrambleCoin.Application/Interfaces/IGameRepository.cs
+++ b/src/ScrambleCoin.Application/Interfaces/IGameRepository.cs
@@ -1,3 +1,4 @@
+using ScrambleCoin.Application.Games.Admin;
 using ScrambleCoin.Domain.Entities;
 
 namespace ScrambleCoin.Application.Interfaces;
@@ -26,4 +27,11 @@ public interface IGameRepository
     /// <param name="playerId">The player-slot identifier to check.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     public Task<bool> HasActiveGameAsync(Guid playerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns lightweight summaries of all games that are currently
+    /// <c>InProgress</c> or <c>WaitingForBots</c>, without reconstructing full Game aggregates.
+    /// Used by the admin panel for live game monitoring.
+    /// </summary>
+    public Task<IReadOnlyList<ActiveGameSummaryDto>> GetAllActiveAsync(CancellationToken cancellationToken = default);
 }

--- a/src/ScrambleCoin.Application/Notifications/BroadcastGameEndedOnFinishedHandler.cs
+++ b/src/ScrambleCoin.Application/Notifications/BroadcastGameEndedOnFinishedHandler.cs
@@ -1,15 +1,15 @@
 using MediatR;
+using Microsoft.Extensions.Logging;
 using ScrambleCoin.Application.Abstractions;
 using ScrambleCoin.Application.Interfaces;
-using ScrambleCoin.Application.Notifications;
 
-namespace ScrambleCoin.Web.Notifications;
+namespace ScrambleCoin.Application.Notifications;
 
 /// <summary>
 /// Reacts to a <see cref="GameFinished"/> notification by broadcasting the <c>GameEnded</c>
 /// SignalR event with final scores and winner info to all spectators watching that game.
-/// Lives in the Web layer so it can depend on <see cref="IGameBroadcaster"/> without
-/// introducing a SignalR dependency in the Application layer.
+/// Lives in the Application layer because it only depends on Application abstractions
+/// (<see cref="IGameBroadcaster"/> and <see cref="IGameRepository"/>) — no SignalR dependency here.
 /// </summary>
 public sealed class BroadcastGameEndedOnFinishedHandler : INotificationHandler<GameFinished>
 {

--- a/src/ScrambleCoin.Application/Notifications/BroadcastPhaseChangedHandler.cs
+++ b/src/ScrambleCoin.Application/Notifications/BroadcastPhaseChangedHandler.cs
@@ -1,15 +1,21 @@
 using MediatR;
+using Microsoft.Extensions.Logging;
 using ScrambleCoin.Application.Abstractions;
-using ScrambleCoin.Application.Notifications;
 
-namespace ScrambleCoin.Web.Notifications;
+namespace ScrambleCoin.Application.Notifications;
 
 /// <summary>
 /// Reacts to a <see cref="TurnPhaseChangedNotification"/> by broadcasting the <c>PhaseChanged</c>
 /// SignalR event to all spectators watching that game.
-/// Lives in the Web layer so it can depend on <see cref="IGameBroadcaster"/> without
-/// introducing a SignalR dependency in the Application layer.
+/// Lives in the Application layer because it only depends on <see cref="IGameBroadcaster"/>,
+/// which is an Application abstraction — no SignalR dependency here.
 /// </summary>
+/// <remarks>
+/// <see cref="Behaviours.SignalRBroadcastBehaviour{TRequest,TResponse}"/> already calls
+/// <see cref="IGameBroadcaster.NotifyActivePlayersAsync"/> after every
+/// <see cref="IGameStateChangingCommand"/>, so this handler deliberately does NOT repeat
+/// that call to avoid duplicate <c>ActionRequired</c> events.
+/// </remarks>
 public sealed class BroadcastPhaseChangedHandler : INotificationHandler<TurnPhaseChangedNotification>
 {
     private readonly IGameBroadcaster _broadcaster;
@@ -33,13 +39,6 @@ public sealed class BroadcastPhaseChangedHandler : INotificationHandler<TurnPhas
                 previousPhase: notification.PreviousPhase,
                 newPhase: notification.NewPhase,
                 ct: cancellationToken);
-
-            // Notify the player(s) who need to act in the new phase.
-            // PlacePhase: both players must place/skip → notify both.
-            // MovePhase:  the initial active mover → notify them.
-            // null / CoinSpawn: no player action needed.
-            if (notification.NewPhase is "PlacePhase" or "MovePhase")
-                await _broadcaster.NotifyActivePlayersAsync(notification.GameId, cancellationToken);
 
             _logger.LogInformation(
                 "Broadcast PhaseChanged for game {GameId}: turn {Turn}, {Previous} → {New}",

--- a/src/ScrambleCoin.Application/Ranking/GetAllBotsProgress/BotProgressDto.cs
+++ b/src/ScrambleCoin.Application/Ranking/GetAllBotsProgress/BotProgressDto.cs
@@ -1,0 +1,14 @@
+namespace ScrambleCoin.Application.Ranking.GetAllBotsProgress;
+
+/// <summary>
+/// Summary of a single bot's solo-mode (villain-path) progress.
+/// </summary>
+/// <param name="BotId">Unique bot identifier.</param>
+/// <param name="BotName">Bot display name (from ranking track, or short ID if unavailable).</param>
+/// <param name="VillainsDefeated">Total number of distinct villains this bot has defeated.</param>
+/// <param name="PiecesUnlocked">Total number of pieces unlocked via villain defeats.</param>
+public sealed record BotProgressDto(
+    Guid BotId,
+    string BotName,
+    int VillainsDefeated,
+    int PiecesUnlocked);

--- a/src/ScrambleCoin.Application/Ranking/GetAllBotsProgress/GetAllBotsProgressQuery.cs
+++ b/src/ScrambleCoin.Application/Ranking/GetAllBotsProgress/GetAllBotsProgressQuery.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace ScrambleCoin.Application.Ranking.GetAllBotsProgress;
+
+/// <summary>
+/// Query to retrieve solo-mode villain-path progress for every bot that has played solo mode.
+/// Results are ordered by villains defeated descending.
+/// </summary>
+public sealed record GetAllBotsProgressQuery : IRequest<IReadOnlyList<BotProgressDto>>;

--- a/src/ScrambleCoin.Application/Ranking/GetAllBotsProgress/GetAllBotsProgressQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Ranking/GetAllBotsProgress/GetAllBotsProgressQueryHandler.cs
@@ -1,0 +1,62 @@
+using MediatR;
+using ScrambleCoin.Application.Interfaces;
+
+namespace ScrambleCoin.Application.Ranking.GetAllBotsProgress;
+
+/// <summary>
+/// Handles <see cref="GetAllBotsProgressQuery"/>: aggregates all bot villain-defeat records
+/// and joins them with ranking-track data to produce per-bot progress summaries.
+/// </summary>
+public sealed class GetAllBotsProgressQueryHandler
+    : IRequestHandler<GetAllBotsProgressQuery, IReadOnlyList<BotProgressDto>>
+{
+    private readonly IBotUnlocksRepository _botUnlocksRepository;
+    private readonly IRankingRepository _rankingRepository;
+
+    public GetAllBotsProgressQueryHandler(
+        IBotUnlocksRepository botUnlocksRepository,
+        IRankingRepository rankingRepository)
+    {
+        _botUnlocksRepository = botUnlocksRepository;
+        _rankingRepository = rankingRepository;
+    }
+
+    public async Task<IReadOnlyList<BotProgressDto>> Handle(
+        GetAllBotsProgressQuery request,
+        CancellationToken cancellationToken)
+    {
+        // Load all defeat records and ranking tracks in parallel.
+        var allUnlocksTask  = _botUnlocksRepository.GetAllAsync(cancellationToken);
+        var rankingTrackTask = _rankingRepository.GetAllAsync(cancellationToken);
+
+        await Task.WhenAll(allUnlocksTask, rankingTrackTask);
+
+        var allUnlocks    = allUnlocksTask.Result;
+        var rankingTracks = rankingTrackTask.Result;
+
+        // Build a BotId → BotName lookup from ranking tracks.
+        var botNames = rankingTracks.ToDictionary(t => t.BotId, t => t.BotName);
+
+        // Group defeat records by BotId.
+        var grouped = allUnlocks
+            .GroupBy(u => u.BotId)
+            .Select(g =>
+            {
+                var botId = g.Key;
+                var botName = botNames.TryGetValue(botId, out var name)
+                    ? name
+                    : botId.ToString()[..8] + "…";
+
+                var villainsDefeated = g.Select(u => u.VillainId).Distinct().Count();
+                var piecesUnlocked   = g.Count(u => !string.IsNullOrEmpty(u.UnlockedPieceId));
+
+                return new BotProgressDto(botId, botName, villainsDefeated, piecesUnlocked);
+            })
+            .OrderByDescending(p => p.VillainsDefeated)
+            .ThenByDescending(p => p.PiecesUnlocked)
+            .ToList()
+            .AsReadOnly();
+
+        return grouped;
+    }
+}

--- a/src/ScrambleCoin.Application/Ranking/GetAllBotsProgress/GetAllBotsProgressQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Ranking/GetAllBotsProgress/GetAllBotsProgressQueryHandler.cs
@@ -25,14 +25,10 @@ public sealed class GetAllBotsProgressQueryHandler
         GetAllBotsProgressQuery request,
         CancellationToken cancellationToken)
     {
-        // Load all defeat records and ranking tracks in parallel.
-        var allUnlocksTask  = _botUnlocksRepository.GetAllAsync(cancellationToken);
-        var rankingTrackTask = _rankingRepository.GetAllAsync(cancellationToken);
-
-        await Task.WhenAll(allUnlocksTask, rankingTrackTask);
-
-        var allUnlocks    = allUnlocksTask.Result;
-        var rankingTracks = rankingTrackTask.Result;
+        // Load all defeat records and ranking tracks sequentially to avoid a concurrent
+        // DbContext operation (both repositories share the same scoped DbContext instance).
+        var allUnlocks    = await _botUnlocksRepository.GetAllAsync(cancellationToken);
+        var rankingTracks = await _rankingRepository.GetAllAsync(cancellationToken);
 
         // Build a BotId → BotName lookup from ranking tracks.
         var botNames = rankingTracks.ToDictionary(t => t.BotId, t => t.BotName);

--- a/src/ScrambleCoin.Application/Services/GameLockService.cs
+++ b/src/ScrambleCoin.Application/Services/GameLockService.cs
@@ -1,0 +1,16 @@
+using System.Collections.Concurrent;
+
+namespace ScrambleCoin.Application.Services;
+
+/// <summary>
+/// Singleton service that provides per-game <see cref="SemaphoreSlim"/> locks.
+/// Used by <c>GameSerializationBehaviour</c> to prevent concurrent mutations of the same game.
+/// </summary>
+public sealed class GameLockService
+{
+    private readonly ConcurrentDictionary<Guid, SemaphoreSlim> _locks = new();
+
+    /// <summary>Returns the semaphore for the given game, creating it on first access.</summary>
+    public SemaphoreSlim GetLock(Guid gameId)
+        => _locks.GetOrAdd(gameId, _ => new SemaphoreSlim(1, 1));
+}

--- a/src/ScrambleCoin.Application/Tournament/GetAllTournaments/GetAllTournamentsQuery.cs
+++ b/src/ScrambleCoin.Application/Tournament/GetAllTournaments/GetAllTournamentsQuery.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace ScrambleCoin.Application.Tournament.GetAllTournaments;
+
+/// <summary>
+/// Query to retrieve a lightweight summary of every tournament in the system.
+/// Results are ordered by <c>CreatedAtUtc</c> descending (newest first).
+/// </summary>
+public sealed record GetAllTournamentsQuery : IRequest<IReadOnlyList<TournamentSummaryDto>>;

--- a/src/ScrambleCoin.Application/Tournament/GetAllTournaments/GetAllTournamentsQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Tournament/GetAllTournaments/GetAllTournamentsQueryHandler.cs
@@ -1,0 +1,37 @@
+using MediatR;
+
+namespace ScrambleCoin.Application.Tournament.GetAllTournaments;
+
+/// <summary>
+/// Handles <see cref="GetAllTournamentsQuery"/>: loads all tournaments via the repository
+/// and projects them to lightweight <see cref="TournamentSummaryDto"/> objects.
+/// </summary>
+public sealed class GetAllTournamentsQueryHandler
+    : IRequestHandler<GetAllTournamentsQuery, IReadOnlyList<TournamentSummaryDto>>
+{
+    private readonly ITournamentRepository _tournamentRepository;
+
+    public GetAllTournamentsQueryHandler(ITournamentRepository tournamentRepository)
+    {
+        _tournamentRepository = tournamentRepository;
+    }
+
+    public async Task<IReadOnlyList<TournamentSummaryDto>> Handle(
+        GetAllTournamentsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var tournaments = await _tournamentRepository.GetAllAsync(cancellationToken);
+
+        return tournaments
+            .OrderByDescending(t => t.CreatedAtUtc)
+            .Select(t => new TournamentSummaryDto(
+                TournamentId:     t.Id,
+                Name:             t.Name,
+                Status:           t.Status.ToString(),
+                ParticipantCount: t.Participants.Count,
+                MaxParticipants:  t.MaxParticipants,
+                CreatedAtUtc:     t.CreatedAtUtc))
+            .ToList()
+            .AsReadOnly();
+    }
+}

--- a/src/ScrambleCoin.Application/Tournament/GetAllTournaments/TournamentSummaryDto.cs
+++ b/src/ScrambleCoin.Application/Tournament/GetAllTournaments/TournamentSummaryDto.cs
@@ -1,0 +1,18 @@
+namespace ScrambleCoin.Application.Tournament.GetAllTournaments;
+
+/// <summary>
+/// Lightweight summary of a tournament for the admin panel list.
+/// </summary>
+/// <param name="TournamentId">Unique identifier of the tournament.</param>
+/// <param name="Name">Human-readable tournament name.</param>
+/// <param name="Status">Current lifecycle status (e.g. "Pending", "GroupStage", "Completed").</param>
+/// <param name="ParticipantCount">Number of bots currently registered.</param>
+/// <param name="MaxParticipants">Maximum allowed participants.</param>
+/// <param name="CreatedAtUtc">UTC creation timestamp.</param>
+public sealed record TournamentSummaryDto(
+    Guid TournamentId,
+    string Name,
+    string Status,
+    int ParticipantCount,
+    int MaxParticipants,
+    DateTimeOffset CreatedAtUtc);

--- a/src/ScrambleCoin.Application/Tournament/GetBotGames/GetBotGamesQuery.cs
+++ b/src/ScrambleCoin.Application/Tournament/GetBotGames/GetBotGamesQuery.cs
@@ -18,9 +18,11 @@ public sealed record GetBotGamesQuery(Guid TournamentId, Guid BotId)
 /// <param name="Round">Round number — always <c>null</c> for group-stage matches.</param>
 /// <param name="GameId">The game identifier to use on the game REST endpoints.</param>
 /// <param name="Token">This bot's authentication token for submitting moves.</param>
+/// <param name="PlayerId">This bot's in-game player-slot ID (used to check whose turn it is).</param>
 public sealed record BotGameDto(
     Guid MatchId,
     string Stage,
     int? Round,
     Guid GameId,
-    Guid Token);
+    Guid Token,
+    Guid PlayerId);

--- a/src/ScrambleCoin.Application/Tournament/GetBotGames/GetBotGamesQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Tournament/GetBotGames/GetBotGamesQueryHandler.cs
@@ -27,12 +27,14 @@ public sealed class GetBotGamesQueryHandler : IRequestHandler<GetBotGamesQuery, 
         {
             if (!match.GameId.HasValue) continue;
 
-            var token = match.BotOne == request.BotId ? match.BotOneToken
-                        : match.BotTwo == request.BotId ? match.BotTwoToken
-                        : null;
+            var (token, playerId) = match.BotOne == request.BotId
+                ? (match.BotOneToken, match.BotOnePlayerId)
+                : match.BotTwo == request.BotId
+                    ? (match.BotTwoToken, match.BotTwoPlayerId)
+                    : (null, null);
 
-            if (token.HasValue)
-                results.Add(new BotGameDto(match.Id, "Group", null, match.GameId.Value, token.Value));
+            if (token.HasValue && playerId.HasValue)
+                results.Add(new BotGameDto(match.Id, "Group", null, match.GameId.Value, token.Value, playerId.Value));
         }
 
         // ── Knockout matches ──────────────────────────────────────────────────
@@ -40,12 +42,14 @@ public sealed class GetBotGamesQueryHandler : IRequestHandler<GetBotGamesQuery, 
         {
             if (!match.GameId.HasValue) continue;
 
-            var token = match.BotOne == request.BotId ? match.BotOneToken
-                        : match.BotTwo == request.BotId ? match.BotTwoToken
-                        : null;
+            var (token, playerId) = match.BotOne == request.BotId
+                ? (match.BotOneToken, match.BotOnePlayerId)
+                : match.BotTwo == request.BotId
+                    ? (match.BotTwoToken, match.BotTwoPlayerId)
+                    : (null, null);
 
-            if (token.HasValue)
-                results.Add(new BotGameDto(match.Id, "Knockout", match.Round, match.GameId.Value, token.Value));
+            if (token.HasValue && playerId.HasValue)
+                results.Add(new BotGameDto(match.Id, "Knockout", match.Round, match.GameId.Value, token.Value, playerId.Value));
         }
 
         return results.AsReadOnly();

--- a/src/ScrambleCoin.Application/Tournament/GetBotGames/GetBotGamesQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Tournament/GetBotGames/GetBotGamesQueryHandler.cs
@@ -1,24 +1,34 @@
 using MediatR;
+using ScrambleCoin.Application.Tournament.GetBracket;
 
 namespace ScrambleCoin.Application.Tournament.GetBotGames;
 
 /// <summary>
-/// Handles <see cref="GetBotGamesQuery"/>: collects all matches (group and knockout)
-/// for a specific bot and returns the game ID and token pairs so the bot can submit moves.
+/// Handles <see cref="GetBotGamesQuery"/>: lazily advances the tournament bracket
+/// (same as <see cref="GetTournamentBracketQuery"/>) then returns the bot's game IDs and tokens.
+/// This ensures bots polling for games will naturally trigger group→knockout advancement
+/// without needing a separate bracket call.
 /// </summary>
 public sealed class GetBotGamesQueryHandler : IRequestHandler<GetBotGamesQuery, IReadOnlyList<BotGameDto>>
 {
     private readonly ITournamentRepository _tournamentRepository;
+    private readonly ISender _sender;
 
-    public GetBotGamesQueryHandler(ITournamentRepository tournamentRepository)
+    public GetBotGamesQueryHandler(ITournamentRepository tournamentRepository, ISender sender)
     {
         _tournamentRepository = tournamentRepository;
+        _sender = sender;
     }
-
     public async Task<IReadOnlyList<BotGameDto>> Handle(
         GetBotGamesQuery request, CancellationToken cancellationToken)
     {
-        var tournament = await _tournamentRepository.GetByIdAsync(request.TournamentId, cancellationToken);
+        // Trigger lazy bracket advancement (creates knockout games when group stage is done).
+        // This is idempotent — safe to call on every poll.
+        await _sender.Send(new GetTournamentBracketQuery(request.TournamentId), cancellationToken);
+
+        // Reload fresh from DB — the bracket query may have committed new game assignments,
+        // and FindAsync would otherwise return the stale identity-map entity.
+        var tournament = await _tournamentRepository.ReloadAsync(request.TournamentId, cancellationToken);
 
         var results = new List<BotGameDto>();
 

--- a/src/ScrambleCoin.Application/Tournament/GetBracket/GetTournamentBracketQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Tournament/GetBracket/GetTournamentBracketQueryHandler.cs
@@ -224,6 +224,11 @@ public sealed class GetTournamentBracketQueryHandler : IRequestHandler<GetTourna
 
     private static TournamentBracketDto BuildDto(DomainTournament tournament)
     {
+        var participants = tournament.Participants
+            .Select(p => new ParticipantDto(p.BotId, p.BotName))
+            .ToList()
+            .AsReadOnly();
+
         var groupDtos = tournament.GroupMatches.Select(m => new GroupMatchDto(
             MatchId: m.Id,
             BotOne: m.BotOne,
@@ -257,6 +262,7 @@ public sealed class GetTournamentBracketQueryHandler : IRequestHandler<GetTourna
             tournament.Name,
             tournament.Status.ToString(),
             tournament.WinnerId,
+            participants,
             groupDtos.AsReadOnly(),
             knockoutRounds.AsReadOnly());
     }

--- a/src/ScrambleCoin.Application/Tournament/GetBracket/GetTournamentBracketQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Tournament/GetBracket/GetTournamentBracketQueryHandler.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Application.Notifications;
 using ScrambleCoin.Domain.Enums;
 using ScrambleCoin.Domain.Entities;
 using DomainTournament = ScrambleCoin.Domain.Tournaments.Tournament;
@@ -19,6 +20,7 @@ public sealed class GetTournamentBracketQueryHandler : IRequestHandler<GetTourna
     private readonly IGameRepository _gameRepository;
     private readonly IBotRegistrationRepository _botRegistrationRepository;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IPublisher _publisher;
     private readonly ILogger<GetTournamentBracketQueryHandler> _logger;
 
     public GetTournamentBracketQueryHandler(
@@ -26,12 +28,14 @@ public sealed class GetTournamentBracketQueryHandler : IRequestHandler<GetTourna
         IGameRepository gameRepository,
         IBotRegistrationRepository botRegistrationRepository,
         IUnitOfWork unitOfWork,
+        IPublisher publisher,
         ILogger<GetTournamentBracketQueryHandler> logger)
     {
         _tournamentRepository = tournamentRepository;
         _gameRepository = gameRepository;
         _botRegistrationRepository = botRegistrationRepository;
         _unitOfWork = unitOfWork;
+        _publisher = publisher;
         _logger = logger;
     }
 
@@ -40,6 +44,7 @@ public sealed class GetTournamentBracketQueryHandler : IRequestHandler<GetTourna
         var tournament = await _tournamentRepository.GetByIdAsync(request.TournamentId, cancellationToken);
 
         var dirty = false;
+        var newGameIds = new List<Guid>();
 
         // ── Group stage sync ──────────────────────────────────────────────────
         if (tournament.Status == TournamentStatus.GroupStage)
@@ -56,14 +61,14 @@ public sealed class GetTournamentBracketQueryHandler : IRequestHandler<GetTourna
                 dirty = true;
 
                 // Create games for round 1 knockout matches
-                await CreateKnockoutGamesForCurrentRoundAsync(tournament, 1, cancellationToken);
+                await CreateKnockoutGamesForCurrentRoundAsync(tournament, 1, newGameIds, cancellationToken);
             }
         }
 
         // ── Knockout stage sync ───────────────────────────────────────────────
         if (tournament.Status == TournamentStatus.KnockoutStage)
         {
-            var knockoutDirty = await SyncKnockoutResultsAsync(tournament, cancellationToken);
+            var knockoutDirty = await SyncKnockoutResultsAsync(tournament, newGameIds, cancellationToken);
             dirty = dirty || knockoutDirty;
         }
 
@@ -77,13 +82,19 @@ public sealed class GetTournamentBracketQueryHandler : IRequestHandler<GetTourna
             catch (ConcurrencyConflictException)
             {
                 // A concurrent request already committed the same state transition.
-                // Reload the now-current tournament and return it without retrying.
+                // Reload fresh from DB (bypassing the identity map which still holds stale data).
                 _logger.LogWarning(
                     "Tournament {TournamentId}: concurrency conflict on bracket sync. Reloading current state.",
                     tournament.Id);
-                tournament = await _tournamentRepository.GetByIdAsync(request.TournamentId, cancellationToken);
+                tournament = await _tournamentRepository.ReloadAsync(request.TournamentId, cancellationToken);
+                newGameIds.Clear(); // other request already published TurnRolledOver for those games
             }
         }
+
+        // Trigger coin spawn for each newly created knockout game so it advances
+        // from CoinSpawn → PlacePhase and bots receive an ActionRequired event.
+        foreach (var gameId in newGameIds)
+            await _publisher.Publish(new TurnRolledOver(gameId), cancellationToken);
 
         return BuildDto(tournament);
     }
@@ -118,7 +129,7 @@ public sealed class GetTournamentBracketQueryHandler : IRequestHandler<GetTourna
         return dirty;
     }
 
-    private async Task<bool> SyncKnockoutResultsAsync(DomainTournament tournament, CancellationToken ct)
+    private async Task<bool> SyncKnockoutResultsAsync(DomainTournament tournament, List<Guid> newGameIds, CancellationToken ct)
     {
         var dirty = false;
 
@@ -160,7 +171,7 @@ public sealed class GetTournamentBracketQueryHandler : IRequestHandler<GetTourna
             var roundComplete = roundMatches.All(m => m.IsCompleted);
             if (roundComplete && round < maxRound)
             {
-                await CreateKnockoutGamesForCurrentRoundAsync(tournament, round + 1, ct);
+                await CreateKnockoutGamesForCurrentRoundAsync(tournament, round + 1, newGameIds, ct);
                 dirty = true;
             }
         }
@@ -171,6 +182,7 @@ public sealed class GetTournamentBracketQueryHandler : IRequestHandler<GetTourna
     private async Task CreateKnockoutGamesForCurrentRoundAsync(
         DomainTournament tournament,
         int round,
+        List<Guid> newGameIds,
         CancellationToken ct)
     {
         var participantMap = tournament.Participants.ToDictionary(p => p.BotId);
@@ -207,6 +219,8 @@ public sealed class GetTournamentBracketQueryHandler : IRequestHandler<GetTourna
             var regTwo = new Domain.BotRegistrations.BotRegistration(botTwoToken, botTwoPlayerId, gameId);
             await _botRegistrationRepository.StageAsync(regOne, ct);
             await _botRegistrationRepository.StageAsync(regTwo, ct);
+
+            newGameIds.Add(gameId);
 
             _logger.LogInformation(
                 "Tournament {TournamentId}: knockout R{Round} match {MatchId} game {GameId} created.",

--- a/src/ScrambleCoin.Application/Tournament/GetBracket/GetTournamentBracketQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Tournament/GetBracket/GetTournamentBracketQueryHandler.cs
@@ -169,11 +169,11 @@ public sealed class GetTournamentBracketQueryHandler : IRequestHandler<GetTourna
 
             // If all matches in this round are now complete, create games for the next round
             var roundComplete = roundMatches.All(m => m.IsCompleted);
-            if (roundComplete && round < maxRound)
-            {
-                await CreateKnockoutGamesForCurrentRoundAsync(tournament, round + 1, newGameIds, ct);
-                dirty = true;
-            }
+            if (!roundComplete || round >= maxRound)
+                continue;
+            
+            await CreateKnockoutGamesForCurrentRoundAsync(tournament, round + 1, newGameIds, ct);
+            dirty = true;
         }
 
         return dirty;

--- a/src/ScrambleCoin.Application/Tournament/GetBracket/TournamentBracketDto.cs
+++ b/src/ScrambleCoin.Application/Tournament/GetBracket/TournamentBracketDto.cs
@@ -5,6 +5,7 @@ namespace ScrambleCoin.Application.Tournament.GetBracket;
 /// <param name="TournamentName">Human-readable name.</param>
 /// <param name="Status">Current lifecycle status.</param>
 /// <param name="WinnerId">Bot ID of the overall tournament winner; <c>null</c> until Completed.</param>
+/// <param name="Participants">All registered participants (available in every lifecycle state).</param>
 /// <param name="GroupMatches">All round-robin group stage matches.</param>
 /// <param name="KnockoutRounds">Knockout rounds, each containing their matches.</param>
 public sealed record TournamentBracketDto(
@@ -12,8 +13,14 @@ public sealed record TournamentBracketDto(
     string TournamentName,
     string Status,
     Guid? WinnerId,
+    IReadOnlyList<ParticipantDto> Participants,
     IReadOnlyList<GroupMatchDto> GroupMatches,
     IReadOnlyList<KnockoutRoundDto> KnockoutRounds);
+
+/// <summary>A registered tournament participant.</summary>
+/// <param name="BotId">Stable bot identifier.</param>
+/// <param name="BotName">Human-readable display name.</param>
+public sealed record ParticipantDto(Guid BotId, string BotName);
 
 /// <summary>DTO for a single group stage match.</summary>
 /// <param name="MatchId">Unique match identifier.</param>

--- a/src/ScrambleCoin.Application/Tournament/ITournamentRepository.cs
+++ b/src/ScrambleCoin.Application/Tournament/ITournamentRepository.cs
@@ -27,6 +27,14 @@ public interface ITournamentRepository
     Task<Domain.Tournaments.Tournament> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Reloads a tournament directly from the database, bypassing any cached/tracked
+    /// entity in the current unit-of-work scope. Use after a concurrency conflict to
+    /// ensure the caller sees the latest committed state.
+    /// </summary>
+    /// <exception cref="ScrambleCoin.Domain.Exceptions.TournamentNotFoundException">Thrown when not found.</exception>
+    Task<Domain.Tournaments.Tournament> ReloadAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Stages the current state of a tournament for persistence (insert or update) without committing.
     /// The caller must commit the staged changes via <see cref="ScrambleCoin.Application.Interfaces.IUnitOfWork.SaveChangesAsync"/>.
     /// </summary>

--- a/src/ScrambleCoin.Application/Tournament/ITournamentRepository.cs
+++ b/src/ScrambleCoin.Application/Tournament/ITournamentRepository.cs
@@ -39,4 +39,10 @@ public interface ITournamentRepository
     /// <param name="gameId">The game ID to search for across all tournament group and knockout matches.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<TournamentBotInfo?> GetBotInfoByGameIdAsync(Guid gameId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all tournaments in the system, ordered by creation time descending.
+    /// Used by the admin panel to display the tournament list.
+    /// </summary>
+    Task<IReadOnlyList<Domain.Tournaments.Tournament>> GetAllAsync(CancellationToken cancellationToken = default);
 }

--- a/src/ScrambleCoin.Application/Tournament/StartTournament/StartTournamentCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Tournament/StartTournament/StartTournamentCommandHandler.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Application.Notifications;
 using ScrambleCoin.Domain.Entities;
 using ScrambleCoin.Domain.Factories;
 using ScrambleCoin.Domain.ValueObjects;
@@ -24,6 +25,7 @@ public sealed class StartTournamentCommandHandler : IRequestHandler<StartTournam
     private readonly IGameRepository _gameRepository;
     private readonly IBotRegistrationRepository _botRegistrationRepository;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IPublisher _publisher;
     private readonly ILogger<StartTournamentCommandHandler> _logger;
 
     public StartTournamentCommandHandler(
@@ -31,12 +33,14 @@ public sealed class StartTournamentCommandHandler : IRequestHandler<StartTournam
         IGameRepository gameRepository,
         IBotRegistrationRepository botRegistrationRepository,
         IUnitOfWork unitOfWork,
+        IPublisher publisher,
         ILogger<StartTournamentCommandHandler> logger)
     {
         _tournamentRepository = tournamentRepository;
         _gameRepository = gameRepository;
         _botRegistrationRepository = botRegistrationRepository;
         _unitOfWork = unitOfWork;
+        _publisher = publisher;
         _logger = logger;
     }
 
@@ -49,6 +53,9 @@ public sealed class StartTournamentCommandHandler : IRequestHandler<StartTournam
 
         // Generate the round-robin schedule
         var groupMatches = tournament.Start();
+
+        // Track game IDs so we can trigger coin spawn after saving
+        var gameIds = new List<Guid>(groupMatches.Count);
 
         // Create a game for every group match
         foreach (var match in groupMatches)
@@ -69,6 +76,8 @@ public sealed class StartTournamentCommandHandler : IRequestHandler<StartTournam
             var regTwo = new DomainBotReg(botTwoToken, botTwoPlayerId, gameId);
             await _botRegistrationRepository.StageAsync(regOne, cancellationToken);
             await _botRegistrationRepository.StageAsync(regTwo, cancellationToken);
+
+            gameIds.Add(gameId);
         }
 
         // Persist tournament (with all match assignments) + all games + registrations atomically
@@ -78,6 +87,12 @@ public sealed class StartTournamentCommandHandler : IRequestHandler<StartTournam
         _logger.LogInformation(
             "Tournament {TournamentId} started. {MatchCount} group matches scheduled.",
             request.TournamentId, groupMatches.Count);
+
+        // Trigger coin spawn for each game AFTER saving so the handler sees a consistent DB state.
+        // BuildGame calls game.Start() which sets phase=CoinSpawn, but clears domain events to
+        // avoid double-publishing — so we publish TurnRolledOver explicitly here.
+        foreach (var gameId in gameIds)
+            await _publisher.Publish(new TurnRolledOver(gameId), cancellationToken);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/src/ScrambleCoin.Domain/Entities/Game.TurnPhases.cs
+++ b/src/ScrambleCoin.Domain/Entities/Game.TurnPhases.cs
@@ -50,6 +50,9 @@ public partial class Game
                 _movedPieceIds.Clear();
                 MovePhaseActivePlayer = PlayerOne;
                 _domainEvents.Add(new TurnPhaseAdvanced(Id, TurnNumber, previousPhase, CurrentPhase, DateTimeOffset.UtcNow));
+                // Eagerly skip any player(s) with no pieces on board so the turn
+                // advances automatically without waiting for a MovePiece call.
+                SkipActiveMoverIfNoPiecesRemaining();
                 break;
 
             case TurnPhase.MovePhase:

--- a/src/ScrambleCoin.Infrastructure/Migrations/20260529100620_AddLastMoveAtToGameRecord.Designer.cs
+++ b/src/ScrambleCoin.Infrastructure/Migrations/20260529100620_AddLastMoveAtToGameRecord.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ScrambleCoin.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using ScrambleCoin.Infrastructure.Persistence;
 namespace ScrambleCoin.Infrastructure.Migrations
 {
     [DbContext(typeof(ScrambleCoinDbContext))]
-    partial class ScrambleCoinDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529100620_AddLastMoveAtToGameRecord")]
+    partial class AddLastMoveAtToGameRecord
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ScrambleCoin.Infrastructure/Migrations/20260529100620_AddLastMoveAtToGameRecord.cs
+++ b/src/ScrambleCoin.Infrastructure/Migrations/20260529100620_AddLastMoveAtToGameRecord.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ScrambleCoin.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLastMoveAtToGameRecord : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "LastMoveAt",
+                table: "Games",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastMoveAt",
+                table: "Games");
+        }
+    }
+}

--- a/src/ScrambleCoin.Infrastructure/Persistence/BotUnlocksRepository.cs
+++ b/src/ScrambleCoin.Infrastructure/Persistence/BotUnlocksRepository.cs
@@ -66,4 +66,10 @@ public sealed class BotUnlocksRepository : IBotUnlocksRepository
         return 
             _context.BotUnlocks.AnyAsync(bu => bu.BotId == botId && bu.VillainId == villainId,cancellationToken);
     }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<BotUnlock>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.BotUnlocks.AsNoTracking().ToListAsync(cancellationToken);
+    }
 }

--- a/src/ScrambleCoin.Infrastructure/Persistence/GameRepository.cs
+++ b/src/ScrambleCoin.Infrastructure/Persistence/GameRepository.cs
@@ -116,7 +116,8 @@ public sealed class GameRepository : IGameRepository
                 TurnNumber:    r.TurnNumber,
                 Phase:         phaseStr,
                 ScorePlayerOne: scoreOne,
-                ScorePlayerTwo: scoreTwo));
+                ScorePlayerTwo: scoreTwo,
+                LastMoveAt:    r.LastMoveAt));
         }
 
         return results.AsReadOnly();
@@ -154,7 +155,8 @@ public sealed class GameRepository : IGameRepository
             LineupPlayerTwoJson = game.LineupPlayerTwo is not null
                 ? SerializeLineup(game.LineupPlayerTwo)
                 : null,
-            BoardStateJson = SerializeBoardState(game.Board)
+            BoardStateJson = SerializeBoardState(game.Board),
+            LastMoveAt = DateTimeOffset.UtcNow
         };
     }
 

--- a/src/ScrambleCoin.Infrastructure/Persistence/GameRepository.cs
+++ b/src/ScrambleCoin.Infrastructure/Persistence/GameRepository.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using ScrambleCoin.Application.Games.Admin;
 using ScrambleCoin.Application.Interfaces;
 using ScrambleCoin.Domain.Entities;
 using ScrambleCoin.Domain.Enums;
@@ -77,6 +78,51 @@ public sealed class GameRepository : IGameRepository
             g => (g.PlayerOne == playerId || g.PlayerTwo == playerId) && g.Status == inProgress,
             cancellationToken);
     }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<ActiveGameSummaryDto>> GetAllActiveAsync(CancellationToken cancellationToken = default)
+    {
+        const int inProgress    = (int)GameStatus.InProgress;
+        const int waitingForBots = (int)GameStatus.WaitingForBots;
+
+        var records = await _context.Games
+            .AsNoTracking()
+            .Where(g => g.Status == inProgress || g.Status == waitingForBots)
+            .ToListAsync(cancellationToken);
+
+        var results = new List<ActiveGameSummaryDto>(records.Count);
+
+        foreach (var r in records)
+        {
+            // Parse scores JSON: {"guid-as-string": score, ...}
+            var scoresDict = string.IsNullOrEmpty(r.ScoresJson)
+                ? new Dictionary<string, int>()
+                : JsonSerializer.Deserialize<Dictionary<string, int>>(r.ScoresJson, JsonOptions)
+                  ?? new Dictionary<string, int>();
+
+            scoresDict.TryGetValue(r.PlayerOne.ToString(), out var scoreOne);
+            scoresDict.TryGetValue(r.PlayerTwo.ToString(), out var scoreTwo);
+
+            var statusStr = ((GameStatus)r.Status).ToString();
+            var phaseStr  = r.CurrentPhase.HasValue
+                ? ((TurnPhase)r.CurrentPhase.Value).ToString()
+                : null;
+
+            results.Add(new ActiveGameSummaryDto(
+                GameId:        r.Id,
+                PlayerOne:     r.PlayerOne,
+                PlayerTwo:     r.PlayerTwo,
+                Status:        statusStr,
+                TurnNumber:    r.TurnNumber,
+                Phase:         phaseStr,
+                ScorePlayerOne: scoreOne,
+                ScorePlayerTwo: scoreTwo));
+        }
+
+        return results.AsReadOnly();
+    }
+
+
 
     // ── Extraction (Game → GameRecord) ────────────────────────────────────────
 

--- a/src/ScrambleCoin.Infrastructure/Persistence/Records/GameRecord.cs
+++ b/src/ScrambleCoin.Infrastructure/Persistence/Records/GameRecord.cs
@@ -46,6 +46,9 @@ public sealed class GameRecord
     /// <summary>JSON: array of <see cref="PieceDto"/> — null until PlayerTwo submits a lineup.</summary>
     public string? LineupPlayerTwoJson { get; set; }
 
+    /// <summary>UTC timestamp of the most recent move recorded in this game.</summary>
+    public DateTimeOffset LastMoveAt { get; set; } = DateTimeOffset.UtcNow;
+
     /// <summary>JSON: <see cref="BoardStateDto"/> capturing all obstacles and tile occupants.</summary>
     public string BoardStateJson { get; set; } = "{}";
 }

--- a/src/ScrambleCoin.Infrastructure/Persistence/TournamentRepository.cs
+++ b/src/ScrambleCoin.Infrastructure/Persistence/TournamentRepository.cs
@@ -39,6 +39,21 @@ public sealed class TournamentRepository : ITournamentRepository
     }
 
     /// <inheritdoc/>
+    public async Task<Tournament> ReloadAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        // Detach any tracked instance so FindAsync is forced to hit the DB.
+        var tracked = _context.ChangeTracker.Entries<TournamentRecord>()
+            .FirstOrDefault(e => e.Entity.Id == id);
+        if (tracked is not null)
+            tracked.State = EntityState.Detached;
+
+        var record = await _context.Tournaments.FindAsync([id], cancellationToken)
+            ?? throw new TournamentNotFoundException(id);
+
+        return Hydrate(record);
+    }
+
+    /// <inheritdoc/>
     public async Task SaveAsync(Tournament tournament, CancellationToken cancellationToken = default)
     {
         var record = Dehydrate(tournament);

--- a/src/ScrambleCoin.Infrastructure/Persistence/TournamentRepository.cs
+++ b/src/ScrambleCoin.Infrastructure/Persistence/TournamentRepository.cs
@@ -115,6 +115,13 @@ public sealed class TournamentRepository : ITournamentRepository
         return null;
     }
 
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<Tournament>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var records = await _context.Tournaments.AsNoTracking().ToListAsync(cancellationToken);
+        return records.Select(Hydrate).ToList().AsReadOnly();
+    }
+
     // ── Serialization ─────────────────────────────────────────────────────────
 
     private static TournamentRecord Dehydrate(Tournament tournament)

--- a/src/ScrambleCoin.Web/Hubs/GameBroadcaster.cs
+++ b/src/ScrambleCoin.Web/Hubs/GameBroadcaster.cs
@@ -13,7 +13,8 @@ namespace ScrambleCoin.Web.Hubs;
 /// </summary>
 public sealed class GameBroadcaster : IGameBroadcaster
 {
-    private const string GroupPrefix = "game-";
+    private const string GameGroupPrefix   = "game-";
+    private const string PlayerGroupPrefix = "player-";
 
     private readonly IHubContext<GameHub> _hubContext;
     private readonly ISender _sender;
@@ -21,14 +22,14 @@ public sealed class GameBroadcaster : IGameBroadcaster
     public GameBroadcaster(IHubContext<GameHub> hubContext, ISender sender)
     {
         _hubContext = hubContext;
-        _sender = sender;
+        _sender     = sender;
     }
 
     /// <inheritdoc />
     public async Task BroadcastBoardStateAsync(Guid gameId, CancellationToken ct = default)
     {
         var boardState = await _sender.Send(new GetSpectatorBoardStateQuery(gameId), ct);
-        var group = _hubContext.Clients.Group(GroupPrefix + gameId);
+        var group = _hubContext.Clients.Group(GameGroupPrefix + gameId);
         await group.SendAsync("BoardStateUpdated", boardState, ct);
     }
 
@@ -40,7 +41,7 @@ public sealed class GameBroadcaster : IGameBroadcaster
         string? newPhase,
         CancellationToken ct = default)
     {
-        var group = _hubContext.Clients.Group(GroupPrefix + gameId);
+        var group = _hubContext.Clients.Group(GameGroupPrefix + gameId);
         await group.SendAsync("PhaseChanged", new
         {
             GameId = gameId,
@@ -59,7 +60,7 @@ public sealed class GameBroadcaster : IGameBroadcaster
         bool isDraw,
         CancellationToken ct = default)
     {
-        var group = _hubContext.Clients.Group(GroupPrefix + gameId);
+        var group = _hubContext.Clients.Group(GameGroupPrefix + gameId);
         await group.SendAsync("GameEnded", new
         {
             GameId = gameId,
@@ -68,5 +69,32 @@ public sealed class GameBroadcaster : IGameBroadcaster
             WinnerId = winnerId,
             IsDraw = isDraw
         }, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task NotifyActivePlayersAsync(Guid gameId, CancellationToken ct = default)
+    {
+        var info = await _sender.Send(new GetGamePlayerIdsQuery(gameId), ct);
+
+        switch (info.Phase)
+        {
+            case "PlacePhase":
+                // Both players need to place (or skip) — notify each on their private channel.
+                await SendActionRequiredAsync(gameId, info.PlayerOne, "PlacePhase", ct);
+                await SendActionRequiredAsync(gameId, info.PlayerTwo, "PlacePhase", ct);
+                break;
+
+            case "MovePhase" when info.ActiveMover is { } activeId:
+                await SendActionRequiredAsync(gameId, activeId, "MovePhase", ct);
+                break;
+        }
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private Task SendActionRequiredAsync(Guid gameId, Guid playerId, string phase, CancellationToken ct)
+    {
+        var group = _hubContext.Clients.Group(PlayerGroupPrefix + gameId + "-" + playerId);
+        return group.SendAsync("ActionRequired", new { Phase = phase }, ct);
     }
 }

--- a/src/ScrambleCoin.Web/Hubs/GameHub.cs
+++ b/src/ScrambleCoin.Web/Hubs/GameHub.cs
@@ -71,7 +71,8 @@ public sealed class GameHub : Hub
             };
 
             if (needsToAct)
-                await Clients.Caller.SendAsync("ActionRequired", new { Phase = info.Phase });
+                await Clients.Caller.SendAsync("ActionRequired", new {
+                    info.Phase });
         }
         catch
         {

--- a/src/ScrambleCoin.Web/Hubs/GameHub.cs
+++ b/src/ScrambleCoin.Web/Hubs/GameHub.cs
@@ -38,4 +38,20 @@ public sealed class GameHub : Hub
         var groupName = GroupPrefix + gameId;
         await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
     }
+
+    /// <summary>
+    /// Registers the caller as an active player for <paramref name="gameId"/>.
+    /// The connection is added to a private group <c>player-{gameId}-{playerId}</c>
+    /// that only receives <c>ActionRequired</c> messages targeted at that specific player.
+    /// Call this once after joining a game — no token validation is performed here because
+    /// <c>ActionRequired</c> carries no secret data; all real actions still require a valid
+    /// <c>X-Bot-Token</c> on the REST API.
+    /// </summary>
+    /// <param name="gameId">The game the caller is participating in (string GUID).</param>
+    /// <param name="playerId">The caller's player ID (string GUID).</param>
+    public async Task RegisterAsPlayer(string gameId, string playerId)
+    {
+        var groupName = $"player-{gameId}-{playerId}";
+        await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+    }
 }

--- a/src/ScrambleCoin.Web/Hubs/GameHub.cs
+++ b/src/ScrambleCoin.Web/Hubs/GameHub.cs
@@ -1,4 +1,6 @@
+using MediatR;
 using Microsoft.AspNetCore.SignalR;
+using ScrambleCoin.Application.Games.GetBoardState;
 
 namespace ScrambleCoin.Web.Hubs;
 
@@ -12,46 +14,69 @@ namespace ScrambleCoin.Web.Hubs;
 ///   <item><c>BoardStateUpdated</c> — full board state after every move/placement/coin-spawn.</item>
 ///   <item><c>PhaseChanged</c>      — phase transition info (turn, previousPhase, newPhase).</item>
 ///   <item><c>GameEnded</c>         — final scores and winner when the game finishes.</item>
+///   <item><c>ActionRequired</c>    — sent to a specific player's private group when they must act.</item>
 /// </list>
 /// </remarks>
 public sealed class GameHub : Hub
 {
     private const string GroupPrefix = "game-";
+    private readonly ISender _sender;
+
+    public GameHub(ISender sender)
+    {
+        _sender = sender;
+    }
 
     /// <summary>
     /// Adds the calling client to the spectator group for <paramref name="gameId"/>.
     /// The caller will receive all later push events for that game.
     /// </summary>
-    /// <param name="gameId">The game to spectate (as a string GUID).</param>
     public async Task JoinGame(string gameId)
     {
-        var groupName = GroupPrefix + gameId;
-        await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+        await Groups.AddToGroupAsync(Context.ConnectionId, GroupPrefix + gameId);
     }
 
     /// <summary>
     /// Removes the calling client from the spectator group for <paramref name="gameId"/>.
     /// </summary>
-    /// <param name="gameId">The game to stop spectating.</param>
     public async Task LeaveGame(string gameId)
     {
-        var groupName = GroupPrefix + gameId;
-        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, GroupPrefix + gameId);
     }
 
     /// <summary>
     /// Registers the caller as an active player for <paramref name="gameId"/>.
     /// The connection is added to a private group <c>player-{gameId}-{playerId}</c>
     /// that only receives <c>ActionRequired</c> messages targeted at that specific player.
-    /// Call this once after joining a game — no token validation is performed here because
-    /// <c>ActionRequired</c> carries no secret data; all real actions still require a valid
-    /// <c>X-Bot-Token</c> on the REST API.
+    /// A catch-up <c>ActionRequired</c> is sent immediately if the player needs to act right now,
+    /// so bots that connect after the initial event was broadcast don't stall.
     /// </summary>
-    /// <param name="gameId">The game the caller is participating in (string GUID).</param>
-    /// <param name="playerId">The caller's player ID (string GUID).</param>
     public async Task RegisterAsPlayer(string gameId, string playerId)
     {
+        if (!Guid.TryParse(gameId, out var gameGuid) || !Guid.TryParse(playerId, out var playerGuid))
+            return;
+
         var groupName = $"player-{gameId}-{playerId}";
         await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+
+        // Catch-up: if the player needs to act right now, send ActionRequired immediately.
+        try
+        {
+            var info = await _sender.Send(new GetGamePlayerIdsQuery(gameGuid));
+            var needsToAct = info.Phase switch
+            {
+                "PlacePhase" => info.PlayerOne == playerGuid || info.PlayerTwo == playerGuid,
+                "MovePhase"  => info.ActiveMover == playerGuid,
+                _            => false
+            };
+
+            if (needsToAct)
+                await Clients.Caller.SendAsync("ActionRequired", new { Phase = info.Phase });
+        }
+        catch
+        {
+            // Best-effort catch-up — don't fail the registration itself.
+        }
     }
 }
+

--- a/src/ScrambleCoin.Web/Notifications/BroadcastPhaseChangedHandler.cs
+++ b/src/ScrambleCoin.Web/Notifications/BroadcastPhaseChangedHandler.cs
@@ -34,6 +34,13 @@ public sealed class BroadcastPhaseChangedHandler : INotificationHandler<TurnPhas
                 newPhase: notification.NewPhase,
                 ct: cancellationToken);
 
+            // Notify the player(s) who need to act in the new phase.
+            // PlacePhase: both players must place/skip → notify both.
+            // MovePhase:  the initial active mover → notify them.
+            // null / CoinSpawn: no player action needed.
+            if (notification.NewPhase is "PlacePhase" or "MovePhase")
+                await _broadcaster.NotifyActivePlayersAsync(notification.GameId, cancellationToken);
+
             _logger.LogInformation(
                 "Broadcast PhaseChanged for game {GameId}: turn {Turn}, {Previous} → {New}",
                 notification.GameId, notification.TurnNumber,

--- a/src/ScrambleCoin.Web/Pages/Admin.razor
+++ b/src/ScrambleCoin.Web/Pages/Admin.razor
@@ -250,99 +250,100 @@
 
                 <MudGrid>
 
-                    @if (_selectedTournament.Status == "Pending")
+                    @switch (_selectedTournament.Status)
                     {
-                        <!-- Add participant -->
-                        <MudItem xs="12" md="4">
-                            <MudCard Elevation="1">
-                                <MudCardHeader>
-                                    <CardHeaderContent>
-                                        <MudText Typo="Typo.subtitle2">Add Bot Participant</MudText>
-                                    </CardHeaderContent>
-                                </MudCardHeader>
-                                <MudCardContent>
-                                    <MudTextField @bind-Value="_addBotName"
-                                                  Label="Bot Name *"
-                                                  Variant="Variant.Outlined"
-                                                  FullWidth="true"
-                                                  Class="mb-2" />
-                                    <MudTextField @bind-Value="_addBotId"
-                                                  Label="Bot ID (leave blank to auto-generate)"
-                                                  Variant="Variant.Outlined"
-                                                  FullWidth="true"
-                                                  Class="mb-2" />
-                                    <MudTextField @bind-Value="_addBotLineup"
-                                                  Label="Lineup (comma-separated piece names)"
-                                                  HelperText="Default: Mickey,Minnie,Donald,Goofy,Scrooge"
-                                                  Variant="Variant.Outlined"
-                                                  FullWidth="true"
-                                                  Class="mb-2" />
-                                </MudCardContent>
-                                <MudCardActions>
-                                    <MudButton Variant="Variant.Filled"
-                                               Color="Color.Secondary"
-                                               StartIcon="@Icons.Material.Filled.PersonAdd"
-                                               OnClick="AddParticipantAsync"
-                                               Disabled="@(string.IsNullOrWhiteSpace(_addBotName))">
-                                        Add Bot
-                                    </MudButton>
-                                </MudCardActions>
-                            </MudCard>
-                        </MudItem>
+                        case "Pending":
+                            @:<!-- Add participant -->
+                            <MudItem xs="12" md="4">
+                                <MudCard Elevation="1">
+                                    <MudCardHeader>
+                                        <CardHeaderContent>
+                                            <MudText Typo="Typo.subtitle2">Add Bot Participant</MudText>
+                                        </CardHeaderContent>
+                                    </MudCardHeader>
+                                    <MudCardContent>
+                                        <MudTextField @bind-Value="_addBotName"
+                                                      Label="Bot Name *"
+                                                      Variant="Variant.Outlined"
+                                                      FullWidth="true"
+                                                      Class="mb-2" />
+                                        <MudTextField @bind-Value="_addBotId"
+                                                      Label="Bot ID (leave blank to auto-generate)"
+                                                      Variant="Variant.Outlined"
+                                                      FullWidth="true"
+                                                      Class="mb-2" />
+                                        <MudTextField @bind-Value="_addBotLineup"
+                                                      Label="Lineup (comma-separated piece names)"
+                                                      HelperText="Default: Mickey,Minnie,Donald,Goofy,Scrooge"
+                                                      Variant="Variant.Outlined"
+                                                      FullWidth="true"
+                                                      Class="mb-2" />
+                                    </MudCardContent>
+                                    <MudCardActions>
+                                        <MudButton Variant="Variant.Filled"
+                                                   Color="Color.Secondary"
+                                                   StartIcon="@Icons.Material.Filled.PersonAdd"
+                                                   OnClick="AddParticipantAsync"
+                                                   Disabled="@(string.IsNullOrWhiteSpace(_addBotName))">
+                                            Add Bot
+                                        </MudButton>
+                                    </MudCardActions>
+                                </MudCard>
+                            </MudItem>
 
-                        <!-- Actions -->
-                        <MudItem xs="12" md="8">
-                            <MudCard Elevation="1">
-                                <MudCardHeader>
-                                    <CardHeaderContent>
-                                        <MudText Typo="Typo.subtitle2">Tournament Actions</MudText>
-                                    </CardHeaderContent>
-                                </MudCardHeader>
-                                <MudCardContent>
-                                    <MudText Typo="Typo.body2" Class="mb-3">
-                                        Registered participants:
-                                        <b>@_selectedTournament.ParticipantCount</b> /
-                                        @_selectedTournament.MaxParticipants
-                                    </MudText>
-                                    @if (_selectedTournament.ParticipantCount < 2)
-                                    {
-                                        <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-3">
-                                            At least 2 bots are required to start.
-                                        </MudAlert>
-                                    }
-                                    <MudButton Variant="Variant.Filled"
-                                               Color="Color.Success"
-                                               StartIcon="@Icons.Material.Filled.RocketLaunch"
-                                               OnClick="StartTournamentAsync"
-                                               Disabled="@(_selectedTournament.ParticipantCount < 2)"
-                                               Class="mr-3 mb-2">
-                                        Start Tournament
-                                    </MudButton>
-                                    <MudButton Variant="Variant.Outlined"
-                                               Color="Color.Error"
-                                               StartIcon="@Icons.Material.Filled.Cancel"
-                                               OnClick="CancelTournamentAsync"
-                                               Class="mb-2">
-                                        Cancel Tournament
-                                    </MudButton>
-                                </MudCardContent>
-                            </MudCard>
-                        </MudItem>
-                    }
-                    else if (_selectedTournament.Status is "GroupStage" or "KnockoutStage")
-                    {
-                        <MudItem xs="12" md="4">
-                            <MudCard Elevation="1">
-                                <MudCardContent>
-                                    <MudButton Variant="Variant.Outlined"
-                                               Color="Color.Error"
-                                               StartIcon="@Icons.Material.Filled.Cancel"
-                                               OnClick="CancelTournamentAsync">
-                                        Cancel Tournament
-                                    </MudButton>
-                                </MudCardContent>
-                            </MudCard>
-                        </MudItem>
+                            @:<!-- Actions -->
+                            <MudItem xs="12" md="8">
+                                <MudCard Elevation="1">
+                                    <MudCardHeader>
+                                        <CardHeaderContent>
+                                            <MudText Typo="Typo.subtitle2">Tournament Actions</MudText>
+                                        </CardHeaderContent>
+                                    </MudCardHeader>
+                                    <MudCardContent>
+                                        <MudText Typo="Typo.body2" Class="mb-3">
+                                            Registered participants:
+                                            <b>@_selectedTournament.ParticipantCount</b> /
+                                            @_selectedTournament.MaxParticipants
+                                        </MudText>
+                                        @if (_selectedTournament.ParticipantCount < 2)
+                                        {
+                                            <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-3">
+                                                At least 2 bots are required to start.
+                                            </MudAlert>
+                                        }
+                                        <MudButton Variant="Variant.Filled"
+                                                   Color="Color.Success"
+                                                   StartIcon="@Icons.Material.Filled.RocketLaunch"
+                                                   OnClick="StartTournamentAsync"
+                                                   Disabled="@(_selectedTournament.ParticipantCount < 2)"
+                                                   Class="mr-3 mb-2">
+                                            Start Tournament
+                                        </MudButton>
+                                        <MudButton Variant="Variant.Outlined"
+                                                   Color="Color.Error"
+                                                   StartIcon="@Icons.Material.Filled.Cancel"
+                                                   OnClick="CancelTournamentAsync"
+                                                   Class="mb-2">
+                                            Cancel Tournament
+                                        </MudButton>
+                                    </MudCardContent>
+                                </MudCard>
+                            </MudItem>
+                            break;
+                        case "GroupStage" or "KnockoutStage":
+                            <MudItem xs="12" md="4">
+                                <MudCard Elevation="1">
+                                    <MudCardContent>
+                                        <MudButton Variant="Variant.Outlined"
+                                                   Color="Color.Error"
+                                                   StartIcon="@Icons.Material.Filled.Cancel"
+                                                   OnClick="CancelTournamentAsync">
+                                            Cancel Tournament
+                                        </MudButton>
+                                    </MudCardContent>
+                                </MudCard>
+                            </MudItem>
+                            break;
                     }
 
                     <!-- Standings -->

--- a/src/ScrambleCoin.Web/Pages/Admin.razor
+++ b/src/ScrambleCoin.Web/Pages/Admin.razor
@@ -124,7 +124,11 @@
                             <strong>@context.ScorePlayerTwo</strong>
                         </MudTd>
                         <MudTd DataLabel="Last Move">
-                            @((DateTimeOffset.UtcNow - context.LastMoveAt).TotalSeconds.ToString("F0"))s ago
+                            @{
+                                var elapsed = DateTimeOffset.UtcNow - context.LastMoveAt;
+                                var lastMoveLabel = elapsed > TimeSpan.FromDays(1) ? "unknown" : $"{elapsed.TotalSeconds:F0}s ago";
+                            }
+                            @lastMoveLabel
                         </MudTd>
                         <MudTd DataLabel="Action">
                             <MudButton Size="Size.Small"

--- a/src/ScrambleCoin.Web/Pages/Admin.razor
+++ b/src/ScrambleCoin.Web/Pages/Admin.razor
@@ -1,83 +1,791 @@
 @page "/admin"
+@using MediatR
+@using ScrambleCoin.Application.Games.Admin
+@using ScrambleCoin.Application.Tournament.GetAllTournaments
+@using ScrambleCoin.Application.Tournament.GetStandings
+@using ScrambleCoin.Application.Tournament.CreateTournament
+@using ScrambleCoin.Application.Tournament.AddParticipant
+@using ScrambleCoin.Application.Tournament.StartTournament
+@using ScrambleCoin.Application.Tournament.CancelTournament
+@using ScrambleCoin.Application.Ranking.GetLeaderboard
+@using ScrambleCoin.Application.Ranking.GetAllBotsProgress
+@inject IMediator Mediator
+@inject IDialogService DialogService
+@implements IDisposable
 
-<MudContainer MaxWidth="MaxWidth.Large">
-    <div style="font-size: 2rem; font-weight: bold; margin: 1.5rem 0;">
-        ⚙️ Admin Dashboard
-    </div>
-    
-    <MudGrid>
-        <MudItem xs="12" sm="6" md="4">
-            <MudCard Class="h-100">
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <div style="font-size: 1.25rem; font-weight: bold;">🎮 Active Games</div>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent>
-                    <MudText Typo="Typo.body2">Games currently in progress</MudText>
-                    <div style="font-size: 2.5rem; font-weight: bold; margin-top: 1rem;">0</div>
+<PageTitle>Admin — ScrambleCoin</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="my-4">
+
+    <div style="font-size: 2rem; font-weight: bold; margin-bottom: 0.5rem;">⚙️ Admin Dashboard</div>
+    <MudText Typo="Typo.caption" Style="color:#888;" Class="mb-4">
+        Auto-refreshes every 10 seconds. Last refresh: @_lastRefreshed.ToString("HH:mm:ss")
+    </MudText>
+
+    @if (!string.IsNullOrEmpty(_globalError))
+    {
+        <MudAlert Severity="Severity.Error" Class="mb-4" ShowCloseIcon="true"
+                  CloseIconClicked="@(() => _globalError = null)">
+            @_globalError
+        </MudAlert>
+    }
+
+    <!-- ── Summary cards ────────────────────────────────────────────────── -->
+    <MudGrid Class="mb-6">
+        <MudItem xs="12" sm="6" md="3">
+            <MudCard Elevation="2">
+                <MudCardContent Class="pa-4">
+                    <MudText Typo="Typo.body2" Style="color:#aaa;">🎮 Active Games</MudText>
+                    <div style="font-size: 2.5rem; font-weight: bold; line-height: 1.2;">@_activeGames.Count</div>
                 </MudCardContent>
             </MudCard>
         </MudItem>
-
-        <MudItem xs="12" sm="6" md="4">
-            <MudCard Class="h-100">
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <div style="font-size: 1.25rem; font-weight: bold;">🤖 Registered Bots</div>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent>
-                    <MudText Typo="Typo.body2">Bots ready to compete</MudText>
-                    <div style="font-size: 2.5rem; font-weight: bold; margin-top: 1rem;">0</div>
+        <MudItem xs="12" sm="6" md="3">
+            <MudCard Elevation="2">
+                <MudCardContent Class="pa-4">
+                    <MudText Typo="Typo.body2" Style="color:#aaa;">🏆 Tournaments</MudText>
+                    <div style="font-size: 2.5rem; font-weight: bold; line-height: 1.2;">@_tournaments.Count</div>
                 </MudCardContent>
             </MudCard>
         </MudItem>
-
-        <MudItem xs="12" sm="6" md="4">
-            <MudCard Class="h-100">
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <div style="font-size: 1.25rem; font-weight: bold;">🏆 Completed Games</div>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent>
-                    <MudText Typo="Typo.body2">Total games finished</MudText>
-                    <div style="font-size: 2.5rem; font-weight: bold; margin-top: 1rem;">0</div>
+        <MudItem xs="12" sm="6" md="3">
+            <MudCard Elevation="2">
+                <MudCardContent Class="pa-4">
+                    <MudText Typo="Typo.body2" Style="color:#aaa;">📊 Ranked Bots</MudText>
+                    <div style="font-size: 2.5rem; font-weight: bold; line-height: 1.2;">@_leaderboard.Count</div>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="3">
+            <MudCard Elevation="2">
+                <MudCardContent Class="pa-4">
+                    <MudText Typo="Typo.body2" Style="color:#aaa;">👾 Solo Players</MudText>
+                    <div style="font-size: 2.5rem; font-weight: bold; line-height: 1.2;">@_botsProgress.Count</div>
                 </MudCardContent>
             </MudCard>
         </MudItem>
     </MudGrid>
 
-    <MudCard Class="my-6">
-        <MudCardHeader>
-            <CardHeaderContent>
-                <div style="font-size: 1.25rem; font-weight: bold;">🎯 Tournament Management</div>
-            </CardHeaderContent>
-        </MudCardHeader>
-        <MudCardContent>
-            <MudText Class="mb-4">Control tournament settings and manage active competitions.</MudText>
-            
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="mr-3 mb-2">
-                Start Tournament
-            </MudButton>
-            <MudButton Variant="Variant.Outlined" Color="Color.Primary" Class="mr-3 mb-2">
-                Pause Tournament
-            </MudButton>
-            <MudButton Variant="Variant.Outlined" Color="Color.Error" Class="mb-2">
-                Reset All Data
-            </MudButton>
-        </MudCardContent>
-    </MudCard>
+    <!-- ── Tabs ──────────────────────────────────────────────────────────── -->
+    <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true">
 
-    <MudCard Class="my-6">
-        <MudCardHeader>
-            <CardHeaderContent>
-                <div style="font-size: 1.25rem; font-weight: bold;">📊 Recent Activity</div>
-            </CardHeaderContent>
-        </MudCardHeader>
-        <MudCardContent>
-            <MudText Typo="Typo.body2" Color="Color.Tertiary">No recent activity</MudText>
-        </MudCardContent>
-    </MudCard>
+        <!-- ─────────────── Active Games tab ──────────────────────────── -->
+        <MudTabPanel Text="🎮 Active Games">
+
+            @if (_isLoading && _activeGames.Count == 0)
+            {
+                <MudProgressCircular Indeterminate="true" Class="my-4" />
+            }
+            else if (_activeGames.Count == 0)
+            {
+                <MudAlert Severity="Severity.Info">No active games right now.</MudAlert>
+            }
+            else
+            {
+                <MudTable Items="_activeGames" Dense="true" Hover="true" Striped="true" Elevation="0">
+                    <HeaderContent>
+                        <MudTh>Game ID</MudTh>
+                        <MudTh>Status</MudTh>
+                        <MudTh>Turn</MudTh>
+                        <MudTh>Phase</MudTh>
+                        <MudTh>P1 Score</MudTh>
+                        <MudTh>P2 Score</MudTh>
+                        <MudTh>Action</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Game ID">
+                            <code title="@context.GameId.ToString()" style="font-size: 0.75rem;">
+                                @context.GameId.ToString()[..8]&hellip;
+                            </code>
+                        </MudTd>
+                        <MudTd DataLabel="Status">
+                            <MudChip T="string" Size="Size.Small" Color="@GetStatusColour(context.Status)">
+                                @context.Status
+                            </MudChip>
+                        </MudTd>
+                        <MudTd DataLabel="Turn">@context.TurnNumber</MudTd>
+                        <MudTd DataLabel="Phase">
+                            @if (context.Phase is not null)
+                            {
+                                <MudChip T="string" Size="Size.Small" Color="@GetPhaseColour(context.Phase)">
+                                    @context.Phase
+                                </MudChip>
+                            }
+                            else
+                            {
+                                <span style="color:#666;">—</span>
+                            }
+                        </MudTd>
+                        <MudTd DataLabel="P1 Score">
+                            <strong>@context.ScorePlayerOne</strong>
+                        </MudTd>
+                        <MudTd DataLabel="P2 Score">
+                            <strong>@context.ScorePlayerTwo</strong>
+                        </MudTd>
+                        <MudTd DataLabel="Action">
+                            <MudButton Size="Size.Small"
+                                       Variant="Variant.Outlined"
+                                       Color="Color.Error"
+                                       StartIcon="@Icons.Material.Filled.Stop"
+                                       OnClick="@(() => ForceEndGameAsync(context.GameId))">
+                                Force End
+                            </MudButton>
+                        </MudTd>
+                    </RowTemplate>
+                </MudTable>
+            }
+        </MudTabPanel>
+
+        <!-- ─────────────── Tournaments tab ───────────────────────────── -->
+        <MudTabPanel Text="🏆 Tournaments">
+
+            @if (!string.IsNullOrEmpty(_tournamentMessage))
+            {
+                <MudAlert Severity="@_tournamentSeverity" Class="mb-4" ShowCloseIcon="true"
+                          CloseIconClicked="@(() => _tournamentMessage = "")">
+                    @_tournamentMessage
+                </MudAlert>
+            }
+
+            <MudGrid>
+
+                <!-- Create form -->
+                <MudItem xs="12" md="4">
+                    <MudCard Elevation="1">
+                        <MudCardHeader>
+                            <CardHeaderContent>
+                                <MudText Typo="Typo.subtitle1"><b>Create Tournament</b></MudText>
+                            </CardHeaderContent>
+                        </MudCardHeader>
+                        <MudCardContent>
+                            <MudTextField @bind-Value="_newTournamentName"
+                                          Label="Tournament Name"
+                                          Variant="Variant.Outlined"
+                                          FullWidth="true"
+                                          Class="mb-3" />
+                            <MudNumericField T="int"
+                                             @bind-Value="_newTournamentMaxParticipants"
+                                             Label="Max Participants"
+                                             Min="2" Max="64"
+                                             Variant="Variant.Outlined"
+                                             FullWidth="true"
+                                             Class="mb-3" />
+                            <MudNumericField T="int"
+                                             @bind-Value="_newTournamentTopN"
+                                             Label="Top N advance to knockout"
+                                             Min="2" Max="16"
+                                             Variant="Variant.Outlined"
+                                             FullWidth="true"
+                                             Class="mb-3" />
+                        </MudCardContent>
+                        <MudCardActions>
+                            <MudButton Variant="Variant.Filled"
+                                       Color="Color.Primary"
+                                       StartIcon="@Icons.Material.Filled.Add"
+                                       OnClick="CreateTournamentAsync"
+                                       Disabled="@(string.IsNullOrWhiteSpace(_newTournamentName))">
+                                Create
+                            </MudButton>
+                        </MudCardActions>
+                    </MudCard>
+                </MudItem>
+
+                <!-- Tournament list -->
+                <MudItem xs="12" md="8">
+                    @if (_tournaments.Count == 0)
+                    {
+                        <MudAlert Severity="Severity.Info">No tournaments yet. Create one!</MudAlert>
+                    }
+                    else
+                    {
+                        @foreach (var t in _tournaments)
+                        {
+                            var isSelected = _selectedTournament?.TournamentId == t.TournamentId;
+                            <MudPaper Elevation="@(isSelected ? 4 : 1)"
+                                      Class="pa-3 mb-2"
+                                      Style="@($"cursor:pointer; border-left: 4px solid {TournamentStatusBorderColour(t.Status)}; {(isSelected ? "background:rgba(var(--mud-palette-primary-rgb),0.08);" : "")}")"
+                                      @onclick="@(() => SelectTournamentAsync(t))">
+                                <div class="d-flex justify-space-between align-center">
+                                    <span>
+                                        <b>@t.Name</b>
+                                        <MudChip T="string" Size="Size.Small"
+                                                 Color="@GetTournamentStatusColour(t.Status)"
+                                                 Class="ml-2">
+                                            @t.Status
+                                        </MudChip>
+                                    </span>
+                                    <MudText Typo="Typo.caption" Style="color:#aaa;">
+                                        @t.ParticipantCount / @t.MaxParticipants bots ·
+                                        @t.CreatedAtUtc.ToLocalTime().ToString("dd MMM HH:mm")
+                                    </MudText>
+                                </div>
+                            </MudPaper>
+                        }
+                    }
+                </MudItem>
+
+            </MudGrid>
+
+            <!-- Selected tournament management -->
+            @if (_selectedTournament is not null)
+            {
+                <MudDivider Class="my-4" />
+
+                <div style="font-size: 1.2rem; font-weight: bold; margin-bottom: 1rem;">
+                    Managing: @_selectedTournament.Name
+                    <MudChip T="string" Size="Size.Small"
+                             Color="@GetTournamentStatusColour(_selectedTournament.Status)"
+                             Class="ml-2">
+                        @_selectedTournament.Status
+                    </MudChip>
+                </div>
+
+                <MudGrid>
+
+                    @if (_selectedTournament.Status == "Pending")
+                    {
+                        <!-- Add participant -->
+                        <MudItem xs="12" md="4">
+                            <MudCard Elevation="1">
+                                <MudCardHeader>
+                                    <CardHeaderContent>
+                                        <MudText Typo="Typo.subtitle2">Add Bot Participant</MudText>
+                                    </CardHeaderContent>
+                                </MudCardHeader>
+                                <MudCardContent>
+                                    <MudTextField @bind-Value="_addBotName"
+                                                  Label="Bot Name *"
+                                                  Variant="Variant.Outlined"
+                                                  FullWidth="true"
+                                                  Class="mb-2" />
+                                    <MudTextField @bind-Value="_addBotId"
+                                                  Label="Bot ID (leave blank to auto-generate)"
+                                                  Variant="Variant.Outlined"
+                                                  FullWidth="true"
+                                                  Class="mb-2" />
+                                    <MudTextField @bind-Value="_addBotLineup"
+                                                  Label="Lineup (comma-separated piece names)"
+                                                  HelperText="Default: Mickey,Minnie,Donald,Goofy,Scrooge"
+                                                  Variant="Variant.Outlined"
+                                                  FullWidth="true"
+                                                  Class="mb-2" />
+                                </MudCardContent>
+                                <MudCardActions>
+                                    <MudButton Variant="Variant.Filled"
+                                               Color="Color.Secondary"
+                                               StartIcon="@Icons.Material.Filled.PersonAdd"
+                                               OnClick="AddParticipantAsync"
+                                               Disabled="@(string.IsNullOrWhiteSpace(_addBotName))">
+                                        Add Bot
+                                    </MudButton>
+                                </MudCardActions>
+                            </MudCard>
+                        </MudItem>
+
+                        <!-- Actions -->
+                        <MudItem xs="12" md="8">
+                            <MudCard Elevation="1">
+                                <MudCardHeader>
+                                    <CardHeaderContent>
+                                        <MudText Typo="Typo.subtitle2">Tournament Actions</MudText>
+                                    </CardHeaderContent>
+                                </MudCardHeader>
+                                <MudCardContent>
+                                    <MudText Typo="Typo.body2" Class="mb-3">
+                                        Registered participants:
+                                        <b>@_selectedTournament.ParticipantCount</b> /
+                                        @_selectedTournament.MaxParticipants
+                                    </MudText>
+                                    @if (_selectedTournament.ParticipantCount < 2)
+                                    {
+                                        <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-3">
+                                            At least 2 bots are required to start.
+                                        </MudAlert>
+                                    }
+                                    <MudButton Variant="Variant.Filled"
+                                               Color="Color.Success"
+                                               StartIcon="@Icons.Material.Filled.RocketLaunch"
+                                               OnClick="StartTournamentAsync"
+                                               Disabled="@(_selectedTournament.ParticipantCount < 2)"
+                                               Class="mr-3 mb-2">
+                                        Start Tournament
+                                    </MudButton>
+                                    <MudButton Variant="Variant.Outlined"
+                                               Color="Color.Error"
+                                               StartIcon="@Icons.Material.Filled.Cancel"
+                                               OnClick="CancelTournamentAsync"
+                                               Class="mb-2">
+                                        Cancel Tournament
+                                    </MudButton>
+                                </MudCardContent>
+                            </MudCard>
+                        </MudItem>
+                    }
+                    else if (_selectedTournament.Status is "GroupStage" or "KnockoutStage")
+                    {
+                        <MudItem xs="12" md="4">
+                            <MudCard Elevation="1">
+                                <MudCardContent>
+                                    <MudButton Variant="Variant.Outlined"
+                                               Color="Color.Error"
+                                               StartIcon="@Icons.Material.Filled.Cancel"
+                                               OnClick="CancelTournamentAsync">
+                                        Cancel Tournament
+                                    </MudButton>
+                                </MudCardContent>
+                            </MudCard>
+                        </MudItem>
+                    }
+
+                    <!-- Standings -->
+                    @if (_standings is not null)
+                    {
+                        <MudItem xs="12">
+                            <MudCard Elevation="1">
+                                <MudCardHeader>
+                                    <CardHeaderContent>
+                                        <MudText Typo="Typo.subtitle1">
+                                            Group Stage Standings — @_standings.TournamentName
+                                        </MudText>
+                                    </CardHeaderContent>
+                                </MudCardHeader>
+                                <MudCardContent>
+                                    @if (_standings.Standings.Count == 0)
+                                    {
+                                        <MudText Typo="Typo.body2" Style="color:#888;">
+                                            No matches completed yet.
+                                        </MudText>
+                                    }
+                                    else
+                                    {
+                                        <MudTable Items="_standings.Standings"
+                                                  Dense="true" Hover="true" Elevation="0">
+                                            <HeaderContent>
+                                                <MudTh>#</MudTh>
+                                                <MudTh>Bot</MudTh>
+                                                <MudTh>P</MudTh>
+                                                <MudTh>W</MudTh>
+                                                <MudTh>D</MudTh>
+                                                <MudTh>L</MudTh>
+                                                <MudTh>Pts</MudTh>
+                                                <MudTh>Coins</MudTh>
+                                            </HeaderContent>
+                                            <RowTemplate>
+                                                <MudTd>@context.Rank</MudTd>
+                                                <MudTd><b>@context.BotName</b></MudTd>
+                                                <MudTd>@context.Played</MudTd>
+                                                <MudTd Style="color:#4caf50;">@context.Wins</MudTd>
+                                                <MudTd Style="color:#ff9800;">@context.Draws</MudTd>
+                                                <MudTd Style="color:#f44336;">@context.Losses</MudTd>
+                                                <MudTd>
+                                                    <MudChip T="string" Size="Size.Small" Color="Color.Primary">
+                                                        @context.Points
+                                                    </MudChip>
+                                                </MudTd>
+                                                <MudTd>@context.TotalCoins</MudTd>
+                                            </RowTemplate>
+                                        </MudTable>
+                                    }
+                                </MudCardContent>
+                            </MudCard>
+                        </MudItem>
+                    }
+
+                </MudGrid>
+            }
+
+        </MudTabPanel>
+
+        <!-- ─────────────── Solo Progress tab ────────────────────────── -->
+        <MudTabPanel Text="👾 Solo Progress">
+
+            @if (_isLoading && _botsProgress.Count == 0)
+            {
+                <MudProgressCircular Indeterminate="true" Class="my-4" />
+            }
+            else if (_botsProgress.Count == 0)
+            {
+                <MudAlert Severity="Severity.Info">
+                    No solo mode data yet. Bots must play solo games first.
+                </MudAlert>
+            }
+            else
+            {
+                <MudTable Items="_botsProgress" Dense="true" Hover="true" Striped="true" Elevation="0">
+                    <HeaderContent>
+                        <MudTh>Bot Name</MudTh>
+                        <MudTh>Villains Defeated</MudTh>
+                        <MudTh>Pieces Unlocked</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Bot Name"><b>@context.BotName</b></MudTd>
+                        <MudTd DataLabel="Villains Defeated">
+                            <MudChip T="string" Size="Size.Small" Color="Color.Secondary">
+                                @context.VillainsDefeated
+                            </MudChip>
+                        </MudTd>
+                        <MudTd DataLabel="Pieces Unlocked">@context.PiecesUnlocked</MudTd>
+                    </RowTemplate>
+                </MudTable>
+            }
+
+        </MudTabPanel>
+
+        <!-- ─────────────── Leaderboard tab ──────────────────────────── -->
+        <MudTabPanel Text="📊 Leaderboard">
+
+            <MudText Typo="Typo.caption" Style="color:#888;" Class="mb-3">
+                Points: +3 Win · +2 Draw · +1 Loss · Max 550 pts.
+            </MudText>
+
+            @if (_isLoading && _leaderboard.Count == 0)
+            {
+                <MudProgressCircular Indeterminate="true" Class="my-4" />
+            }
+            else if (_leaderboard.Count == 0)
+            {
+                <MudAlert Severity="Severity.Info">
+                    No ranking data yet. Bots must complete games first.
+                </MudAlert>
+            }
+            else
+            {
+                <MudTable Items="_leaderboard" Dense="true" Hover="true" Striped="true" Elevation="0">
+                    <HeaderContent>
+                        <MudTh>Rank</MudTh>
+                        <MudTh>Bot</MudTh>
+                        <MudTh>Points</MudTh>
+                        <MudTh>W</MudTh>
+                        <MudTh>D</MudTh>
+                        <MudTh>L</MudTh>
+                        <MudTh>Games</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Rank">
+                            @switch (context.Rank)
+                            {
+                                case 1: <span>🥇 1</span> break;
+                                case 2: <span>🥈 2</span> break;
+                                case 3: <span>🥉 3</span> break;
+                                default: <span>@context.Rank</span> break;
+                            }
+                        </MudTd>
+                        <MudTd DataLabel="Bot"><b>@context.BotName</b></MudTd>
+                        <MudTd DataLabel="Points">
+                            <MudChip T="string" Size="Size.Small" Color="@GetPointsColour(context.Points)">
+                                @context.Points
+                            </MudChip>
+                        </MudTd>
+                        <MudTd DataLabel="W" Style="color:#4caf50;">@context.Wins</MudTd>
+                        <MudTd DataLabel="D" Style="color:#ff9800;">@context.Draws</MudTd>
+                        <MudTd DataLabel="L" Style="color:#f44336;">@context.Losses</MudTd>
+                        <MudTd DataLabel="Games">@context.GamesPlayed</MudTd>
+                    </RowTemplate>
+                </MudTable>
+            }
+
+        </MudTabPanel>
+
+    </MudTabs>
+
 </MudContainer>
+
+@code {
+
+    // ── Data state ────────────────────────────────────────────────────────────
+
+    private List<ActiveGameSummaryDto> _activeGames = [];
+    private List<TournamentSummaryDto> _tournaments  = [];
+    private List<BotProgressDto>       _botsProgress = [];
+    private List<LeaderboardEntryDto>  _leaderboard  = [];
+
+    private TournamentSummaryDto?   _selectedTournament;
+    private TournamentStandingsDto? _standings;
+
+    private bool    _isLoading     = false;
+    private string? _globalError;
+    private DateTime _lastRefreshed = DateTime.Now;
+    private CancellationTokenSource? _cts;
+
+    // Tournament create form
+    private string _newTournamentName            = "";
+    private int    _newTournamentMaxParticipants  = 8;
+    private int    _newTournamentTopN             = 4;
+
+    // Add participant form
+    private string _addBotName   = "";
+    private string _addBotId     = "";
+    private string _addBotLineup = "Mickey,Minnie,Donald,Goofy,Scrooge";
+
+    // Feedback
+    private string   _tournamentMessage  = "";
+    private Severity _tournamentSeverity = Severity.Success;
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    protected override async Task OnInitializedAsync()
+    {
+        _cts = new CancellationTokenSource();
+        await LoadAllAsync();
+        _ = RefreshLoopAsync(_cts.Token);
+    }
+
+    private async Task RefreshLoopAsync(CancellationToken ct)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        try
+        {
+            while (await timer.WaitForNextTickAsync(ct))
+            {
+                await LoadAllAsync();
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+        catch (OperationCanceledException) { /* component disposed */ }
+    }
+
+    private async Task LoadAllAsync()
+    {
+        _isLoading = true;
+        try
+        {
+            _activeGames  = (await Mediator.Send(new GetAllActiveGamesQuery())).ToList();
+            _tournaments  = (await Mediator.Send(new GetAllTournamentsQuery())).ToList();
+            _botsProgress = (await Mediator.Send(new GetAllBotsProgressQuery())).ToList();
+            _leaderboard  = (await Mediator.Send(new GetLeaderboardQuery())).ToList();
+            _lastRefreshed = DateTime.Now;
+            _globalError = null;
+
+            // Refresh selected tournament standings.
+            if (_selectedTournament is not null)
+            {
+                _selectedTournament = _tournaments
+                    .FirstOrDefault(t => t.TournamentId == _selectedTournament.TournamentId)
+                    ?? _selectedTournament;
+
+                if (_selectedTournament.Status is not ("Pending" or "Cancelled"))
+                    await LoadStandingsAsync(_selectedTournament.TournamentId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _globalError = $"Refresh failed: {ex.Message}";
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    // ── Tournament actions ────────────────────────────────────────────────────
+
+    private async Task CreateTournamentAsync()
+    {
+        try
+        {
+            var result = await Mediator.Send(new CreateTournamentCommand(
+                _newTournamentName.Trim(),
+                _newTournamentMaxParticipants,
+                _newTournamentTopN));
+
+            _tournamentMessage  = $"✅ Tournament '{_newTournamentName.Trim()}' created. ID: {result.TournamentId}";
+            _tournamentSeverity = Severity.Success;
+            _newTournamentName  = "";
+
+            await LoadAllAsync();
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            _tournamentMessage  = $"❌ {ex.Message}";
+            _tournamentSeverity = Severity.Error;
+        }
+    }
+
+    private async Task AddParticipantAsync()
+    {
+        if (_selectedTournament is null) return;
+
+        try
+        {
+            var botId = Guid.TryParse(_addBotId.Trim(), out var parsed) ? parsed : Guid.NewGuid();
+
+            var lineup = _addBotLineup
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList()
+                .AsReadOnly();
+
+            if (lineup.Count == 0)
+                throw new InvalidOperationException("Lineup must contain at least one piece name.");
+
+            await Mediator.Send(new AddTournamentParticipantCommand(
+                _selectedTournament.TournamentId,
+                botId,
+                _addBotName.Trim(),
+                lineup));
+
+            _tournamentMessage  = $"✅ Bot '{_addBotName.Trim()}' added. Bot ID to share: {botId}";
+            _tournamentSeverity = Severity.Success;
+            _addBotName = "";
+            _addBotId   = "";
+
+            await LoadAllAsync();
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            _tournamentMessage  = $"❌ {ex.Message}";
+            _tournamentSeverity = Severity.Error;
+        }
+    }
+
+    private async Task StartTournamentAsync()
+    {
+        if (_selectedTournament is null) return;
+        try
+        {
+            await Mediator.Send(new StartTournamentCommand(_selectedTournament.TournamentId));
+            _tournamentMessage  = "🚀 Tournament started! Group-stage games are now being scheduled.";
+            _tournamentSeverity = Severity.Success;
+
+            await LoadAllAsync();
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            _tournamentMessage  = $"❌ {ex.Message}";
+            _tournamentSeverity = Severity.Error;
+        }
+    }
+
+    private async Task CancelTournamentAsync()
+    {
+        if (_selectedTournament is null) return;
+
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Cancel Tournament",
+            $"Are you sure you want to cancel '{_selectedTournament.Name}'? This cannot be undone.",
+            yesText: "Yes, Cancel",
+            cancelText: "No");
+
+        if (confirmed != true) return;
+
+        try
+        {
+            await Mediator.Send(new CancelTournamentCommand(_selectedTournament.TournamentId));
+            _tournamentMessage  = "Tournament cancelled.";
+            _tournamentSeverity = Severity.Warning;
+            _selectedTournament = null;
+            _standings = null;
+
+            await LoadAllAsync();
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            _tournamentMessage  = $"❌ {ex.Message}";
+            _tournamentSeverity = Severity.Error;
+        }
+    }
+
+    private async Task SelectTournamentAsync(TournamentSummaryDto tournament)
+    {
+        _selectedTournament = tournament;
+        _standings = null;
+
+        if (tournament.Status is not ("Pending" or "Cancelled"))
+            await LoadStandingsAsync(tournament.TournamentId);
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task LoadStandingsAsync(Guid tournamentId)
+    {
+        try
+        {
+            _standings = await Mediator.Send(new GetTournamentStandingsQuery(tournamentId));
+        }
+        catch
+        {
+            _standings = null;
+        }
+    }
+
+    // ── Game actions ──────────────────────────────────────────────────────────
+
+    private async Task ForceEndGameAsync(Guid gameId)
+    {
+        var shortId = gameId.ToString()[..8];
+
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Force End Game",
+            $"Force-end game {shortId}…? The winner will be determined by current coin scores. " +
+            "Ranking points will be awarded normally. This cannot be undone.",
+            yesText: "Force End",
+            cancelText: "Cancel");
+
+        if (confirmed != true) return;
+
+        try
+        {
+            await Mediator.Send(new ForceEndGameCommand(gameId));
+            await LoadAllAsync();
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            _globalError = $"Force end failed for game {shortId}: {ex.Message}";
+        }
+    }
+
+    // ── Colour helpers ────────────────────────────────────────────────────────
+
+    private static Color GetStatusColour(string status) => status switch
+    {
+        "InProgress"    => Color.Success,
+        "WaitingForBots" => Color.Warning,
+        _               => Color.Default
+    };
+
+    private static Color GetPhaseColour(string? phase) => phase switch
+    {
+        "CoinSpawn"  => Color.Info,
+        "PlacePhase" => Color.Warning,
+        "MovePhase"  => Color.Success,
+        _            => Color.Default
+    };
+
+    private static Color GetTournamentStatusColour(string status) => status switch
+    {
+        "Pending"       => Color.Warning,
+        "GroupStage"    => Color.Info,
+        "KnockoutStage" => Color.Primary,
+        "Completed"     => Color.Success,
+        "Cancelled"     => Color.Error,
+        _               => Color.Default
+    };
+
+    private static string TournamentStatusBorderColour(string status) => status switch
+    {
+        "Pending"       => "#ff9800",
+        "GroupStage"    => "#2196f3",
+        "KnockoutStage" => "#9c27b0",
+        "Completed"     => "#4caf50",
+        "Cancelled"     => "#f44336",
+        _               => "#666"
+    };
+
+    private static Color GetPointsColour(int points) => points switch
+    {
+        >= 400 => Color.Success,
+        >= 200 => Color.Primary,
+        >= 100 => Color.Warning,
+        _      => Color.Default
+    };
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+    }
+}

--- a/src/ScrambleCoin.Web/Pages/Admin.razor
+++ b/src/ScrambleCoin.Web/Pages/Admin.razor
@@ -90,6 +90,7 @@
                         <MudTh>Phase</MudTh>
                         <MudTh>P1 Score</MudTh>
                         <MudTh>P2 Score</MudTh>
+                        <MudTh>Last Move</MudTh>
                         <MudTh>Action</MudTh>
                     </HeaderContent>
                     <RowTemplate>
@@ -121,6 +122,9 @@
                         </MudTd>
                         <MudTd DataLabel="P2 Score">
                             <strong>@context.ScorePlayerTwo</strong>
+                        </MudTd>
+                        <MudTd DataLabel="Last Move">
+                            @((DateTimeOffset.UtcNow - context.LastMoveAt).TotalSeconds.ToString("F0"))s ago
                         </MudTd>
                         <MudTd DataLabel="Action">
                             <MudButton Size="Size.Small"
@@ -537,8 +541,10 @@
         {
             while (await timer.WaitForNextTickAsync(ct))
             {
-                await LoadAllAsync();
-                await InvokeAsync(StateHasChanged);
+                // Marshal the entire load onto the Blazor circuit thread so that all
+                // state-field writes and the final StateHasChanged happen on the same
+                // thread, eliminating any race with in-progress renders.
+                await InvokeAsync(LoadAllAsync);
             }
         }
         catch (OperationCanceledException) { /* component disposed */ }
@@ -575,6 +581,10 @@
         {
             _isLoading = false;
         }
+
+        // Called from both OnInitializedAsync (already on the circuit thread) and
+        // from InvokeAsync inside RefreshLoopAsync (also on the circuit thread).
+        StateHasChanged();
     }
 
     // ── Tournament actions ────────────────────────────────────────────────────

--- a/src/ScrambleCoin.Web/Pages/Tournament.razor
+++ b/src/ScrambleCoin.Web/Pages/Tournament.razor
@@ -375,7 +375,7 @@
             {
                 var totalMatches = _bracket.GroupMatches.Count;
                 var doneMatches  = _bracket.GroupMatches.Count(m => m.IsCompleted);
-                var liveMatches  = _bracket.GroupMatches.Count(m => m.GameId.HasValue && !m.IsCompleted);
+                var liveMatches  = _bracket.GroupMatches.Count(m => m is { GameId: not null, IsCompleted: false });
                 var pct = totalMatches > 0 ? (double)doneMatches / totalMatches * 100 : 0;
 
                 <div style="margin-top:2rem; margin-bottom:.5rem; display:flex; align-items:baseline; gap:10px;">
@@ -398,12 +398,12 @@
                         var b2 = names.GetValueOrDefault(m.BotTwo, ShortId(m.BotTwo));
                         var w1 = m.WinnerId == m.BotOne;
                         var w2 = m.WinnerId == m.BotTwo;
-                        var isLive = m.GameId.HasValue && !m.IsCompleted;
-                        var cssCard = m.IsCompleted ? (m.IsDraw ? "gm-card draw" : "gm-card completed")
+                        var isLive = m is { GameId: not null, IsCompleted: false };
+                        var cssCard = m.IsCompleted ? m.IsDraw ? "gm-card draw" : "gm-card completed"
                                     : isLive        ? "gm-card live"
                                     :                 "gm-card";
                         var headerCss  = isLive ? "gm-header live" : "gm-header";
-                        var headerText = m.IsCompleted ? (m.IsDraw ? "🤝 Draw" : "✅ Done")
+                        var headerText = m.IsCompleted ? m.IsDraw ? "🤝 Draw" : "✅ Done"
                                        : isLive        ? "🔴 Live"
                                        :                 "⏳ Pending";
                         <div class="@cssCard">
@@ -437,7 +437,7 @@
             {
                 var rounds = _bracket.KnockoutRounds.OrderBy(r => r.Round).ToList();
                 var totalRounds = rounds.Count;
-                // First round has the most matches (a power of 2)
+                // The first round has the most matches (a power of 2)
                 var firstCount = rounds[0].Matches.Count;
                 // Compute total canvas height
                 var totalH = firstCount * (CardH + CardGap) - CardGap;
@@ -449,7 +449,7 @@
                     @{
                         var allKo = rounds.SelectMany(r => r.Matches).ToList();
                         var doneKo = allKo.Count(m => m.IsCompleted);
-                        var liveKo = allKo.Count(m => m.GameId.HasValue && !m.IsCompleted && !m.IsBye);
+                        var liveKo = allKo.Count(m => m is { GameId: not null, IsCompleted: false, IsBye: false });
                         if (liveKo > 0)
                         {
                             <span style="font-size:.78rem; display:flex; align-items:center; gap:4px; color:#ef9a9a;">
@@ -483,7 +483,7 @@
                                 var b2 = match.BotTwo.HasValue ? names.GetValueOrDefault(match.BotTwo.Value, ShortId(match.BotTwo.Value)) : null;
                                 var w1 = match.WinnerId.HasValue && match.WinnerId == match.BotOne;
                                 var w2 = match.WinnerId.HasValue && match.WinnerId == match.BotTwo;
-                                var cardClass = "bm" + (match.IsCompleted ? " completed" : "") + (isFinal ? " final-match" : "") + (!match.IsCompleted && match.GameId.HasValue && !match.IsBye ? " live" : "");
+                                var cardClass = "bm" + (match.IsCompleted ? " completed" : "") + (isFinal ? " final-match" : "") + (match is { IsCompleted: false, GameId: not null, IsBye: false } ? " live" : "");
 
                                 <div class="@cardClass"
                                      style="left:@(roundLeft)px; top:@(cardTop)px; height:@(CardH)px;">
@@ -492,7 +492,7 @@
                                     {
                                         <div class="bm-label" style="color:#b8860b;">⭐ Final</div>
                                     }
-                                    else if (!match.IsCompleted && match.GameId.HasValue && !match.IsBye)
+                                    else if (match is { IsCompleted: false, GameId: not null, IsBye: false })
                                     {
                                         <div class="bm-label" style="display:flex; align-items:center; justify-content:center; gap:3px; color:#ef9a9a;">
                                             <span class="live-dot"></span><span>Live</span>
@@ -522,37 +522,37 @@
                             }
 
                             <!-- SVG connectors from this round to the next -->
-                            @if (ri < rounds.Count - 1)
-                            {
-                                var svgLeft = roundLeft + CardW;
-                                var nextSlotH = SlotH(ri + 1, firstCount);
+                            @if (ri >= rounds.Count - 1)
+                                continue;
+                            
+                            var svgLeft = roundLeft + CardW;
+                            var nextSlotH = SlotH(ri + 1, firstCount);
 
-                                <svg style="position:absolute; left:@(svgLeft)px; top:0; overflow:visible;"
-                                     width="@(ConnW + RoundPad * 2)" height="@(totalH)"
-                                     xmlns="http://www.w3.org/2000/svg">
-                                    @{
-                                        var matchesThisRound = rounds[ri].Matches.Count;
-                                        for (var mi2 = 0; mi2 < matchesThisRound; mi2 += 2)
-                                        {
-                                            // Two matches in this round feed one match in the next
-                                            var topY = MatchCenterY(ri, mi2, firstCount);
-                                            var botY = MatchCenterY(ri, mi2 + 1 < matchesThisRound ? mi2 + 1 : mi2, firstCount);
-                                            var midY = (topY + botY) / 2;
-                                            var halfConn = (ConnW + RoundPad * 2) / 2;
-                                            var fullConn = ConnW + RoundPad * 2;
+                            <svg style="position:absolute; left:@(svgLeft)px; top:0; overflow:visible;"
+                                 width="@(ConnW + RoundPad * 2)" height="@totalH"
+                                 xmlns="http://www.w3.org/2000/svg">
+                                @{
+                                    var matchesThisRound = rounds[ri].Matches.Count;
+                                    for (var mi2 = 0; mi2 < matchesThisRound; mi2 += 2)
+                                    {
+                                        // Two matches in this round feed one match in the next
+                                        var topY = MatchCenterY(ri, mi2, firstCount);
+                                        var botY = MatchCenterY(ri, mi2 + 1 < matchesThisRound ? mi2 + 1 : mi2, firstCount);
+                                        var midY = (topY + botY) / 2;
+                                        const int halfConn = (ConnW + RoundPad * 2) / 2;
+                                        const int fullConn = ConnW + RoundPad * 2;
 
-                                            // Path: horizontal arm from top match → join point → horizontal arm to next round
-                                            //       plus horizontal arm from bottom match → join point
-                                            <path d="M 0 @topY H @halfConn V @botY H 0"
-                                                  fill="none" stroke="#3a3a5a" stroke-width="1.5"
-                                                  stroke-linecap="round" stroke-linejoin="round"/>
-                                            <path d="M @halfConn @midY H @fullConn"
-                                                  fill="none" stroke="#3a3a5a" stroke-width="1.5"
-                                                  stroke-linecap="round"/>
-                                        }
+                                        // Path: horizontal arm from top match → join point → horizontal arm to next round
+                                        //       plus horizontal arm from bottom match → join point
+                                        <path d="M 0 @topY H @halfConn V @botY H 0"
+                                              fill="none" stroke="#3a3a5a" stroke-width="1.5"
+                                              stroke-linecap="round" stroke-linejoin="round"/>
+                                        <path d="M @halfConn @midY H @fullConn"
+                                              fill="none" stroke="#3a3a5a" stroke-width="1.5"
+                                              stroke-linecap="round"/>
                                     }
-                                </svg>
-                            }
+                                } 
+                            </svg>
                         }
                     </div>
                 </div>
@@ -627,7 +627,7 @@
                 .ThenByDescending(t => t.CreatedAtUtc)
                 .ToList();
 
-            // Auto-select best tournament
+            // Auto-select the best tournament
             if (_selectedId is null || _tournaments.All(t => t.TournamentId != _selectedId))
                 _selectedId = _tournaments.FirstOrDefault()?.TournamentId;
 
@@ -657,9 +657,9 @@
                 : null;
 
             // Count in-progress games across all stages
-            var groupLive    = _bracket.GroupMatches.Count(m => m.GameId.HasValue && !m.IsCompleted);
+            var groupLive    = _bracket.GroupMatches.Count(m => m is { GameId: not null, IsCompleted: false });
             var knockoutLive = _bracket.KnockoutRounds.SelectMany(r => r.Matches)
-                                       .Count(m => m.GameId.HasValue && !m.IsCompleted && !m.IsBye);
+                                       .Count(m => m is { GameId: not null, IsCompleted: false, IsBye: false });
             _liveGameCount = groupLive + knockoutLive;
         }
         catch (Exception ex)
@@ -683,7 +683,7 @@
     // ── Bracket layout helpers ────────────────────────────────────────────────
 
     /// <summary>Slot height for a given round index (doubles each round).</summary>
-    private int SlotH(int roundIndex, int firstCount) =>
+    private static int SlotH(int roundIndex, int firstCount) =>
         (CardH + CardGap) * (1 << roundIndex);
 
     /// <summary>Top pixel offset for match [roundIndex, matchIndex].</summary>
@@ -693,7 +693,7 @@
         return matchIndex * slotH + (slotH - CardH) / 2;
     }
 
-    /// <summary>Vertical center pixel for match [roundIndex, matchIndex].</summary>
+    /// <summary>Vertical centre pixel for match [roundIndex, matchIndex].</summary>
     private int MatchCenterY(int roundIndex, int matchIndex, int firstCount)
     {
         var slotH = SlotH(roundIndex, firstCount);

--- a/src/ScrambleCoin.Web/Pages/Tournament.razor
+++ b/src/ScrambleCoin.Web/Pages/Tournament.razor
@@ -1,0 +1,733 @@
+@page "/tournament"
+@using MediatR
+@using ScrambleCoin.Application.Tournament.GetAllTournaments
+@using ScrambleCoin.Application.Tournament.GetBracket
+@using ScrambleCoin.Application.Tournament.GetStandings
+@inject IMediator Mediator
+@implements IDisposable
+
+<PageTitle>Tournament — ScrambleCoin</PageTitle>
+
+<style>
+    /* ── Bracket layout ────────────────────────────────────────────────────── */
+    .bracket-scroll {
+        overflow-x: auto;
+        padding: 32px 16px 40px 16px;
+    }
+
+    .bracket-canvas {
+        display: flex;
+        flex-direction: row;
+        align-items: flex-start;
+        position: relative;
+        user-select: none;
+    }
+
+    /* ── Match card ────────────────────────────────────────────────────────── */
+    .bm {
+        width: 190px;
+        border-radius: 10px;
+        overflow: hidden;
+        border: 1.5px solid #333;
+        background: #1c1c2e;
+        box-shadow: 0 2px 8px rgba(0,0,0,.4);
+        position: absolute;
+        transition: box-shadow .2s;
+    }
+    .bm.completed { border-color: #2a4a2a; }
+    .bm.final-match { border-color: #b8860b; box-shadow: 0 0 14px rgba(255,215,0,.25); }
+
+    .bp {
+        display: flex;
+        align-items: center;
+        padding: 7px 10px;
+        font-size: .85rem;
+        border-bottom: 1px solid #282840;
+        min-height: 34px;
+        gap: 6px;
+    }
+    .bp:last-child { border-bottom: none; }
+    .bp.winner { color: #66bb6a; font-weight: 700; background: rgba(102,187,106,.08); }
+    .bp.tbd { color: #555; font-style: italic; }
+    .bp.active { color: #e0e0e0; }
+    .bp .score { margin-left: auto; font-size: .8rem; color: #aaa; }
+    .bp.winner .score { color: #66bb6a; }
+    .bp .trophy { font-size: .9rem; }
+
+    .bm-label {
+        font-size: .65rem;
+        text-transform: uppercase;
+        letter-spacing: .08em;
+        color: #555;
+        text-align: center;
+        padding: 2px 0;
+        background: #16162a;
+        border-bottom: 1px solid #222;
+    }
+
+    /* ── Group match cards ─────────────────────────────────────────────────── */
+    .gm-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: 12px;
+    }
+
+    .gm-card {
+        border-radius: 10px;
+        border: 1.5px solid #2a2a3e;
+        background: #1c1c2e;
+        overflow: hidden;
+        box-shadow: 0 2px 6px rgba(0,0,0,.3);
+    }
+    .gm-card.completed { border-color: #2a4a2a; }
+    .gm-card.draw { border-color: #5a4a1a; }
+
+    .gm-row {
+        display: flex;
+        align-items: center;
+        padding: 8px 12px;
+        gap: 8px;
+        border-bottom: 1px solid #242438;
+    }
+    .gm-row:last-child { border-bottom: none; }
+    .gm-row.winner { background: rgba(102,187,106,.08); color: #66bb6a; font-weight: 700; }
+    .gm-row.draw { color: #ffb74d; }
+    .gm-row.pending { color: #666; }
+
+    .gm-score {
+        margin-left: auto;
+        font-size: .85rem;
+        font-weight: 700;
+        min-width: 24px;
+        text-align: right;
+    }
+
+    .gm-header {
+        font-size: .65rem;
+        text-transform: uppercase;
+        letter-spacing: .06em;
+        color: #555;
+        padding: 4px 12px 2px;
+        background: #16162a;
+    }
+
+    /* ── Standings table ───────────────────────────────────────────────────── */
+    .standings-table { width: 100%; border-collapse: collapse; }
+    .standings-table th {
+        text-align: left; font-size: .75rem; text-transform: uppercase;
+        letter-spacing: .06em; color: #666; padding: 6px 10px;
+        border-bottom: 1px solid #2a2a3e;
+    }
+    .standings-table td { padding: 7px 10px; font-size: .88rem; border-bottom: 1px solid #1f1f30; }
+    .standings-table tr:last-child td { border-bottom: none; }
+    .standings-table tr.top { background: rgba(102,187,106,.05); }
+
+    /* ── Participant pill ──────────────────────────────────────────────────── */
+    .bot-pill {
+        display: inline-flex; align-items: center; gap: 6px;
+        background: #1c1c2e; border: 1.5px solid #2a2a4e;
+        border-radius: 20px; padding: 6px 14px;
+        font-size: .88rem;
+    }
+
+    /* ── Join box ──────────────────────────────────────────────────────────── */
+    .join-box {
+        background: #12122a;
+        border: 1.5px dashed #333;
+        border-radius: 10px;
+        padding: 20px 24px;
+        font-family: monospace;
+        font-size: .82rem;
+        color: #aaa;
+        line-height: 1.7;
+    }
+
+    /* ── Live pulse animation ──────────────────────────────────────────────── */
+    @@keyframes pulse-live {
+        0%, 100% { opacity: 1; }
+        50%       { opacity: .35; }
+    }
+    .live-dot {
+        display: inline-block;
+        width: 7px; height: 7px;
+        border-radius: 50%;
+        background: #ef5350;
+        animation: pulse-live 1.2s ease-in-out infinite;
+        margin-right: 4px;
+        vertical-align: middle;
+    }
+
+    /* ── Live game header accent ───────────────────────────────────────────── */
+    .gm-card.live     { border-color: #4a2a2a; }
+    .gm-header.live   { color: #ef9a9a; }
+    .bm.live          { border-color: #4a2a2a; }
+
+    /* ── Progress bar ──────────────────────────────────────────────────────── */
+    .progress-bar-track {
+        height: 3px;
+        background: #1a1a2e;
+        border-radius: 2px;
+        overflow: hidden;
+        margin-bottom: 12px;
+    }
+    .progress-bar-fill {
+        height: 100%;
+        background: linear-gradient(90deg, #42a5f5, #66bb6a);
+        border-radius: 2px;
+        transition: width .6s ease;
+    }
+
+
+    .winner-banner {
+        background: linear-gradient(135deg, #2a2a1a 0%, #1a1a0a 100%);
+        border: 2px solid #b8860b;
+        border-radius: 14px;
+        padding: 20px 32px;
+        text-align: center;
+        box-shadow: 0 0 30px rgba(255,215,0,.15);
+    }
+</style>
+
+<MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="my-4">
+
+    <div class="d-flex align-center mb-3" style="gap:12px;">
+        <div style="font-size: 2rem; font-weight: bold;">🏆 Tournament</div>
+        @if (_isLoading)
+        {
+            <MudProgressCircular Size="Size.Small" Indeterminate="true" />
+        }
+        @if (_liveGameCount > 0)
+        {
+            <div style="display:flex; align-items:center; gap:5px; background:#2a1a1a; border:1px solid #4a2a2a; border-radius:20px; padding:3px 10px; font-size:.8rem;">
+                <span class="live-dot"></span>
+                <span style="color:#ef9a9a;">@_liveGameCount game@(_liveGameCount == 1 ? "" : "s") live</span>
+            </div>
+        }
+        <MudText Typo="Typo.caption" Style="color:#555; margin-left:auto;">
+            Auto-refresh · @_lastRefreshed.ToString("HH:mm:ss")
+        </MudText>
+    </div>
+
+    @if (!string.IsNullOrEmpty(_error))
+    {
+        <MudAlert Severity="Severity.Error" Class="mb-4">@_error</MudAlert>
+    }
+
+    @if (_tournaments.Count == 0 && !_isLoading)
+    {
+        <MudAlert Severity="Severity.Info">
+            No tournaments yet. Ask the organiser to create one via the Admin panel.
+        </MudAlert>
+    }
+    else
+    {
+        <!-- ── Tournament picker ─────────────────────────────────────────── -->
+        @if (_tournaments.Count > 1)
+        {
+            <div class="d-flex flex-wrap mb-4" style="gap:8px;">
+                @foreach (var t in _tournaments)
+                {
+                    <MudButton Variant="@(_selectedId == t.TournamentId ? Variant.Filled : Variant.Outlined)"
+                               Color="@StatusColour(t.Status)"
+                               Size="Size.Small"
+                               OnClick="@(() => SelectAsync(t.TournamentId))">
+                        @t.Name &nbsp;
+                        <small style="opacity:.7;">@t.Status · @t.ParticipantCount/@t.MaxParticipants</small>
+                    </MudButton>
+                }
+            </div>
+        }
+
+        @if (_bracket is not null)
+        {
+            var names = _bracket.Participants.ToDictionary(p => p.BotId, p => p.BotName);
+
+            <!-- ── Status chip + winner banner ──────────────────────────── -->
+            <div class="d-flex align-center mb-4" style="gap:10px; flex-wrap:wrap;">
+                <MudText Typo="Typo.h6">@_bracket.TournamentName</MudText>
+                <MudChip T="string" Color="@StatusColour(_bracket.Status)" Size="Size.Small">@_bracket.Status</MudChip>
+            </div>
+
+            @if (_bracket.Status == "Completed" && _bracket.WinnerId.HasValue)
+            {
+                var wName = names.GetValueOrDefault(_bracket.WinnerId.Value, "Unknown");
+                <div class="winner-banner mb-5">
+                    <div style="font-size:2.5rem;">🏆</div>
+                    <div style="font-size:1.5rem; font-weight:700; color:#ffd700; margin:.4rem 0;">@wName</div>
+                    <div style="color:#aaa; font-size:.9rem;">Tournament Champion</div>
+                </div>
+            }
+
+            <!-- ── Pending: waiting room ─────────────────────────────────── -->
+            @if (_bracket.Status == "Pending")
+            {
+                <MudGrid Spacing="4">
+                    <MudItem xs="12" md="5">
+                        <MudCard Elevation="3">
+                            <MudCardHeader>
+                                <CardHeaderContent>
+                                    <MudText Typo="Typo.subtitle1">
+                                        👾 Registered Bots — @_bracket.Participants.Count / @(_tournaments.FirstOrDefault(t => t.TournamentId == _selectedId)?.MaxParticipants ?? 0)
+                                    </MudText>
+                                </CardHeaderContent>
+                            </MudCardHeader>
+                            <MudCardContent>
+                                @if (_bracket.Participants.Count == 0)
+                                {
+                                    <MudText Style="color:#666;" Typo="Typo.body2">
+                                        No bots yet — register below!
+                                    </MudText>
+                                }
+                                else
+                                {
+                                    <div class="d-flex flex-wrap" style="gap:8px;">
+                                        @foreach (var p in _bracket.Participants)
+                                        {
+                                            <div class="bot-pill">
+                                                <span>🤖</span>
+                                                <span>@p.BotName</span>
+                                            </div>
+                                        }
+                                    </div>
+                                }
+                            </MudCardContent>
+                        </MudCard>
+                    </MudItem>
+
+                    <MudItem xs="12" md="7">
+                        <MudCard Elevation="3">
+                            <MudCardHeader>
+                                <CardHeaderContent>
+                                    <MudText Typo="Typo.subtitle1">🔌 How to Join</MudText>
+                                </CardHeaderContent>
+                            </MudCardHeader>
+                            <MudCardContent>
+                                <div class="join-box">
+                                    POST @GetBaseUrl()/api/tournament/@_bracket.TournamentId/join<br/>
+                                    <br/>
+                                    @("{") <br/>
+                                    &nbsp;&nbsp;"botId":   "&lt;your-stable-guid&gt;",<br/>
+                                    &nbsp;&nbsp;"botName": "&lt;YourTeamName&gt;",<br/>
+                                    &nbsp;&nbsp;"lineup":  ["Mickey","Donald","Scrooge","Minnie","Goofy"]<br/>
+                                    @("}")
+                                </div>
+                                <MudText Typo="Typo.caption" Style="color:#555;" Class="mt-2 d-block">
+                                    No authentication required. Call this once while the tournament is Pending.
+                                    The organiser will start it once all bots have registered.
+                                </MudText>
+                            </MudCardContent>
+                        </MudCard>
+                    </MudItem>
+                </MudGrid>
+            }
+
+            <!-- ── Standings (group + knockout stages) ───────────────────── -->
+            @if (_standings is not null && _standings.Standings.Count > 0)
+            {
+                <div style="margin-top:2rem; margin-bottom:.5rem; font-size:1.1rem; font-weight:600;">
+                    📊 Group Stage Standings
+                </div>
+                <MudCard Elevation="2" Class="mb-4">
+                    <MudCardContent Class="pa-0">
+                        <table class="standings-table">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Bot</th>
+                                    <th>P</th>
+                                    <th>W</th>
+                                    <th>D</th>
+                                    <th>L</th>
+                                    <th>Pts</th>
+                                    <th>Coins</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var s in _standings.Standings)
+                                {
+                                    <tr class="@(s.Rank <= (_bracket.KnockoutRounds.Count > 0 || _bracket.Status == "KnockoutStage" || _bracket.Status == "Completed" ? 99 : 4) ? "top" : "")">
+                                        <td>
+                                            @switch (s.Rank)
+                                            {
+                                                case 1: <span>🥇</span> break;
+                                                case 2: <span>🥈</span> break;
+                                                case 3: <span>🥉</span> break;
+                                                default: <span style="color:#555;">@s.Rank</span> break;
+                                            }
+                                        </td>
+                                        <td><strong>@s.BotName</strong></td>
+                                        <td>@s.Played</td>
+                                        <td style="color:#66bb6a;">@s.Wins</td>
+                                        <td style="color:#ffb74d;">@s.Draws</td>
+                                        <td style="color:#ef5350;">@s.Losses</td>
+                                        <td><MudChip T="string" Size="Size.Small" Color="Color.Primary">@s.Points</MudChip></td>
+                                        <td style="color:#aaa;">@s.TotalCoins</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </MudCardContent>
+                </MudCard>
+            }
+
+            <!-- ── Group matches grid ────────────────────────────────────── -->
+            @if (_bracket.GroupMatches.Count > 0)
+            {
+                var totalMatches = _bracket.GroupMatches.Count;
+                var doneMatches  = _bracket.GroupMatches.Count(m => m.IsCompleted);
+                var liveMatches  = _bracket.GroupMatches.Count(m => m.GameId.HasValue && !m.IsCompleted);
+                var pct = totalMatches > 0 ? (double)doneMatches / totalMatches * 100 : 0;
+
+                <div style="margin-top:2rem; margin-bottom:.5rem; display:flex; align-items:baseline; gap:10px;">
+                    <span style="font-size:1.1rem; font-weight:600;">🎮 Group Matches</span>
+                    <span style="font-size:.8rem; color:#666;">@doneMatches / @totalMatches done</span>
+                    @if (liveMatches > 0)
+                    {
+                        <span style="font-size:.78rem; display:flex; align-items:center; gap:4px; color:#ef9a9a;">
+                            <span class="live-dot"></span>@liveMatches in progress
+                        </span>
+                    }
+                </div>
+                <div class="progress-bar-track mb-1">
+                    <div class="progress-bar-fill" style="width:@(pct.ToString("F1", System.Globalization.CultureInfo.InvariantCulture))%;"></div>
+                </div>
+                <div class="gm-grid mb-5">
+                    @foreach (var m in _bracket.GroupMatches)
+                    {
+                        var b1 = names.GetValueOrDefault(m.BotOne, ShortId(m.BotOne));
+                        var b2 = names.GetValueOrDefault(m.BotTwo, ShortId(m.BotTwo));
+                        var w1 = m.WinnerId == m.BotOne;
+                        var w2 = m.WinnerId == m.BotTwo;
+                        var isLive = m.GameId.HasValue && !m.IsCompleted;
+                        var cssCard = m.IsCompleted ? (m.IsDraw ? "gm-card draw" : "gm-card completed")
+                                    : isLive        ? "gm-card live"
+                                    :                 "gm-card";
+                        var headerCss  = isLive ? "gm-header live" : "gm-header";
+                        var headerText = m.IsCompleted ? (m.IsDraw ? "🤝 Draw" : "✅ Done")
+                                       : isLive        ? "🔴 Live"
+                                       :                 "⏳ Pending";
+                        <div class="@cssCard">
+                            <div class="@headerCss" style="display:flex; align-items:center; gap:4px;">
+                                @if (isLive) { <span class="live-dot"></span> }
+                                <span>@headerText</span>
+                            </div>
+                            <div class="gm-row @(w1 ? "winner" : m.IsCompleted && !w1 ? "pending" : "")">
+                                @if (w1) { <span>🏆</span> }
+                                <span>@b1</span>
+                                @if (m.IsCompleted)
+                                {
+                                    <span class="gm-score">@m.BotOneScore</span>
+                                }
+                            </div>
+                            <div class="gm-row @(w2 ? "winner" : m.IsCompleted && !w2 ? "pending" : "")">
+                                @if (w2) { <span>🏆</span> }
+                                <span>@b2</span>
+                                @if (m.IsCompleted)
+                                {
+                                    <span class="gm-score">@m.BotTwoScore</span>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
+
+            <!-- ── Knockout visual bracket ───────────────────────────────── -->
+            @if (_bracket.KnockoutRounds.Count > 0)
+            {
+                var rounds = _bracket.KnockoutRounds.OrderBy(r => r.Round).ToList();
+                var totalRounds = rounds.Count;
+                // First round has the most matches (a power of 2)
+                var firstCount = rounds[0].Matches.Count;
+                // Compute total canvas height
+                var totalH = firstCount * (CardH + CardGap) - CardGap;
+                // Total canvas width
+                var totalW = totalRounds * CardW + (totalRounds - 1) * ConnW + totalRounds * RoundPad * 2;
+
+                <div style="margin-top:2rem; margin-bottom:.75rem; display:flex; align-items:baseline; gap:10px;">
+                    <span style="font-size:1.1rem; font-weight:600;">⚡ Knockout Bracket</span>
+                    @{
+                        var allKo = rounds.SelectMany(r => r.Matches).ToList();
+                        var doneKo = allKo.Count(m => m.IsCompleted);
+                        var liveKo = allKo.Count(m => m.GameId.HasValue && !m.IsCompleted && !m.IsBye);
+                        if (liveKo > 0)
+                        {
+                            <span style="font-size:.78rem; display:flex; align-items:center; gap:4px; color:#ef9a9a;">
+                                <span class="live-dot"></span>@liveKo in progress
+                            </span>
+                        }
+                    }
+                </div>
+
+                <div class="bracket-scroll">
+                    <div class="bracket-canvas" style="width:@(totalW)px; height:@(totalH)px; position:relative;">
+
+                        @for (var ri = 0; ri < rounds.Count; ri++)
+                        {
+                            var round = rounds[ri];
+                            var roundLeft = ri * (CardW + ConnW + RoundPad * 2) + RoundPad;
+                            var slotH = SlotH(ri, firstCount);
+                            var isFinal = ri == rounds.Count - 1;
+
+                            <!-- Round column label -->
+                            <div style="position:absolute; left:@(roundLeft)px; top:-26px; width:@(CardW)px;
+                                        text-align:center; font-size:.7rem; text-transform:uppercase;
+                                        letter-spacing:.08em; color:#555;">
+                                @RoundLabel(round.Round, totalRounds)
+                            </div>
+
+                            @foreach (var (match, mi) in round.Matches.Select((m, i) => (m, i)))
+                            {
+                                var cardTop = MatchTop(ri, mi, firstCount);
+                                var b1 = match.BotOne.HasValue ? names.GetValueOrDefault(match.BotOne.Value, ShortId(match.BotOne.Value)) : null;
+                                var b2 = match.BotTwo.HasValue ? names.GetValueOrDefault(match.BotTwo.Value, ShortId(match.BotTwo.Value)) : null;
+                                var w1 = match.WinnerId.HasValue && match.WinnerId == match.BotOne;
+                                var w2 = match.WinnerId.HasValue && match.WinnerId == match.BotTwo;
+                                var cardClass = "bm" + (match.IsCompleted ? " completed" : "") + (isFinal ? " final-match" : "") + (!match.IsCompleted && match.GameId.HasValue && !match.IsBye ? " live" : "");
+
+                                <div class="@cardClass"
+                                     style="left:@(roundLeft)px; top:@(cardTop)px; height:@(CardH)px;">
+
+                                    @if (isFinal)
+                                    {
+                                        <div class="bm-label" style="color:#b8860b;">⭐ Final</div>
+                                    }
+                                    else if (!match.IsCompleted && match.GameId.HasValue && !match.IsBye)
+                                    {
+                                        <div class="bm-label" style="display:flex; align-items:center; justify-content:center; gap:3px; color:#ef9a9a;">
+                                            <span class="live-dot"></span><span>Live</span>
+                                        </div>
+                                    }
+
+                                    @if (match.IsBye)
+                                    {
+                                        <div class="bp @(b1 != null ? "active" : "tbd")">
+                                            @if (b1 != null) { <span>🤖</span> <span>@b1</span> }
+                                            else { <span>TBD</span> }
+                                        </div>
+                                        <div class="bp tbd"><span>Bye ✓</span></div>
+                                    }
+                                    else
+                                    {
+                                        <div class="bp @(w1 ? "winner" : b1 != null ? "active" : "tbd")">
+                                            @if (w1) { <span class="trophy">🏆</span> }
+                                            <span>@(b1 ?? "TBD")</span>
+                                        </div>
+                                        <div class="bp @(w2 ? "winner" : b2 != null ? "active" : "tbd")">
+                                            @if (w2) { <span class="trophy">🏆</span> }
+                                            <span>@(b2 ?? "TBD")</span>
+                                        </div>
+                                    }
+                                </div>
+                            }
+
+                            <!-- SVG connectors from this round to the next -->
+                            @if (ri < rounds.Count - 1)
+                            {
+                                var svgLeft = roundLeft + CardW;
+                                var nextSlotH = SlotH(ri + 1, firstCount);
+
+                                <svg style="position:absolute; left:@(svgLeft)px; top:0; overflow:visible;"
+                                     width="@(ConnW + RoundPad * 2)" height="@(totalH)"
+                                     xmlns="http://www.w3.org/2000/svg">
+                                    @{
+                                        var matchesThisRound = rounds[ri].Matches.Count;
+                                        for (var mi2 = 0; mi2 < matchesThisRound; mi2 += 2)
+                                        {
+                                            // Two matches in this round feed one match in the next
+                                            var topY = MatchCenterY(ri, mi2, firstCount);
+                                            var botY = MatchCenterY(ri, mi2 + 1 < matchesThisRound ? mi2 + 1 : mi2, firstCount);
+                                            var midY = (topY + botY) / 2;
+                                            var halfConn = (ConnW + RoundPad * 2) / 2;
+                                            var fullConn = ConnW + RoundPad * 2;
+
+                                            // Path: horizontal arm from top match → join point → horizontal arm to next round
+                                            //       plus horizontal arm from bottom match → join point
+                                            <path d="M 0 @topY H @halfConn V @botY H 0"
+                                                  fill="none" stroke="#3a3a5a" stroke-width="1.5"
+                                                  stroke-linecap="round" stroke-linejoin="round"/>
+                                            <path d="M @halfConn @midY H @fullConn"
+                                                  fill="none" stroke="#3a3a5a" stroke-width="1.5"
+                                                  stroke-linecap="round"/>
+                                        }
+                                    }
+                                </svg>
+                            }
+                        }
+                    </div>
+                </div>
+            }
+        }
+    }
+
+</MudContainer>
+
+@code {
+    // ── Layout constants ──────────────────────────────────────────────────────
+    private const int CardH    = 72;   // match card height (px)
+    private const int CardGap  = 28;   // vertical gap between cards in round 1
+    private const int CardW    = 190;  // match card width (px)
+    private const int ConnW    = 32;   // SVG connector width between rounds
+    private const int RoundPad = 10;   // extra padding either side of a round column
+
+    // ── State ─────────────────────────────────────────────────────────────────
+    private List<TournamentSummaryDto> _tournaments = [];
+    private Guid? _selectedId;
+    private TournamentBracketDto? _bracket;
+    private TournamentStandingsDto? _standings;
+    private bool _isLoading = true;
+    private string? _error;
+    private DateTime _lastRefreshed = DateTime.Now;
+    private int _liveGameCount;
+    private CancellationTokenSource? _cts;
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+    protected override async Task OnInitializedAsync()
+    {
+        _cts = new CancellationTokenSource();
+        await LoadAllAsync();
+        _ = RefreshLoopAsync(_cts.Token);
+    }
+
+    private async Task RefreshLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                // Refresh faster when games are actively running
+                var delay = _liveGameCount > 0 ? TimeSpan.FromSeconds(3) : TimeSpan.FromSeconds(10);
+                await Task.Delay(delay, ct);
+                await LoadAllAsync();
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private async Task LoadAllAsync()
+    {
+        try
+        {
+            _isLoading = true;
+            _error = null;
+
+            var all = await Mediator.Send(new GetAllTournamentsQuery());
+
+            // Sort: active first, then by most recent
+            _tournaments = all
+                .OrderBy(t => t.Status switch
+                {
+                    "GroupStage"    => 0,
+                    "KnockoutStage" => 1,
+                    "Pending"       => 2,
+                    "Completed"     => 3,
+                    _               => 4
+                })
+                .ThenByDescending(t => t.CreatedAtUtc)
+                .ToList();
+
+            // Auto-select best tournament
+            if (_selectedId is null || _tournaments.All(t => t.TournamentId != _selectedId))
+                _selectedId = _tournaments.FirstOrDefault()?.TournamentId;
+
+            if (_selectedId.HasValue)
+                await LoadBracketAsync(_selectedId.Value);
+
+            _lastRefreshed = DateTime.Now;
+        }
+        catch (Exception ex)
+        {
+            _error = $"Failed to load: {ex.Message}";
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task LoadBracketAsync(Guid id)
+    {
+        try
+        {
+            _bracket = await Mediator.Send(new GetTournamentBracketQuery(id));
+
+            _standings = _bracket.Status is "GroupStage" or "KnockoutStage" or "Completed"
+                ? await Mediator.Send(new GetTournamentStandingsQuery(id))
+                : null;
+
+            // Count in-progress games across all stages
+            var groupLive    = _bracket.GroupMatches.Count(m => m.GameId.HasValue && !m.IsCompleted);
+            var knockoutLive = _bracket.KnockoutRounds.SelectMany(r => r.Matches)
+                                       .Count(m => m.GameId.HasValue && !m.IsCompleted && !m.IsBye);
+            _liveGameCount = groupLive + knockoutLive;
+        }
+        catch (Exception ex)
+        {
+            _error = $"Failed to load bracket: {ex.Message}";
+            _bracket = null;
+            _standings = null;
+            _liveGameCount = 0;
+        }
+    }
+
+    private async Task SelectAsync(Guid id)
+    {
+        _selectedId = id;
+        _bracket = null;
+        _standings = null;
+        await LoadBracketAsync(id);
+        StateHasChanged();
+    }
+
+    // ── Bracket layout helpers ────────────────────────────────────────────────
+
+    /// <summary>Slot height for a given round index (doubles each round).</summary>
+    private int SlotH(int roundIndex, int firstCount) =>
+        (CardH + CardGap) * (1 << roundIndex);
+
+    /// <summary>Top pixel offset for match [roundIndex, matchIndex].</summary>
+    private int MatchTop(int roundIndex, int matchIndex, int firstCount)
+    {
+        var slotH = SlotH(roundIndex, firstCount);
+        return matchIndex * slotH + (slotH - CardH) / 2;
+    }
+
+    /// <summary>Vertical center pixel for match [roundIndex, matchIndex].</summary>
+    private int MatchCenterY(int roundIndex, int matchIndex, int firstCount)
+    {
+        var slotH = SlotH(roundIndex, firstCount);
+        return matchIndex * slotH + slotH / 2;
+    }
+
+    // ── UI helpers ────────────────────────────────────────────────────────────
+
+    private static string RoundLabel(int round, int totalRounds) =>
+        (totalRounds - round) switch
+        {
+            0 => "Final",
+            1 => "Semi-Finals",
+            2 => "Quarter-Finals",
+            _ => $"Round {round}"
+        };
+
+    private static Color StatusColour(string status) => status switch
+    {
+        "Pending"       => Color.Default,
+        "GroupStage"    => Color.Primary,
+        "KnockoutStage" => Color.Warning,
+        "Completed"     => Color.Success,
+        "Cancelled"     => Color.Error,
+        _               => Color.Default
+    };
+
+    private static string ShortId(Guid id) => id.ToString()[..8] + "…";
+
+    private static string GetBaseUrl() => "http://localhost:7102";
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+    }
+}

--- a/src/ScrambleCoin.Web/Program.cs
+++ b/src/ScrambleCoin.Web/Program.cs
@@ -51,8 +51,7 @@ try
     builder.Services.AddMediatR(cfg =>
     {
         cfg.RegisterServicesFromAssemblies(
-            typeof(ScrambleCoin.Application.Games.CreateGame.CreateGameCommandHandler).Assembly,
-            typeof(ScrambleCoin.Web.Notifications.BroadcastGameEndedOnFinishedHandler).Assembly);
+            typeof(ScrambleCoin.Application.Games.CreateGame.CreateGameCommandHandler).Assembly);
         // Serialization must wrap everything — register first so it is the outermost behaviour.
         cfg.AddOpenBehavior(typeof(GameSerializationBehaviour<,>));
         cfg.AddOpenBehavior(typeof(SignalRBroadcastBehaviour<,>));

--- a/src/ScrambleCoin.Web/Program.cs
+++ b/src/ScrambleCoin.Web/Program.cs
@@ -80,12 +80,12 @@ try
         sp => sp.GetRequiredService<ScrambleCoinDbContext>());
 
     // ── Application Services ───────────────────────────────────────────────────
-    builder.Services.AddScoped<ScrambleCoin.Application.Services.ICoinSpawnService,
-        ScrambleCoin.Application.Services.CoinSpawnService>();
-    builder.Services.AddScoped<ScrambleCoin.Application.Services.IVillainActionDispatcher,
-        ScrambleCoin.Application.Services.VillainActionDispatcher>();
-    builder.Services.AddScoped<ScrambleCoin.Application.Services.IVillainAutomationService,
-        ScrambleCoin.Application.Services.VillainAutomationService>();
+    builder.Services.AddScoped<ICoinSpawnService,
+        CoinSpawnService>();
+    builder.Services.AddScoped<IVillainActionDispatcher,
+        VillainActionDispatcher>();
+    builder.Services.AddScoped<IVillainAutomationService,
+        VillainAutomationService>();
     builder.Services.AddSingleton<ScrambleCoin.Application.Services.Villains.IVillainStrategyFactory,
         ScrambleCoin.Application.Services.Villains.VillainStrategyFactory>();
     builder.Services.AddSingleton<Random>();

--- a/src/ScrambleCoin.Web/Program.cs
+++ b/src/ScrambleCoin.Web/Program.cs
@@ -4,6 +4,7 @@ using Serilog.Events;
 using Microsoft.EntityFrameworkCore;
 using ScrambleCoin.Application.Abstractions;
 using ScrambleCoin.Application.Behaviours;
+using ScrambleCoin.Application.Services;
 using ScrambleCoin.Infrastructure.Persistence;
 using ScrambleCoin.Web.Hubs;
 
@@ -52,8 +53,11 @@ try
         cfg.RegisterServicesFromAssemblies(
             typeof(ScrambleCoin.Application.Games.CreateGame.CreateGameCommandHandler).Assembly,
             typeof(ScrambleCoin.Web.Notifications.BroadcastGameEndedOnFinishedHandler).Assembly);
+        // Serialization must wrap everything — register first so it is the outermost behaviour.
+        cfg.AddOpenBehavior(typeof(GameSerializationBehaviour<,>));
         cfg.AddOpenBehavior(typeof(SignalRBroadcastBehaviour<,>));
     });
+    builder.Services.AddSingleton<GameLockService>();
 
     // ── Database & EF Core ─────────────────────────────────────────────────────
     var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");

--- a/src/ScrambleCoin.Web/Shared/NavBar.razor
+++ b/src/ScrambleCoin.Web/Shared/NavBar.razor
@@ -14,6 +14,9 @@
             <MudNavLink Href="/leaderboard" Icon="@Icons.Material.Filled.EmojiEvents" IconColor="Color.Inherit">
                 Leaderboard
             </MudNavLink>
+            <MudNavLink Href="/tournament" Icon="@Icons.Material.Filled.AccountTree" IconColor="Color.Inherit">
+                Tournament
+            </MudNavLink>
             <MudNavLink Href="/admin" Icon="@Icons.Material.Filled.Settings" IconColor="Color.Inherit">
                 Admin
             </MudNavLink>

--- a/src/ScrambleCoint.Console.PlayGround/Program.cs
+++ b/src/ScrambleCoint.Console.PlayGround/Program.cs
@@ -252,4 +252,7 @@ sealed class InMemoryGameRepository(Game initial) : IGameRepository
 
     public Task<bool> HasActiveGameAsync(Guid playerId, CancellationToken cancellationToken = default)
         => Task.FromResult(false);
+
+    public Task<IReadOnlyList<ScrambleCoin.Application.Games.Admin.ActiveGameSummaryDto>> GetAllActiveAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<ScrambleCoin.Application.Games.Admin.ActiveGameSummaryDto>>([]);
 }

--- a/tests/ScrambleCoin.Application.Tests/CoinSpawnServiceTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/CoinSpawnServiceTests.cs
@@ -40,13 +40,23 @@ public class CoinSpawnServiceTests
         game.SetLineup(p2, new Lineup(p2Pieces));
         game.Start(); // → CoinSpawn, turn 1
 
-        // Advance through (targetTurn - 1) full turns without pieces on the board.
+        // Advance through (targetTurn - 1) full turns with one piece per player on the board
+        // so MovePhase is not immediately auto-skipped (0-piece auto-skip behaviour).
+        // Place pieces on turn 1; skip placement on subsequent turns (pieces stay on board).
         for (var t = 1; t < targetTurn; t++)
         {
-            game.AdvancePhase();     // CoinSpawn → PlacePhase
-            game.SkipPlacement(p1); // P1 skips
-            game.SkipPlacement(p2); // P2 skips → auto-advances to MovePhase
-            game.AdvanceTurn();     // MovePhase → CoinSpawn (next turn)
+            game.AdvancePhase(); // CoinSpawn → PlacePhase
+            if (t == 1)
+            {
+                game.PlacePiece(p1, p1Pieces[0].Id, new Position(0, 0)); // places + marks p1 done
+                game.PlacePiece(p2, p2Pieces[0].Id, new Position(7, 7)); // marks p2 done → auto-advances to MovePhase
+            }
+            else
+            {
+                game.SkipPlacement(p1);
+                game.SkipPlacement(p2); // auto-advances to MovePhase (pieces already on board)
+            }
+            game.AdvanceTurn(); // MovePhase → CoinSpawn (next turn)
         }
 
         return (game, p1, p2);

--- a/tests/ScrambleCoin.Application.Tests/Games/Admin/ForceEndGameCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/Games/Admin/ForceEndGameCommandHandlerTests.cs
@@ -159,6 +159,33 @@ public sealed class ForceEndGameCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WhenGameIsInProgress_PublishesCorrectWinnerIdAndIsDraw_WhenOnePlayerLeads()
+    {
+        // Arrange — give PlayerOne a score advantage so the game is not a draw.
+        var game = InProgressGame();
+        game.AddScore(game.PlayerOne, 5);
+
+        var gameRepo  = Substitute.For<IGameRepository>();
+        var publisher = Substitute.For<IPublisher>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        GameFinished? capturedNotification = null;
+        await publisher.Publish(
+            Arg.Do<GameFinished>(n => capturedNotification = n),
+            Arg.Any<CancellationToken>());
+
+        var handler = BuildHandler(gameRepo, publisher);
+
+        // Act
+        await handler.Handle(new ForceEndGameCommand(game.Id), CancellationToken.None);
+
+        // Assert: PlayerOne leads → IsDraw = false, WinnerId = PlayerOne.
+        Assert.NotNull(capturedNotification);
+        Assert.False(capturedNotification!.IsDraw);
+        Assert.Equal(game.PlayerOne, capturedNotification.WinnerId);
+    }
+
+    [Fact]
     public async Task Handle_WhenGameIsInProgress_SavesGameBeforePublishing()
     {
         // Verify ordering by making SaveAsync throw — Publish must not be called if Save fails.

--- a/tests/ScrambleCoin.Application.Tests/Games/Admin/ForceEndGameCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/Games/Admin/ForceEndGameCommandHandlerTests.cs
@@ -1,0 +1,264 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using ScrambleCoin.Application.Games.Admin;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Application.Notifications;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Tests.Helpers;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Tests.Games.Admin;
+
+/// <summary>
+/// Unit tests for <see cref="ForceEndGameCommandHandler"/> (Issue #57).
+/// </summary>
+public sealed class ForceEndGameCommandHandlerTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static readonly IReadOnlyList<string> DefaultLineup =
+        ["Mickey", "Minnie", "Donald", "Goofy", "Scrooge"];
+
+    private static Lineup MakeLineup(Guid playerId) =>
+        new(DefaultLineup.Select(n => PieceFactory.Any(n, playerId)).ToList());
+
+    /// <summary>Creates a fresh game in <see cref="GameStatus.WaitingForBots"/> state.</summary>
+    private static Game WaitingGame()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        return new Game(p1, p2, new Board());
+    }
+
+    /// <summary>Creates a game that has had both lineups set and Start() called — status = InProgress.</summary>
+    private static Game InProgressGame()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, MakeLineup(p1));
+        game.SetLineup(p2, MakeLineup(p2));
+        game.Start();
+        return game;
+    }
+
+    /// <summary>Creates a game that is already <see cref="GameStatus.Finished"/>.</summary>
+    private static Game FinishedGame()
+    {
+        var game = InProgressGame();
+        game.End();
+        return game;
+    }
+
+    /// <summary>Creates a game that is already <see cref="GameStatus.Cancelled"/>.</summary>
+    private static Game CancelledGame()
+    {
+        var game = WaitingGame();
+        game.ForceCancel();
+        return game;
+    }
+
+    private static ForceEndGameCommandHandler BuildHandler(
+        IGameRepository gameRepo,
+        IPublisher publisher)
+    {
+        var logger = Substitute.For<ILogger<ForceEndGameCommandHandler>>();
+        return new ForceEndGameCommandHandler(gameRepo, publisher, logger);
+    }
+
+    // ── Already-terminal states ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenGameIsFinished_SkipsEndingAndDoesNotPublish()
+    {
+        // Arrange
+        var game = FinishedGame();
+        var gameRepo  = Substitute.For<IGameRepository>();
+        var publisher = Substitute.For<IPublisher>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var handler = BuildHandler(gameRepo, publisher);
+
+        // Act
+        await handler.Handle(new ForceEndGameCommand(game.Id), CancellationToken.None);
+
+        // Assert: status stays Finished and no notification is published.
+        Assert.Equal(GameStatus.Finished, game.Status);
+        await publisher.DidNotReceive().Publish(Arg.Any<GameFinished>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenGameIsCancelled_SkipsEndingAndDoesNotPublish()
+    {
+        // Arrange
+        var game = CancelledGame();
+        var gameRepo  = Substitute.For<IGameRepository>();
+        var publisher = Substitute.For<IPublisher>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var handler = BuildHandler(gameRepo, publisher);
+
+        // Act
+        await handler.Handle(new ForceEndGameCommand(game.Id), CancellationToken.None);
+
+        // Assert: status stays Cancelled and no notification is published.
+        Assert.Equal(GameStatus.Cancelled, game.Status);
+        await publisher.DidNotReceive().Publish(Arg.Any<GameFinished>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── InProgress path ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenGameIsInProgress_CallsEndAndPublishesGameFinished()
+    {
+        // Arrange
+        var game = InProgressGame();
+        var gameRepo  = Substitute.For<IGameRepository>();
+        var publisher = Substitute.For<IPublisher>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var handler = BuildHandler(gameRepo, publisher);
+
+        // Act
+        await handler.Handle(new ForceEndGameCommand(game.Id), CancellationToken.None);
+
+        // Assert: game transitions to Finished.
+        Assert.Equal(GameStatus.Finished, game.Status);
+
+        // Assert: GameFinished notification is published with the game's ID.
+        await publisher.Received(1).Publish(
+            Arg.Is<GameFinished>(n => n.GameId == game.Id),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenGameIsInProgress_PublishesCorrectWinnerIdAndIsDraw()
+    {
+        // Arrange — start with a tied score (0–0) → should be a draw.
+        var game = InProgressGame();
+        var gameRepo  = Substitute.For<IGameRepository>();
+        var publisher = Substitute.For<IPublisher>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        GameFinished? capturedNotification = null;
+        await publisher.Publish(
+            Arg.Do<GameFinished>(n => capturedNotification = n),
+            Arg.Any<CancellationToken>());
+
+        var handler = BuildHandler(gameRepo, publisher);
+
+        // Act
+        await handler.Handle(new ForceEndGameCommand(game.Id), CancellationToken.None);
+
+        // Assert: equal scores (both 0) → IsDraw = true, WinnerId = null.
+        Assert.NotNull(capturedNotification);
+        Assert.True(capturedNotification!.IsDraw);
+        Assert.Null(capturedNotification.WinnerId);
+    }
+
+    [Fact]
+    public async Task Handle_WhenGameIsInProgress_SavesGameBeforePublishing()
+    {
+        // Verify ordering by making SaveAsync throw — Publish must not be called if Save fails.
+        var game = InProgressGame();
+        var gameRepo  = Substitute.For<IGameRepository>();
+        var publisher = Substitute.For<IPublisher>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+        gameRepo.SaveAsync(Arg.Any<Game>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("Save failed")));
+
+        var handler = BuildHandler(gameRepo, publisher);
+
+        // Act — the handler should propagate the save exception.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => handler.Handle(new ForceEndGameCommand(game.Id), CancellationToken.None));
+
+        // Assert: if Save raised an exception, Publish was never reached.
+        await publisher.DidNotReceive().Publish(
+            Arg.Any<GameFinished>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── WaitingForBots path ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenGameIsWaitingForBots_CallsForceCancelAndDoesNotPublishGameFinished()
+    {
+        // Arrange
+        var game = WaitingGame();
+        var gameRepo  = Substitute.For<IGameRepository>();
+        var publisher = Substitute.For<IPublisher>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var handler = BuildHandler(gameRepo, publisher);
+
+        // Act
+        await handler.Handle(new ForceEndGameCommand(game.Id), CancellationToken.None);
+
+        // Assert: game is cancelled (ForceCancel was called).
+        Assert.Equal(GameStatus.Cancelled, game.Status);
+
+        // Assert: no GameFinished notification is published.
+        await publisher.DidNotReceive().Publish(
+            Arg.Any<GameFinished>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenGameIsWaitingForBots_SavesGame()
+    {
+        // Arrange
+        var game = WaitingGame();
+        var gameRepo  = Substitute.For<IGameRepository>();
+        var publisher = Substitute.For<IPublisher>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var handler = BuildHandler(gameRepo, publisher);
+
+        // Act
+        await handler.Handle(new ForceEndGameCommand(game.Id), CancellationToken.None);
+
+        // Assert: the cancelled game is still persisted.
+        await gameRepo.Received(1).SaveAsync(game, Arg.Any<CancellationToken>());
+    }
+
+    // ── Repository interaction ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenGameIsFinished_DoesNotCallSaveAsync()
+    {
+        // Arrange: already-finished game should be skipped entirely.
+        var game = FinishedGame();
+        var gameRepo  = Substitute.For<IGameRepository>();
+        var publisher = Substitute.For<IPublisher>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var handler = BuildHandler(gameRepo, publisher);
+
+        // Act
+        await handler.Handle(new ForceEndGameCommand(game.Id), CancellationToken.None);
+
+        // Assert: no persistence call was made.
+        await gameRepo.DidNotReceive().SaveAsync(Arg.Any<Game>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenGameIsCancelled_DoesNotCallSaveAsync()
+    {
+        // Arrange: already-cancelled game should be skipped entirely.
+        var game = CancelledGame();
+        var gameRepo  = Substitute.For<IGameRepository>();
+        var publisher = Substitute.For<IPublisher>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var handler = BuildHandler(gameRepo, publisher);
+
+        // Act
+        await handler.Handle(new ForceEndGameCommand(game.Id), CancellationToken.None);
+
+        // Assert: no persistence call was made.
+        await gameRepo.DidNotReceive().SaveAsync(Arg.Any<Game>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/ScrambleCoin.Application.Tests/Games/Admin/GetAllActiveGamesQueryHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/Games/Admin/GetAllActiveGamesQueryHandlerTests.cs
@@ -1,0 +1,133 @@
+using NSubstitute;
+using ScrambleCoin.Application.Games.Admin;
+using ScrambleCoin.Application.Interfaces;
+
+namespace ScrambleCoin.Application.Tests.Games.Admin;
+
+/// <summary>
+/// Unit tests for <see cref="GetAllActiveGamesQueryHandler"/> (Issue #57).
+/// </summary>
+public sealed class GetAllActiveGamesQueryHandlerTests
+{
+    private static GetAllActiveGamesQueryHandler BuildHandler(IGameRepository repo) =>
+        new(repo);
+
+    [Fact]
+    public async Task Handle_ReturnsActiveGamesFromRepository()
+    {
+        // Arrange
+        var expected = new List<ActiveGameSummaryDto>
+        {
+            new(
+                GameId:        Guid.NewGuid(),
+                PlayerOne:     Guid.NewGuid(),
+                PlayerTwo:     Guid.NewGuid(),
+                Status:        "InProgress",
+                TurnNumber:    2,
+                Phase:         "MovePhase",
+                ScorePlayerOne: 5,
+                ScorePlayerTwo: 3,
+                LastMoveAt:    DateTimeOffset.UtcNow),
+            new(
+                GameId:        Guid.NewGuid(),
+                PlayerOne:     Guid.NewGuid(),
+                PlayerTwo:     Guid.NewGuid(),
+                Status:        "WaitingForBots",
+                TurnNumber:    0,
+                Phase:         null,
+                ScorePlayerOne: 0,
+                ScorePlayerTwo: 0,
+                LastMoveAt:    DateTimeOffset.UtcNow),
+        }.AsReadOnly();
+
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetAllActiveAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<ActiveGameSummaryDto>)expected);
+
+        var handler = BuildHandler(repo);
+
+        // Act
+        var result = await handler.Handle(new GetAllActiveGamesQuery(), CancellationToken.None);
+
+        // Assert: the handler passes through exactly what the repository returns.
+        Assert.Equal(expected.Count, result.Count);
+        Assert.Equal(expected[0].GameId, result[0].GameId);
+        Assert.Equal(expected[1].GameId, result[1].GameId);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoActiveGames_ReturnsEmptyList()
+    {
+        // Arrange
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetAllActiveAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<ActiveGameSummaryDto>)new List<ActiveGameSummaryDto>().AsReadOnly());
+
+        var handler = BuildHandler(repo);
+
+        // Act
+        var result = await handler.Handle(new GetAllActiveGamesQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Handle_DelegatesDirectlyToRepository()
+    {
+        // Arrange
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetAllActiveAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<ActiveGameSummaryDto>)new List<ActiveGameSummaryDto>().AsReadOnly());
+
+        var handler = BuildHandler(repo);
+
+        // Act
+        await handler.Handle(new GetAllActiveGamesQuery(), CancellationToken.None);
+
+        // Assert: the handler calls the repository exactly once.
+        await repo.Received(1).GetAllActiveAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PreservesAllDtoFields()
+    {
+        // Arrange
+        var gameId    = Guid.NewGuid();
+        var playerOne = Guid.NewGuid();
+        var playerTwo = Guid.NewGuid();
+        var lastMove  = DateTimeOffset.UtcNow.AddMinutes(-3);
+
+        var summary = new ActiveGameSummaryDto(
+            GameId:        gameId,
+            PlayerOne:     playerOne,
+            PlayerTwo:     playerTwo,
+            Status:        "InProgress",
+            TurnNumber:    4,
+            Phase:         "PlacePhase",
+            ScorePlayerOne: 10,
+            ScorePlayerTwo: 7,
+            LastMoveAt:    lastMove);
+
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetAllActiveAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<ActiveGameSummaryDto>)new List<ActiveGameSummaryDto> { summary }.AsReadOnly());
+
+        var handler = BuildHandler(repo);
+
+        // Act
+        var result = await handler.Handle(new GetAllActiveGamesQuery(), CancellationToken.None);
+
+        // Assert: every field is preserved unchanged.
+        var dto = result.Single();
+        Assert.Equal(gameId,       dto.GameId);
+        Assert.Equal(playerOne,    dto.PlayerOne);
+        Assert.Equal(playerTwo,    dto.PlayerTwo);
+        Assert.Equal("InProgress", dto.Status);
+        Assert.Equal(4,            dto.TurnNumber);
+        Assert.Equal("PlacePhase", dto.Phase);
+        Assert.Equal(10,           dto.ScorePlayerOne);
+        Assert.Equal(7,            dto.ScorePlayerTwo);
+        Assert.Equal(lastMove,     dto.LastMoveAt);
+    }
+}

--- a/tests/ScrambleCoin.Application.Tests/GetBoardStateQueryHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/GetBoardStateQueryHandlerTests.cs
@@ -829,9 +829,12 @@ public class GetBoardStateQueryHandlerTests
     {
         // Arrange: advance game CoinSpawn → PlacePhase → MovePhase
         // After Start(), game is in CoinSpawn phase.
-        var (game, p1, _) = NewStartedGame();
+        var (game, p1, p2) = NewStartedGame();
         game.AdvancePhase(); // CoinSpawn → PlacePhase
-        game.AdvancePhase(); // PlacePhase → MovePhase; MovePhaseActivePlayer = PlayerOne
+        // Place one piece per player so MovePhase is not immediately auto-skipped.
+        game.PlacePiece(p1, game.LineupPlayerOne!.Pieces[0].Id, new Position(0, 0));
+        game.PlacePiece(p2, game.LineupPlayerTwo!.Pieces[0].Id, new Position(7, 7));
+        // MarkPlacePhaseActed auto-advances to MovePhase; MovePhaseActivePlayer = PlayerOne.
 
         var reg = MakeRegistration(game.Id, p1);
 

--- a/tests/ScrambleCoin.Application.Tests/GetTournamentBracketQueryHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/GetTournamentBracketQueryHandlerTests.cs
@@ -1,3 +1,4 @@
+using MediatR;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -23,10 +24,11 @@ public class GetTournamentBracketQueryHandlerTests
         ITournamentRepository tournamentRepo,
         IGameRepository gameRepo,
         IBotRegistrationRepository botRegRepo,
+        IPublisher publisher,
         IUnitOfWork uow)
     {
         var logger = Substitute.For<ILogger<GetTournamentBracketQueryHandler>>();
-        return new GetTournamentBracketQueryHandler(tournamentRepo, gameRepo, botRegRepo, uow, logger);
+        return new GetTournamentBracketQueryHandler(tournamentRepo, gameRepo, botRegRepo, uow, publisher, logger);
     }
 
     [Fact]
@@ -44,8 +46,9 @@ public class GetTournamentBracketQueryHandlerTests
         var gameRepo = Substitute.For<IGameRepository>();
         var botRegRepo = Substitute.For<IBotRegistrationRepository>();
         var uow = Substitute.For<IUnitOfWork>();
-
-        var handler = BuildHandler(repo, gameRepo, botRegRepo, uow);
+        var publisher = Substitute.For<IPublisher>();
+        
+        var handler = BuildHandler(repo, gameRepo, botRegRepo, publisher, uow);
         var result = await handler.Handle(
             new GetTournamentBracketQuery(tournamentId),
             CancellationToken.None);
@@ -65,9 +68,12 @@ public class GetTournamentBracketQueryHandlerTests
         repo.GetByIdAsync(tournamentId, Arg.Any<CancellationToken>())
             .Returns(tournament);
 
-        var handler = BuildHandler(repo, Substitute.For<IGameRepository>(),
-            Substitute.For<IBotRegistrationRepository>(), Substitute.For<IUnitOfWork>());
-
+        var gameRepo = Substitute.For<IGameRepository>();
+        var botRegRepo = Substitute.For<IBotRegistrationRepository>();
+        var uow = Substitute.For<IUnitOfWork>();
+        var publisher = Substitute.For<IPublisher>();
+        
+        var handler = BuildHandler(repo, gameRepo, botRegRepo, publisher, uow);
         var result = await handler.Handle(
             new GetTournamentBracketQuery(tournamentId),
             CancellationToken.None);
@@ -93,8 +99,10 @@ public class GetTournamentBracketQueryHandlerTests
         var gameRepo = Substitute.For<IGameRepository>();
         var botRegRepo = Substitute.For<IBotRegistrationRepository>();
         var uow = Substitute.For<IUnitOfWork>();
-
-        var handler = BuildHandler(repo, gameRepo, botRegRepo, uow);
+        var publisher = Substitute.For<IPublisher>();
+        
+        var handler = BuildHandler(repo, gameRepo, botRegRepo, publisher, uow);
+        
         var result = await handler.Handle(
             new GetTournamentBracketQuery(tournamentId),
             CancellationToken.None);
@@ -128,8 +136,10 @@ public class GetTournamentBracketQueryHandlerTests
 
         var botRegRepo = Substitute.For<IBotRegistrationRepository>();
         var uow = Substitute.For<IUnitOfWork>();
-
-        var handler = BuildHandler(repo, gameRepo, botRegRepo, uow);
+        var publisher = Substitute.For<IPublisher>();
+        
+        var handler = BuildHandler(repo, gameRepo, botRegRepo, publisher, uow);
+        
         var result = await handler.Handle(
             new GetTournamentBracketQuery(tournamentId),
             CancellationToken.None);
@@ -160,8 +170,10 @@ public class GetTournamentBracketQueryHandlerTests
 
         var botRegRepo = Substitute.For<IBotRegistrationRepository>();
         var uow = Substitute.For<IUnitOfWork>();
-
-        var handler = BuildHandler(repo, gameRepo, botRegRepo, uow);
+        var publisher = Substitute.For<IPublisher>();
+        
+        var handler = BuildHandler(repo, gameRepo, botRegRepo, publisher, uow);
+        
         await handler.Handle(
             new GetTournamentBracketQuery(tournamentId),
             CancellationToken.None);
@@ -182,9 +194,13 @@ public class GetTournamentBracketQueryHandlerTests
         repo.GetByIdAsync(tournamentId, Arg.Any<CancellationToken>())
             .Returns(tournament);
 
-        var handler = BuildHandler(repo, Substitute.For<IGameRepository>(),
-            Substitute.For<IBotRegistrationRepository>(), Substitute.For<IUnitOfWork>());
-
+        var gameRepo = Substitute.For<IGameRepository>();
+        var botRegRepo = Substitute.For<IBotRegistrationRepository>();
+        var uow = Substitute.For<IUnitOfWork>();
+        var publisher = Substitute.For<IPublisher>();
+        
+        var handler = BuildHandler(repo, gameRepo, botRegRepo, publisher, uow);
+        
         await handler.Handle(
             new GetTournamentBracketQuery(tournamentId),
             CancellationToken.None);

--- a/tests/ScrambleCoin.Application.Tests/JoinGameCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/JoinGameCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using MediatR;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using ScrambleCoin.Application.BotRegistration;
@@ -28,7 +29,8 @@ public class JoinGameCommandHandlerTests
     {
         var logger = Substitute.For<ILogger<JoinGameCommandHandler>>();
         botRegRepo ??= Substitute.For<IBotRegistrationRepository>();
-        return new JoinGameCommandHandler(gameRepo, botRegRepo, logger);
+        var publisher = Substitute.For<IPublisher>();
+        return new JoinGameCommandHandler(gameRepo, botRegRepo, publisher, logger);
     }
 
     // ── Tests ─────────────────────────────────────────────────────────────────

--- a/tests/ScrambleCoin.Application.Tests/Ranking/GetAllBotsProgressQueryHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/Ranking/GetAllBotsProgressQueryHandlerTests.cs
@@ -1,0 +1,229 @@
+using NSubstitute;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Application.Ranking.GetAllBotsProgress;
+using ScrambleCoin.Domain.Entities;
+
+namespace ScrambleCoin.Application.Tests.Ranking;
+
+/// <summary>
+/// Unit tests for <see cref="GetAllBotsProgressQueryHandler"/> (Issue #57).
+/// </summary>
+public sealed class GetAllBotsProgressQueryHandlerTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private readonly IBotUnlocksRepository _unlocksRepo =
+        Substitute.For<IBotUnlocksRepository>();
+
+    private readonly IRankingRepository _rankingRepo =
+        Substitute.For<IRankingRepository>();
+
+    private GetAllBotsProgressQueryHandler BuildHandler() =>
+        new(_unlocksRepo, _rankingRepo);
+
+    private static BotUnlock Unlock(Guid botId, string villainId, string? pieceId = null) =>
+        new() { BotId = botId, VillainId = villainId, UnlockedPieceId = pieceId };
+
+    private static RankingTrack Track(Guid botId, string botName) =>
+        new(botId, botName, points: 0, wins: 0, draws: 0, losses: 0, gamesPlayed: 0, milestonesHit: []);
+
+    // ── Core aggregation ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_AggregatesUnlocksByBot_ReturnsCorrectVillainCountsAndPieceCounts()
+    {
+        // Arrange
+        var botId = Guid.NewGuid();
+
+        // Two distinct villains defeated; only one unlock has a piece reward.
+        var unlocks = new List<BotUnlock>
+        {
+            Unlock(botId, "villain-a", "piece-mickey"),
+            Unlock(botId, "villain-b", null),          // no piece reward
+        };
+
+        _unlocksRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(unlocks.AsEnumerable());
+        _rankingRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<RankingTrack>)new List<RankingTrack>().AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllBotsProgressQuery(), CancellationToken.None);
+
+        // Assert
+        var dto = result.Single();
+        Assert.Equal(botId, dto.BotId);
+        Assert.Equal(2,     dto.VillainsDefeated);
+        Assert.Equal(1,     dto.PiecesUnlocked);
+    }
+
+    [Fact]
+    public async Task Handle_DeduplicatesVillains_WhenSameVillainDefeatedMultipleTimes()
+    {
+        // Arrange: same villain defeated twice (e.g. re-challenge).
+        var botId = Guid.NewGuid();
+
+        var unlocks = new List<BotUnlock>
+        {
+            Unlock(botId, "villain-a", "piece-one"),
+            Unlock(botId, "villain-a", "piece-two"),   // duplicate villain
+        };
+
+        _unlocksRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(unlocks.AsEnumerable());
+        _rankingRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<RankingTrack>)new List<RankingTrack>().AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllBotsProgressQuery(), CancellationToken.None);
+
+        // Assert: villain counted once even though two defeat records exist.
+        var dto = result.Single();
+        Assert.Equal(1, dto.VillainsDefeated);
+        // Both unlock records have a piece, so PiecesUnlocked = 2.
+        Assert.Equal(2, dto.PiecesUnlocked);
+    }
+
+    // ── Bot name resolution ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_UsesRankingTrackForBotName_WhenTrackExists()
+    {
+        // Arrange
+        var botId = Guid.NewGuid();
+
+        _unlocksRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { Unlock(botId, "villain-a") }.AsEnumerable());
+        _rankingRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<RankingTrack>)new List<RankingTrack> { Track(botId, "AlphaBot") }.AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllBotsProgressQuery(), CancellationToken.None);
+
+        // Assert: display name from ranking track is used.
+        Assert.Equal("AlphaBot", result.Single().BotName);
+    }
+
+    [Fact]
+    public async Task Handle_FallsBackToShortId_WhenNoRankingTrack()
+    {
+        // Arrange
+        var botId = Guid.NewGuid();
+
+        _unlocksRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(new[] { Unlock(botId, "villain-a") }.AsEnumerable());
+        _rankingRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<RankingTrack>)new List<RankingTrack>().AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllBotsProgressQuery(), CancellationToken.None);
+
+        // Assert: fallback is first-8-chars of GUID + ellipsis.
+        var expectedFallback = botId.ToString()[..8] + "…";
+        Assert.Equal(expectedFallback, result.Single().BotName);
+    }
+
+    // ── Ordering ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_OrdersByVillainsDefeatedDescending()
+    {
+        // Arrange
+        var botA = Guid.NewGuid(); // 3 villains
+        var botB = Guid.NewGuid(); // 1 villain
+        var botC = Guid.NewGuid(); // 2 villains
+
+        var unlocks = new List<BotUnlock>
+        {
+            Unlock(botA, "v1"), Unlock(botA, "v2"), Unlock(botA, "v3"),
+            Unlock(botB, "v1"),
+            Unlock(botC, "v1"), Unlock(botC, "v2"),
+        };
+
+        _unlocksRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(unlocks.AsEnumerable());
+        _rankingRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<RankingTrack>)new List<RankingTrack>().AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllBotsProgressQuery(), CancellationToken.None);
+
+        // Assert: sorted 3 → 2 → 1.
+        Assert.Equal(3, result[0].VillainsDefeated);
+        Assert.Equal(2, result[1].VillainsDefeated);
+        Assert.Equal(1, result[2].VillainsDefeated);
+    }
+
+    [Fact]
+    public async Task Handle_TiesInVillainsDefeated_OrdersByPiecesUnlockedDescending()
+    {
+        // Arrange: two bots with the same villain count but different piece counts.
+        var botA = Guid.NewGuid(); // 1 villain, 2 pieces
+        var botB = Guid.NewGuid(); // 1 villain, 1 piece
+
+        var unlocks = new List<BotUnlock>
+        {
+            Unlock(botA, "v1", "piece-1"),
+            Unlock(botA, "v1", "piece-2"), // duplicate villain but another piece
+            Unlock(botB, "v1", "piece-x"),
+        };
+
+        _unlocksRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(unlocks.AsEnumerable());
+        _rankingRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<RankingTrack>)new List<RankingTrack>().AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllBotsProgressQuery(), CancellationToken.None);
+
+        // Assert: botA (2 pieces) comes before botB (1 piece).
+        Assert.Equal(botA, result[0].BotId);
+        Assert.Equal(botB, result[1].BotId);
+    }
+
+    // ── Empty state ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenNoUnlocks_ReturnsEmpty()
+    {
+        // Arrange
+        _unlocksRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Enumerable.Empty<BotUnlock>());
+        _rankingRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<RankingTrack>)new List<RankingTrack>().AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllBotsProgressQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    // ── Multiple bots isolation ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_DoesNotMixVillainsBetweenBots()
+    {
+        // Arrange: two bots that both defeated the same villain ID — each should count it separately.
+        var botA = Guid.NewGuid();
+        var botB = Guid.NewGuid();
+
+        var unlocks = new List<BotUnlock>
+        {
+            Unlock(botA, "villain-shared"),
+            Unlock(botB, "villain-shared"),
+        };
+
+        _unlocksRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(unlocks.AsEnumerable());
+        _rankingRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<RankingTrack>)new List<RankingTrack>().AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllBotsProgressQuery(), CancellationToken.None);
+
+        // Assert: each bot has exactly 1 villain, and results contain 2 entries.
+        Assert.Equal(2, result.Count);
+        Assert.All(result, dto => Assert.Equal(1, dto.VillainsDefeated));
+    }
+}

--- a/tests/ScrambleCoin.Application.Tests/StartTournamentCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/StartTournamentCommandHandlerTests.cs
@@ -25,8 +25,9 @@ public class StartTournamentCommandHandlerTests
         IBotRegistrationRepository botRegRepo,
         IUnitOfWork uow)
     {
-        var logger = Substitute.For<ILogger<StartTournamentCommandHandler>>();
-        return new StartTournamentCommandHandler(tournamentRepo, gameRepo, botRegRepo, uow, logger);
+        var logger    = Substitute.For<ILogger<StartTournamentCommandHandler>>();
+        var publisher = Substitute.For<MediatR.IPublisher>();
+        return new StartTournamentCommandHandler(tournamentRepo, gameRepo, botRegRepo, uow, publisher, logger);
     }
 
     private static DomainTournament BuildTournamentWithBots(Guid id, int botCount)

--- a/tests/ScrambleCoin.Application.Tests/Tournament/GetAllTournamentsQueryHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/Tournament/GetAllTournamentsQueryHandlerTests.cs
@@ -1,0 +1,150 @@
+using NSubstitute;
+using ScrambleCoin.Application.Tournament;
+using ScrambleCoin.Application.Tournament.GetAllTournaments;
+using ScrambleCoin.Domain.Enums;
+using DomainTournament = ScrambleCoin.Domain.Tournaments.Tournament;
+
+namespace ScrambleCoin.Application.Tests.Tournament;
+
+/// <summary>
+/// Unit tests for <see cref="GetAllTournamentsQueryHandler"/> (Issue #57).
+/// </summary>
+public sealed class GetAllTournamentsQueryHandlerTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private readonly ITournamentRepository _repo =
+        Substitute.For<ITournamentRepository>();
+
+    private GetAllTournamentsQueryHandler BuildHandler() =>
+        new(_repo);
+
+    private static DomainTournament MakeTournament(
+        string name         = "Test Tournament",
+        int maxParticipants = 8,
+        int topN            = 4,
+        DateTimeOffset? createdAt = null)
+    {
+        return new DomainTournament(
+            id:              Guid.NewGuid(),
+            name:            name,
+            maxParticipants: maxParticipants,
+            topN:            topN,
+            createdAtUtc:    createdAt ?? DateTimeOffset.UtcNow);
+    }
+
+    // ── Ordering ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_ReturnsAllTournaments_OrderedByCreatedAtDescending()
+    {
+        // Arrange: three tournaments with distinct creation times.
+        var oldest = MakeTournament("Alpha",  createdAt: DateTimeOffset.UtcNow.AddDays(-3));
+        var middle = MakeTournament("Beta",   createdAt: DateTimeOffset.UtcNow.AddDays(-2));
+        var newest = MakeTournament("Gamma",  createdAt: DateTimeOffset.UtcNow.AddDays(-1));
+
+        // Repository returns them in arbitrary order.
+        _repo.GetAllAsync(Arg.Any<CancellationToken>())
+             .Returns((IReadOnlyList<DomainTournament>)new[] { oldest, newest, middle }.ToList().AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllTournamentsQuery(), CancellationToken.None);
+
+        // Assert: newest first.
+        Assert.Equal(newest.Id, result[0].TournamentId);
+        Assert.Equal(middle.Id, result[1].TournamentId);
+        Assert.Equal(oldest.Id, result[2].TournamentId);
+    }
+
+    // ── Empty state ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenNoTournaments_ReturnsEmptyList()
+    {
+        // Arrange
+        _repo.GetAllAsync(Arg.Any<CancellationToken>())
+             .Returns((IReadOnlyList<DomainTournament>)new List<DomainTournament>().AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllTournamentsQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    // ── DTO mapping ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_MapsTournamentFieldsCorrectly()
+    {
+        // Arrange
+        var now        = DateTimeOffset.UtcNow;
+        var tournament = MakeTournament("Grand Prix", maxParticipants: 16, topN: 4, createdAt: now);
+
+        _repo.GetAllAsync(Arg.Any<CancellationToken>())
+             .Returns((IReadOnlyList<DomainTournament>)new[] { tournament }.ToList().AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllTournamentsQuery(), CancellationToken.None);
+
+        // Assert: all DTO fields map correctly.
+        var dto = result.Single();
+        Assert.Equal(tournament.Id,             dto.TournamentId);
+        Assert.Equal("Grand Prix",              dto.Name);
+        Assert.Equal(TournamentStatus.Pending.ToString(), dto.Status);
+        Assert.Equal(0,                         dto.ParticipantCount); // no participants added
+        Assert.Equal(16,                        dto.MaxParticipants);
+        Assert.Equal(now,                       dto.CreatedAtUtc);
+    }
+
+    [Fact]
+    public async Task Handle_MapsStatusString_MatchesTournamentStatusEnum()
+    {
+        // Arrange: a freshly created tournament starts in Pending status.
+        var tournament = MakeTournament();
+
+        _repo.GetAllAsync(Arg.Any<CancellationToken>())
+             .Returns((IReadOnlyList<DomainTournament>)new[] { tournament }.ToList().AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllTournamentsQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal("Pending", result.Single().Status);
+    }
+
+    // ── Repository interaction ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_CallsRepositoryExactlyOnce()
+    {
+        // Arrange
+        _repo.GetAllAsync(Arg.Any<CancellationToken>())
+             .Returns((IReadOnlyList<DomainTournament>)new List<DomainTournament>().AsReadOnly());
+
+        var handler = BuildHandler();
+
+        // Act
+        await handler.Handle(new GetAllTournamentsQuery(), CancellationToken.None);
+
+        // Assert
+        await _repo.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SingleTournament_HasCorrectParticipantCount()
+    {
+        // Arrange: tournament with no participants added yet.
+        var tournament = MakeTournament(maxParticipants: 8, topN: 4);
+
+        _repo.GetAllAsync(Arg.Any<CancellationToken>())
+             .Returns((IReadOnlyList<DomainTournament>)new[] { tournament }.ToList().AsReadOnly());
+
+        // Act
+        var result = await BuildHandler().Handle(new GetAllTournamentsQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, result.Single().ParticipantCount);
+        Assert.Equal(8, result.Single().MaxParticipants);
+    }
+}

--- a/tests/ScrambleCoin.Application.Tests/VillainStrategyTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/VillainStrategyTests.cs
@@ -32,11 +32,16 @@ public class VillainStrategyTests
 
     /// <summary>
     /// Advances the game through CoinSpawn and PlacePhase.
+    /// Places one piece per player so MovePhase is not immediately auto-skipped.
     /// </summary>
     private static void AdvanceToMovePhase(Game game)
     {
+        var p1 = game.PlayerOne;
+        var p2 = game.PlayerTwo;
         game.AdvancePhase(); // CoinSpawn → PlacePhase
-        game.AdvancePhase(); // PlacePhase → MovePhase
+        game.PlacePiece(p1, game.LineupPlayerOne!.Pieces.First(p => !p.IsOnBoard).Id, new Position(0, 0));
+        game.PlacePiece(p2, game.LineupPlayerTwo!.Pieces.First(p => !p.IsOnBoard).Id, new Position(7, 7));
+        // MarkPlacePhaseActed auto-advances to MovePhase.
     }
 
     // ── Tests ─────────────────────────────────────────────────────────────────

--- a/tests/ScrambleCoin.Domain.Tests/ArchitectureTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/ArchitectureTests.cs
@@ -36,7 +36,7 @@ public class ArchitectureTests
 
     // ── Acceptance criterion 1 ──────────────────────────────────────────────
     [Fact]
-    public void Solution_ContainsElevenProjects()
+    public void Solution_ContainsTwelveProjects()
     {
         var sln = Path.Combine(RepoRoot, "ScrambleCoin.sln");
         var content = File.ReadAllText(sln);
@@ -46,7 +46,7 @@ public class ArchitectureTests
             .Split('\n')
             .Count(line => line.Contains(".csproj", StringComparison.OrdinalIgnoreCase));
 
-        Assert.Equal(11, csprojCount);
+        Assert.Equal(14, csprojCount);
     }
 
     // ── Clean Architecture rule: Domain has zero project dependencies ───────

--- a/tests/ScrambleCoin.Domain.Tests/GameTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/GameTests.cs
@@ -38,13 +38,25 @@ public class GameTests
     }
 
     /// <summary>
-    /// Advances the game through CoinSpawn and PlacePhase, so it is in MovePhase,
-    /// ready for a call to <see cref="Game.AdvanceTurn"/>.
+    /// Advances the game through CoinSpawn and PlacePhase (placing a piece per player
+    /// on the first visit so MovePhase is not immediately auto-skipped), ending in MovePhase.
     /// </summary>
     private static void AdvanceToMovePhase(Game game)
     {
         game.AdvancePhase(); // CoinSpawn → PlacePhase
-        game.AdvancePhase(); // PlacePhase → MovePhase
+        var p1 = game.PlayerOne;
+        var p2 = game.PlayerTwo;
+        // On the first turn each player has no pieces on board; place one so MovePhase sticks.
+        // On later turns the pieces are already on board; skip placement instead.
+        if (game.PiecesOnBoard[p1] == 0)
+            game.PlacePiece(p1, game.LineupPlayerOne!.Pieces.First(p => !p.IsOnBoard).Id, new Position(0, 0));
+        else
+            game.SkipPlacement(p1);
+        // Second player acting triggers MarkPlacePhaseActed → auto-advances to MovePhase.
+        if (game.PiecesOnBoard[p2] == 0)
+            game.PlacePiece(p2, game.LineupPlayerTwo!.Pieces.First(p => !p.IsOnBoard).Id, new Position(7, 7));
+        else
+            game.SkipPlacement(p2);
     }
 
 
@@ -794,8 +806,10 @@ public class GameTests
     [Fact]
     public void AdvancePhase_FromPlacePhase_SetsCurrentPhaseToMovePhase()
     {
-        var (game, _, _) = StartedGame();
+        var (game, p1, _) = StartedGame();
         game.AdvancePhase(); // CoinSpawn → PlacePhase
+        // Place one piece for P1 so MovePhase is not immediately auto-skipped.
+        game.PlacePiece(p1, game.LineupPlayerOne!.Pieces[0].Id, new Position(0, 0));
         game.AdvancePhase(); // PlacePhase → MovePhase
         Assert.Equal(TurnPhase.MovePhase, game.CurrentPhase);
     }
@@ -854,11 +868,12 @@ public class GameTests
     public void AdvancePhase_FullFiveTurnCycle_AllFifteenTransitions_EndsGameAsFinished()
     {
         var (game, _, _) = StartedGame();
-        // 5 turns × 3 phases each = 15 calls to AdvancePhase
+        // 5 turns × 3 phases (CoinSpawn→Place, Place→Move, Move→CoinSpawn/End).
+        // AdvanceToMovePhase handles CoinSpawn→Place + placement that auto-advances to Move.
+        // The final AdvancePhase() triggers Move→CoinSpawn (or End on turn 5).
         for (var turn = 0; turn < Game.TotalTurns; turn++)
         {
-            game.AdvancePhase(); // CoinSpawn → PlacePhase
-            game.AdvancePhase(); // PlacePhase → MovePhase
+            AdvanceToMovePhase(game);
             game.AdvancePhase(); // MovePhase → CoinSpawn (or End on turn 5)
         }
         Assert.Equal(GameStatus.Finished, game.Status);
@@ -1013,8 +1028,9 @@ public class GameTests
     [Fact]
     public void AdvancePhase_PlacePhaseToMovePhase_RaisesTurnPhaseAdvancedEvent()
     {
-        var (game, _, _) = StartedGame();
+        var (game, p1, _) = StartedGame();
         game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.PlacePiece(p1, game.LineupPlayerOne!.Pieces[0].Id, new Position(0, 0));
         game.ClearDomainEvents();
         game.AdvancePhase(); // PlacePhase → MovePhase
         Assert.Single(game.DomainEvents.OfType<TurnPhaseAdvanced>());
@@ -1023,10 +1039,11 @@ public class GameTests
     [Fact]
     public void AdvancePhase_PlacePhaseToMovePhase_Event_HasCorrectPreviousPhase()
     {
-        var (game, _, _) = StartedGame();
-        game.AdvancePhase();
+        var (game, p1, _) = StartedGame();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.PlacePiece(p1, game.LineupPlayerOne!.Pieces[0].Id, new Position(0, 0));
         game.ClearDomainEvents();
-        game.AdvancePhase();
+        game.AdvancePhase(); // PlacePhase → MovePhase
         var evt = game.DomainEvents.OfType<TurnPhaseAdvanced>().Single();
         Assert.Equal(TurnPhase.PlacePhase, evt.PreviousPhase);
     }
@@ -1034,10 +1051,11 @@ public class GameTests
     [Fact]
     public void AdvancePhase_PlacePhaseToMovePhase_Event_HasCorrectNewPhase()
     {
-        var (game, _, _) = StartedGame();
-        game.AdvancePhase();
+        var (game, p1, _) = StartedGame();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.PlacePiece(p1, game.LineupPlayerOne!.Pieces[0].Id, new Position(0, 0));
         game.ClearDomainEvents();
-        game.AdvancePhase();
+        game.AdvancePhase(); // PlacePhase → MovePhase
         var evt = game.DomainEvents.OfType<TurnPhaseAdvanced>().Single();
         Assert.Equal(TurnPhase.MovePhase, evt.NewPhase);
     }

--- a/tests/ScrambleCoin.Domain.Tests/PiecePlacementTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/PiecePlacementTests.cs
@@ -335,15 +335,16 @@ public class PiecePlacementTests
     }
 
     [Fact]
-    public void SkipPlacement_BothPlayers_AutoAdvancesToMovePhase()
+    public void SkipPlacement_BothPlayers_WithNoPieces_AutoSkipsMovePhaseAndAdvancesToCoinSpawn()
     {
         var (game, p1, p2, _, _) = GameInPlacePhase();
 
         game.SkipPlacement(p1);
         Assert.Equal(TurnPhase.PlacePhase, game.CurrentPhase);
 
+        // Both skipped → 0 pieces on board → MovePhase is auto-skipped to CoinSpawn.
         game.SkipPlacement(p2);
-        Assert.Equal(TurnPhase.MovePhase, game.CurrentPhase);
+        Assert.Equal(TurnPhase.CoinSpawn, game.CurrentPhase);
     }
 
     [Fact]

--- a/tests/ScrambleCoin.Infrastructure.Tests/Persistence/GameRepositoryTests.cs
+++ b/tests/ScrambleCoin.Infrastructure.Tests/Persistence/GameRepositoryTests.cs
@@ -274,11 +274,14 @@ public sealed class GameRepositoryTests
     public async Task SaveAsync_ThenGetByIdAsync_MovePhase_MovePhaseActivePlayerIsPreserved()
     {
         var options = BuildOptions(nameof(SaveAsync_ThenGetByIdAsync_MovePhase_MovePhaseActivePlayerIsPreserved));
-        var (game, playerOne, _) = BuildStartedGame();
+        var (game, playerOne, playerTwo) = BuildStartedGame();
 
-        // Advance through CoinSpawn → PlacePhase → MovePhase
-        game.AdvancePhase(); // → PlacePhase
-        game.AdvancePhase(); // → MovePhase (MovePhaseActivePlayer = PlayerOne)
+        // Advance through CoinSpawn → PlacePhase, then place pieces.
+        // The second PlacePiece auto-advances to MovePhase (MovePhaseActivePlayer = PlayerOne).
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.PlacePiece(playerOne, game.LineupPlayerOne!.Pieces[0].Id, new Position(0, 0));
+        game.PlacePiece(playerTwo, game.LineupPlayerTwo!.Pieces[0].Id, new Position(7, 7));
+        // game is now in MovePhase (auto-advanced by MarkPlacePhaseActed)
 
         await using var writeCtx = new ScrambleCoinDbContext(options);
         await new GameRepository(writeCtx).SaveAsync(game);
@@ -293,10 +296,13 @@ public sealed class GameRepositoryTests
     public async Task SaveAsync_ThenGetByIdAsync_MovePhase_CurrentPhaseIsMovePhase()
     {
         var options = BuildOptions(nameof(SaveAsync_ThenGetByIdAsync_MovePhase_CurrentPhaseIsMovePhase));
-        var (game, _, _) = BuildStartedGame();
+        var (game, playerOne, playerTwo) = BuildStartedGame();
 
+        // The second PlacePiece auto-advances to MovePhase.
         game.AdvancePhase(); // CoinSpawn → PlacePhase
-        game.AdvancePhase(); // PlacePhase → MovePhase
+        game.PlacePiece(playerOne, game.LineupPlayerOne!.Pieces[0].Id, new Position(0, 0));
+        game.PlacePiece(playerTwo, game.LineupPlayerTwo!.Pieces[0].Id, new Position(7, 7));
+        // game is now in MovePhase (auto-advanced by MarkPlacePhaseActed)
 
         await using var writeCtx = new ScrambleCoinDbContext(options);
         await new GameRepository(writeCtx).SaveAsync(game);

--- a/tests/ScrambleCoin.Infrastructure.Tests/QueueServiceTests.cs
+++ b/tests/ScrambleCoin.Infrastructure.Tests/QueueServiceTests.cs
@@ -340,16 +340,16 @@ public class QueueServiceTests
     [Fact]
     public async Task Poll_AfterTimeoutElapses_SubsequentPollReturnsNull()
     {
-        // After the entry is marked timed_out the record is removed, so further polls
+        // After the entry is marked timed_out, the record is removed, so further polls
         // must return null (not timed_out again).
         var (service, _, _, _) = BuildQueueServiceWithZeroTimeout();
         var entry = await service.EnqueueAsync(DefaultLineup);
         await Task.Delay(1);
 
-        // First poll removes the entry and returns "timed_out".
+        // The first poll removes the entry and returns "timed_out".
         await service.PollAsync(entry.QueueId);
 
-        // Act: second poll on same ID.
+        // Act: a second poll on the same ID.
         var polled2 = await service.PollAsync(entry.QueueId);
 
         // Assert: entry is gone.
@@ -394,7 +394,7 @@ public class QueueServiceTests
         var waitingTokens = GetWaitingTokens(service);
         waitingTokens.TryAdd(token, true);
 
-        // Act: second enqueue with same token finds an empty queue (no waiting bot to dequeue)
+        // Act: the second enqueue with the same token finds an empty queue (no waiting bot to dequeue),
         // but the token is already in the waiting set → conflict.
         var entry = await service.EnqueueAsync(DefaultLineup, token);
 
@@ -595,7 +595,7 @@ public class QueueServiceTests
 
         // Post-eviction matching is validated on a freshly configured service (5-minute timeout).
         // The zero-timeout instance cannot pair new bots usefully because every entry expires
-        // before a second bot can arrive. Using a correctly-configured instance proves the
+        // before a second bot can arrive. Using a correctly configured instance proves the
         // service architecture supports normal matching once timeout is set appropriately.
         var (svc2, _, _, _) = BuildQueueService(); // 5-minute timeout
         await svc2.EnqueueAsync(DefaultLineup);    // Bot C parks
@@ -623,7 +623,7 @@ public class QueueServiceTests
         // Act: PollAsync triggers timeout + removes token from _waitingTokens.
         await svc.PollAsync(entry.QueueId);
 
-        // Assert: same token can re-enqueue without conflict.
+        // Assert: the same token can re-enqueue without a conflict.
         var requeue = await svc.EnqueueAsync(DefaultLineup, token);
         Assert.NotEqual("conflict", requeue.Status);
     }
@@ -648,7 +648,7 @@ public class QueueServiceTests
         var botBToken = Guid.NewGuid();
         await svc.EnqueueAsync(DefaultLineup, botBToken);
 
-        // Assert: Bot A's token was freed by the eviction — re-enqueue must not return conflict.
+        // Assert: The eviction freed Bot A's token — re-enqueue must not return conflict.
         var requeue = await svc.EnqueueAsync(DefaultLineup, botAToken);
         Assert.NotEqual("conflict", requeue.Status);
     }

--- a/tests/ScrambleCoin.Web.Tests/BroadcastGameEndedOnFinishedHandlerTests.cs
+++ b/tests/ScrambleCoin.Web.Tests/BroadcastGameEndedOnFinishedHandlerTests.cs
@@ -5,7 +5,7 @@ using ScrambleCoin.Application.Abstractions;
 using ScrambleCoin.Application.Interfaces;
 using ScrambleCoin.Application.Notifications;
 using ScrambleCoin.Domain.Entities;
-using ScrambleCoin.Web.Notifications;
+using ScrambleCoin.Application.Notifications;
 
 namespace ScrambleCoin.Web.Tests;
 

--- a/tests/ScrambleCoin.Web.Tests/BroadcastPhaseChangedHandlerTests.cs
+++ b/tests/ScrambleCoin.Web.Tests/BroadcastPhaseChangedHandlerTests.cs
@@ -3,7 +3,7 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using ScrambleCoin.Application.Abstractions;
 using ScrambleCoin.Application.Notifications;
-using ScrambleCoin.Web.Notifications;
+using ScrambleCoin.Application.Notifications;
 
 namespace ScrambleCoin.Web.Tests;
 

--- a/tests/ScrambleCoin.Web.Tests/GameHubTests.cs
+++ b/tests/ScrambleCoin.Web.Tests/GameHubTests.cs
@@ -1,3 +1,4 @@
+using MediatR;
 using Microsoft.AspNetCore.SignalR;
 using NSubstitute;
 using ScrambleCoin.Web.Hubs;
@@ -19,11 +20,12 @@ public class GameHubTests
     private static (GameHub hub, IGroupManager groups) BuildHub(string connectionId = "conn-abc-123")
     {
         var groups = Substitute.For<IGroupManager>();
+        var sender = Substitute.For<ISender>();
 
         var context = Substitute.For<HubCallerContext>();
         context.ConnectionId.Returns(connectionId);
 
-        var hub = new GameHub();
+        var hub = new GameHub(sender);
         hub.Context = context;
         hub.Groups = groups;
 

--- a/tests/ScrambleCoin.Web.Tests/PlacementEndpointTests.cs
+++ b/tests/ScrambleCoin.Web.Tests/PlacementEndpointTests.cs
@@ -530,7 +530,7 @@ public class PlacementEndpointTests : IClassFixture<PlacementEndpointTests.TestW
     // ── AC 11: phase auto-advances to MovePhase when both players act ────────
 
     [Fact]
-    public async Task Place_BothPlayersSkip_PhaseAdvancesToMovePhase()
+    public async Task Place_BothPlayersSkip_PhaseAdvancesToCoinSpawn()
     {
         // Arrange
         var (game, tokenP1, tokenP2, _, _) = await SeedGameInPlacePhaseAsync();
@@ -544,14 +544,14 @@ public class PlacementEndpointTests : IClassFixture<PlacementEndpointTests.TestW
         // P1 skips
         await clientP1.PostAsJsonAsync($"/api/games/{game.Id}/place", new { action = "skip" });
 
-        // Act: P2 skips — the response should reflect the auto-advanced phase
+        // Act: P2 skips — with 0 pieces on board, MovePhase is auto-skipped → CoinSpawn
         var response = await clientP2.PostAsJsonAsync($"/api/games/{game.Id}/place", new { action = "skip" });
         var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
 
-        // Assert: phase advanced to MovePhase
+        // Assert: phase auto-advanced past MovePhase (no pieces) to CoinSpawn
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.True(json.RootElement.TryGetProperty("phase", out var phaseElement));
-        Assert.Equal("MovePhase", phaseElement.GetString());
+        Assert.Equal("CoinSpawn", phaseElement.GetString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Closes #57.

## Changes
- `src/ScrambleCoin.Application/Games/Admin/`: New `GetAllActiveGamesQuery` + handler, `ForceEndGameCommand` + handler, `ActiveGameSummaryDto`
- `src/ScrambleCoin.Application/Ranking/GetAllBotsProgress/`: New `GetAllBotsProgressQuery` + handler, `BotProgressDto`
- `src/ScrambleCoin.Application/Tournament/GetAllTournaments/`: New `GetAllTournamentsQuery` + handler, `TournamentSummaryDto`
- `src/ScrambleCoin.Application/Interfaces/IGameRepository.cs`: Added `GetAllActiveAsync()`
- `src/ScrambleCoin.Application/Interfaces/IBotUnlocksRepository.cs`: Added `GetAllAsync()`
- `src/ScrambleCoin.Application/Tournament/ITournamentRepository.cs`: Added `GetAllAsync()`
- `src/ScrambleCoin.Infrastructure/Persistence/GameRepository.cs`: Implemented `GetAllActiveAsync`
- `src/ScrambleCoin.Infrastructure/Persistence/BotUnlocksRepository.cs`: Implemented `GetAllAsync`
- `src/ScrambleCoin.Infrastructure/Persistence/TournamentRepository.cs`: Implemented `GetAllAsync`
- `src/ScrambleCoin.Infrastructure/Persistence/Records/GameRecord.cs`: Added `LastMoveAt` field
- `src/ScrambleCoin.Infrastructure/Migrations/`: EF Core migration `AddLastMoveAtToGameRecord`
- `src/ScrambleCoin.Web/Pages/Admin.razor`: Full 4-tab admin dashboard (Active Games, Tournaments, Solo Progress, Leaderboard)
- `tests/ScrambleCoin.Application.Tests/Games/Admin/`: 13 unit tests for `ForceEndGameCommandHandler` and `GetAllActiveGamesQueryHandler`
- `tests/ScrambleCoin.Application.Tests/Ranking/`: 8 unit tests for `GetAllBotsProgressQueryHandler`
- `tests/ScrambleCoin.Application.Tests/Tournament/`: 6 unit tests for `GetAllTournamentsQueryHandler`

## Key design decisions
- **Force-end behaviour**: `WaitingForBots` → `Cancelled` (no ranking points); `InProgress` → `End()` by coin score, publishes `GameFinished` so existing ranking + SignalR handlers fire automatically
- **Thread safety**: `LoadAllAsync` fully marshalled via `InvokeAsync` onto the Blazor circuit thread; `StateHasChanged()` called at the end of `LoadAllAsync`
- **No concurrent DbContext**: `GetAllBotsProgressQueryHandler` uses sequential awaits to avoid EF Core concurrency exception
- **LastMoveAt guard**: Display shows "unknown" for rows with pre-migration default timestamps (> 1 day old)

## Testing
- Unit tests: 28 added (Application layer)
- Integration tests: 0 (not applicable for Blazor UI panels)
- E2E tests: 0 (covered by manual test plan on Issue #57)

All automated tests pass ✅ (290/290 Application.Tests)

## Manual test plan
See the comment on Issue #57 for the full manual test plan. The reviewer should execute steps 1–10 before approving.

## Review cycles
- Implementation: 1 cycle
- Tests: 1 cycle

## Version bump
Label `minor` applied (issue label: `ui`)

## Wiki
📚 [Admin Panel documentation](https://github.com/NickThys3012/CodeRetreat_ScrambleCoin/wiki/Admin-Panel) published.