### PR TITLE
Piece turn-availability conditions (e.g. Elsa only placeable from turn 2)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -296,7 +296,6 @@ dotnet_diagnostic.CA1511.severity = error
 dotnet_diagnostic.CA1512.severity = error
 dotnet_diagnostic.CA1513.severity = error
 dotnet_diagnostic.CA1514.severity = error
-dotnet_diagnostic.CA1515.severity = warning     # review roel 20250114
 
 # IL Trimming Rules
 dotnet_diagnostic.IL3000.severity = error
@@ -502,6 +501,13 @@ dotnet_naming_rule.test_members_should_allow_underscores.symbols = test_members
 dotnet_naming_rule.test_members_should_allow_underscores.style = test_method_with_underscores
 dotnet_naming_rule.test_members_should_allow_underscores.severity = suggestion
 
+resharper_loop_can_be_converted_to_query_highlighting = none
+
+# CA1515 is a Roslyn SDK analyzer (not a ReSharper inspection), so only the
+# dotnet_diagnostic severity controls it — there is no resharper_*_highlighting alias.
+# Public types here are intentionally public (API / Domain surface).
+dotnet_diagnostic.CA1515.severity = none
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Path-based overrides
 # ─────────────────────────────────────────────────────────────────────────────
@@ -536,6 +542,15 @@ csharp_style_unused_value_assignment_preference = discard_variable:none
 resharper_unused_auto_property_accessor_global_highlighting  = none
 resharper_unused_auto_property_accessor_local_highlighting = none
 
+[samples/ScrambleCoin.StarterBot/Models/**/*.cs]
+resharper_unused_auto_property_accessor_global_highlighting  = none
+resharper_unused_auto_property_accessor_local_highlighting = none
+resharper_unused_member_global_highlighting = none
+resharper_class_never_instantiated_global_highlighting = none
+resharper_auto_property_can_be_made_get_only_global_highlighting = none
+
+[src/ScrambleCoin.Api/RequestBodies/**/*.cs]
+resharper_class_never_instantiated_global_highlighting = none
 
 [src/ScrambleCoin.Infrastructure/Persistence/Records/*.cs]
 resharper_entity_framework_model_validation_unlimited_string_length_highlighting = none

--- a/samples/ScrambleCoin.StarterBot/GameLoop.cs
+++ b/samples/ScrambleCoin.StarterBot/GameLoop.cs
@@ -153,40 +153,33 @@ public sealed class GameLoop
                     lastPhase = state.Phase ?? "";
                 }
 
-                // ── Game isn't started yet ───────────────────────────────────────
-                if (state.Phase is null && state.Turn == 0)
+                switch (state.Phase)
                 {
-                    Console.WriteLine($"[{_botName}]  Waiting for game to start…");
-                    continue; // wait for the next SignalR event
-                }
+                    // ── Game isn't started yet ───────────────────────────────────────
+                    case null when state.Turn == 0:
+                        Console.WriteLine($"[{_botName}]  Waiting for game to start…");
+                        continue; // wait for the next SignalR event
+                    // ── Game ended ────────────────────────────────────────────────
+                    case null when state.Turn > 0:
+                        await PrintFinalResultAsync(gameId, playerId, state, ct);
+                        return;
+                    // ── CoinSpawn ─────────────────────────────────────────────────
+                    case "CoinSpawn":
+                        // Server handles this; the next SignalR event will show PlacePhase.
+                        continue;
+                    // ── PlacePhase ────────────────────────────────────────────────
+                    case "PlacePhase":
+                        {
+                            if (placedThisTurn.Count == 0)
+                                await HandlePlacePhaseAsync(gameId, state, placedThisTurn, ct);
+                            // If already placed, just wait for the next event (opponent placing).
+                            continue;
+                        }
 
-                // ── Game ended ────────────────────────────────────────────────
-                if (state.Phase is null && state.Turn > 0)
-                {
-                    await PrintFinalResultAsync(gameId, playerId, state, ct);
-                    return;
-                }
-
-                // ── CoinSpawn ─────────────────────────────────────────────────
-                if (state.Phase == "CoinSpawn")
-                {
-                    // Server handles this; the next SignalR event will show PlacePhase.
-                    continue;
-                }
-
-                // ── PlacePhase ────────────────────────────────────────────────
-                if (state.Phase == "PlacePhase")
-                {
-                    if (placedThisTurn.Count == 0)
-                        await HandlePlacePhaseAsync(gameId, state, placedThisTurn, ct);
-                    // If already placed, just wait for the next event (opponent placing).
-                    continue;
-                }
-
-                // ── MovePhase ─────────────────────────────────────────────────
-                if (state.Phase == "MovePhase")
-                {
-                    await HandleMovePhaseAsync(gameId, playerId, state, movedThisTurn, ct);
+                    // ── MovePhase ─────────────────────────────────────────────────
+                    case "MovePhase":
+                        await HandleMovePhaseAsync(gameId, playerId, state, movedThisTurn, ct);
+                        break;
                 }
             }
         }

--- a/src/ScrambleCoin.Api/Endpoints/GameEndpoints.cs
+++ b/src/ScrambleCoin.Api/Endpoints/GameEndpoints.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using ScrambleCoin.Api.RequestBodies;
 using ScrambleCoin.Application.Games.CreateGame;
 using ScrambleCoin.Application.Games.GetBoardState;
 using ScrambleCoin.Application.Games.GetGameResult;
@@ -82,7 +83,7 @@ internal static class GameEndpoints
     /// <summary>Bot joins a game and submits a lineup of 5-piece names.</summary>
     private static async Task<IResult> JoinGame(
         Guid gameId,
-        JoinGameRequest body,
+        GameEndpointRequests.JoinGameRequest body,
         ISender sender,
         CancellationToken ct)
     {
@@ -109,7 +110,7 @@ internal static class GameEndpoints
 
     /// <summary>Bot joins the matchmaking queue with a lineup.</summary>
     private static async Task<IResult> QueueBot(
-        QueueRequest body,
+        GameEndpointRequests.QueueRequest body,
         HttpRequest httpRequest,
         IQueueService queueService,
         CancellationToken ct)
@@ -180,7 +181,7 @@ internal static class GameEndpoints
     /// <summary>Bot submits a placement decision (place, replace, or skip) during PlacePhase.</summary>
     private static async Task<IResult> PlacePiece(
         Guid gameId,
-        PlacementRequest body,
+        GameEndpointRequests.PlacementRequest body,
         HttpRequest httpRequest,
         ISender sender,
         CancellationToken ct)
@@ -285,36 +286,11 @@ internal static class GameEndpoints
             statusCode: StatusCodes.Status403Forbidden,
             title: "Forbidden");
 
-    // ── Request bodies ────────────────────────────────────────────────────────
-
-    private sealed record JoinGameRequest(IReadOnlyList<string> Lineup);
-
-    private sealed record QueueRequest(IReadOnlyList<string> Lineup);
-
-    /// <summary>
-    /// Request body for <c>POST /api/games/{gameId}/move</c>.
-    /// </summary>
-    /// <param name="PieceId">The piece to move.</param>
-    /// <param name="Segments">One segment per MovesPerTurn; each segment is an ordered list of positions.</param>
-    private sealed record MoveRequest(Guid PieceId, IReadOnlyList<IReadOnlyList<PositionRequest>>? Segments);
-
-    /// <summary>
-    /// Request body for <c>POST /api/games/{gameId}/place</c>.
-    /// </summary>
-    /// <param name="Action">One of: "place", "replace", "skip".</param>
-    /// <param name="PieceId">The piece to place or use as a replacement (required for "place" and "replace").</param>
-    /// <param name="ReplacedPieceId">The on-board piece to remove (required for "replace" only).</param>
-    /// <param name="Position">Target board position (required for "place" and "replace").</param>
-    private sealed record PlacementRequest(
-        string? Action,
-        Guid? PieceId,
-        Guid? ReplacedPieceId,
-        PositionRequest? Position);
-
+  
     /// <summary>Bot submits a piece move during MovePhase.</summary>
     private static async Task<IResult> MovePiece(
         Guid gameId,
-        MoveRequest body,
+        GameEndpointRequests.MoveRequest body,
         HttpRequest httpRequest,
         ISender sender,
         CancellationToken ct)

--- a/src/ScrambleCoin.Api/Endpoints/SoloModeEndpoints.cs
+++ b/src/ScrambleCoin.Api/Endpoints/SoloModeEndpoints.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using ScrambleCoin.Api.RequestBodies;
 using ScrambleCoin.Application.Games.SoloMode.CreateSoloGame;
 using ScrambleCoin.Application.Games.SoloMode.GetStarterPieces;
 using ScrambleCoin.Application.Games.SoloMode.GetUnlockedPieces;
@@ -98,7 +99,7 @@ internal static class SoloModeEndpoints
     }
 
     private static async Task<IResult> CreateSoloGame(
-        CreateSoloGameRequest body,
+        SoloModeEndpointRequests.CreateSoloGameRequest body,
         ISender sender,
         CancellationToken ct)
     {
@@ -132,10 +133,4 @@ internal static class SoloModeEndpoints
                 title: "Internal Server Error");
         }
     }
-
-    // ── Request bodies ────────────────────────────────────────────────────────
-
-    private sealed record CreateSoloGameRequest(
-        Guid BotId,
-        string VillainId);
 }

--- a/src/ScrambleCoin.Api/Endpoints/TournamentEndpoints.cs
+++ b/src/ScrambleCoin.Api/Endpoints/TournamentEndpoints.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using ScrambleCoin.Api.RequestBodies;
 using ScrambleCoin.Application.Tournament.AddParticipant;
 using ScrambleCoin.Application.Tournament.CancelTournament;
 using ScrambleCoin.Application.Tournament.CreateTournament;
@@ -104,7 +105,7 @@ internal static class TournamentEndpoints
 
     /// <summary>Admin creates a tournament. Requires <c>X-Admin-Key: scramblecoin-admin</c>.</summary>
     private static async Task<IResult> CreateTournament(
-        CreateTournamentRequest body,
+        TournamentEndpointRequests.CreateTournamentRequest body,
         HttpRequest httpRequest,
         ISender sender,
         CancellationToken ct)
@@ -135,7 +136,7 @@ internal static class TournamentEndpoints
     /// <summary>Bot self-registers for the tournament. No admin key is required.</summary>
     private static async Task<IResult> JoinTournament(
         Guid id,
-        AddParticipantRequest body,
+        TournamentEndpointRequests.AddParticipantRequest body,
         ISender sender,
         CancellationToken ct)
     {
@@ -173,7 +174,7 @@ internal static class TournamentEndpoints
     /// <summary>Admin registers a bot for the tournament.</summary>
     private static async Task<IResult> AddParticipant(
         Guid id,
-        AddParticipantRequest body,
+        TournamentEndpointRequests.AddParticipantRequest? body,
         HttpRequest httpRequest,
         ISender sender,
         CancellationToken ct)
@@ -355,21 +356,4 @@ internal static class TournamentEndpoints
         var result = await sender.Send(new GetLeaderboardQuery(), ct);
         return Results.Ok(result);
     }
-
-    // ── Request bodies ────────────────────────────────────────────────────────
-
-    /// <summary>Request body for <c>POST /api/tournament</c>.</summary>
-    /// <param name="Name">Tournament display name.</param>
-    /// <param name="MaxParticipants">Maximum number of bots (minimum 2).</param>
-    /// <param name="TopN">Number of group-stage qualifiers for the knockout stage (default: 4).</param>
-    private sealed record CreateTournamentRequest(string Name, int MaxParticipants, int? TopN);
-
-    /// <summary>Request body for <c>POST /api/tournament/{id}/participants</c>.</summary>
-    /// <param name="BotId">Stable identifier for the bot (used as their game token throughout the tournament).</param>
-    /// <param name="BotName">Human-readable display name for this bot.</param>
-    /// <param name="Lineup">Ordered list of piece names the bot will use in all their tournament games.</param>
-    private sealed record AddParticipantRequest(
-        Guid BotId,
-        string BotName,
-        IReadOnlyList<string> Lineup);
 }

--- a/src/ScrambleCoin.Api/RequestBodies/GameEndpointRequests.cs
+++ b/src/ScrambleCoin.Api/RequestBodies/GameEndpointRequests.cs
@@ -1,0 +1,32 @@
+using ScrambleCoin.Application.Games.SubmitPlacement;
+namespace ScrambleCoin.Api.RequestBodies;
+
+public static class GameEndpointRequests
+{
+    // ── Request bodies ────────────────────────────────────────────────────────
+
+    public sealed record JoinGameRequest(IReadOnlyList<string> Lineup);
+
+    public sealed record QueueRequest(IReadOnlyList<string> Lineup);
+
+    /// <summary>
+    /// Request body for <c>POST /api/games/{gameId}/move</c>.
+    /// </summary>
+    /// <param name="PieceId">The piece to move.</param>
+    /// <param name="Segments">One segment per MovesPerTurn; each segment is an ordered list of positions.</param>
+    public sealed record MoveRequest(Guid PieceId, IReadOnlyList<IReadOnlyList<PositionRequest>>? Segments);
+
+    /// <summary>
+    /// Request body for <c>POST /api/games/{gameId}/place</c>.
+    /// </summary>
+    /// <param name="Action">One of: "place", "replace", "skip".</param>
+    /// <param name="PieceId">The piece to place or use as a replacement (required for "place" and "replace").</param>
+    /// <param name="ReplacedPieceId">The on-board piece to remove (required for "replace" only).</param>
+    /// <param name="Position">Target board position (required for "place" and "replace").</param>
+    public sealed record PlacementRequest(
+        string? Action,
+        Guid? PieceId,
+        Guid? ReplacedPieceId,
+        PositionRequest? Position);
+
+}

--- a/src/ScrambleCoin.Api/RequestBodies/SoloModeEndpointRequests.cs
+++ b/src/ScrambleCoin.Api/RequestBodies/SoloModeEndpointRequests.cs
@@ -1,0 +1,9 @@
+namespace ScrambleCoin.Api.RequestBodies;
+
+public static class SoloModeEndpointRequests
+{
+    // ── Request bodies ────────────────────────────────────────────────────────
+    public sealed record CreateSoloGameRequest(
+        Guid BotId,
+        string VillainId);
+}

--- a/src/ScrambleCoin.Api/RequestBodies/TournamentEndpointRequests.cs
+++ b/src/ScrambleCoin.Api/RequestBodies/TournamentEndpointRequests.cs
@@ -1,0 +1,22 @@
+namespace ScrambleCoin.Api.RequestBodies;
+
+public static class TournamentEndpointRequests
+{
+    
+    // ── Request bodies ────────────────────────────────────────────────────────
+
+    /// <summary>Request body for <c>POST /api/tournament</c>.</summary>
+    /// <param name="Name">Tournament display name.</param>
+    /// <param name="MaxParticipants">Maximum number of bots (minimum 2).</param>
+    /// <param name="TopN">Number of group-stage qualifiers for the knockout stage (default: 4).</param>
+    public sealed record CreateTournamentRequest(string Name, int MaxParticipants, int? TopN);
+
+    /// <summary>Request body for <c>POST /api/tournament/{id}/participants</c>.</summary>
+    /// <param name="BotId">Stable identifier for the bot (used as their game token throughout the tournament).</param>
+    /// <param name="BotName">Human-readable display name for this bot.</param>
+    /// <param name="Lineup">Ordered list of piece names the bot will use in all their tournament games.</param>
+    public sealed record AddParticipantRequest(
+        Guid BotId,
+        string BotName,
+        IReadOnlyList<string> Lineup);
+}

--- a/src/ScrambleCoin.Api/ScrambleCoin.Api.csproj
+++ b/src/ScrambleCoin.Api/ScrambleCoin.Api.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/ScrambleCoin.Api/ScrambleCoin.Api.csproj
+++ b/src/ScrambleCoin.Api/ScrambleCoin.Api.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/ScrambleCoin.Application/Games/GetBoardState/BoardStateDto.cs
+++ b/src/ScrambleCoin.Application/Games/GetBoardState/BoardStateDto.cs
@@ -67,6 +67,10 @@ public sealed record TileOccupantDto(
 /// <param name="MaxDistance">Maximum tiles per move action.</param>
 /// <param name="MovesPerTurn">Number of move actions the piece must perform each turn.</param>
 /// <param name="IsOnBoard">True when the piece has been placed on the board.</param>
+/// <param name="AvailableFromTurn">
+/// Earliest turn (1-based) at which this piece may be placed on the board.
+/// <c>null</c> means the piece is available from turn 1 (no restriction).
+/// </param>
 public sealed record PieceDto(
     Guid PieceId,
     string Name,
@@ -74,7 +78,8 @@ public sealed record PieceDto(
     string MovementType,
     int MaxDistance,
     int MovesPerTurn,
-    bool IsOnBoard);
+    bool IsOnBoard,
+    int? AvailableFromTurn);
 
 /// <summary>A coin currently available on the board.</summary>
 /// <param name="Position">The tile this coin occupies.</param>

--- a/src/ScrambleCoin.Application/Games/GetBoardState/GetBoardStateQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Games/GetBoardState/GetBoardStateQueryHandler.cs
@@ -100,7 +100,8 @@ public sealed class GetBoardStateQueryHandler : IRequestHandler<GetBoardStateQue
             MovementType: piece.MovementType.ToString(),
             MaxDistance: piece.MaxDistance,
             MovesPerTurn: piece.MovesPerTurn,
-            IsOnBoard: piece.IsOnBoard);
+            IsOnBoard: piece.IsOnBoard,
+            AvailableFromTurn: piece.AvailableFromTurn);
 
     private static ReadOnlyCollection<TileDto> BuildTiles(Board board, BoardObstacles obstacles)
     {

--- a/src/ScrambleCoin.Application/Games/GetBoardState/GetSpectatorBoardStateQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Games/GetBoardState/GetSpectatorBoardStateQueryHandler.cs
@@ -73,7 +73,8 @@ public sealed class GetSpectatorBoardStateQueryHandler : IRequestHandler<GetSpec
             MovementType: piece.MovementType.ToString(),
             MaxDistance: piece.MaxDistance,
             MovesPerTurn: piece.MovesPerTurn,
-            IsOnBoard: piece.IsOnBoard);
+            IsOnBoard: piece.IsOnBoard,
+            AvailableFromTurn: piece.AvailableFromTurn);
 
     private static ReadOnlyCollection<TileDto> BuildTiles(Board board, BoardObstacles obstacles)
     {

--- a/src/ScrambleCoin.Domain/Entities/Game.Movement.cs
+++ b/src/ScrambleCoin.Domain/Entities/Game.Movement.cs
@@ -947,7 +947,6 @@ public partial class Game
 
     /// <summary>
     /// Calculates the jump distance from <paramref name="from"/> to <paramref name="to"/> based on the
-    /// <paramref name="movementType"/>. For Jump pieces, distance determines if the jump is valid
     /// within MaxDistance.
     /// 
     /// Distance is always Chebyshev distance (king move distance / max of |Δrow|, |Δcol|),
@@ -956,9 +955,6 @@ public partial class Game
     /// - Diagonal jump to (3,3) = 3 tiles
     /// - AnyDirection jump to (2,3) = 3 tiles (max of 2 and 3)
     /// </summary>
-    /// <exception cref="DomainException">
-    /// Thrown if <paramref name="movementType"/> is not a valid Jump-compatible type.
-    /// </exception>
     private static int CalculateJumpDistance(Position from, Position to)
     {
         // All Jump movement types use Chebyshev distance (max of |Δrow|, |Δcol|)

--- a/src/ScrambleCoin.Domain/Entities/Game.TurnPhases.cs
+++ b/src/ScrambleCoin.Domain/Entities/Game.TurnPhases.cs
@@ -190,6 +190,10 @@ public partial class Game
         if (piece.IsOnBoard)
             throw new DomainException($"Piece {pieceId} is already on the board. Use ReplacePiece to swap it.");
 
+        if (piece.AvailableFromTurn is { } availableFromTurn && TurnNumber < availableFromTurn)
+            throw new DomainException(
+                $"Piece '{piece.Name}' ({pieceId}) cannot be placed before turn {availableFromTurn}. Current turn: {TurnNumber}.");
+
         if (!Board.IsValidEntryPoint(position, piece.EntryPointType))
             throw new DomainException($"Position {position} is not a valid entry point for entry type {piece.EntryPointType}.");
 
@@ -263,6 +267,10 @@ public partial class Game
 
         if (newPiece.IsOnBoard)
             throw new DomainException($"Piece {newPieceId} is already on the board; cannot use it as the replacement.");
+
+        if (newPiece.AvailableFromTurn is { } availableFromTurn && TurnNumber < availableFromTurn)
+            throw new DomainException(
+                $"Piece '{newPiece.Name}' ({newPieceId}) cannot be placed before turn {availableFromTurn}. Current turn: {TurnNumber}.");
 
         // Remove the existing piece — this clears the tile the new piece will occupy.
         var existingTile = Board.GetTile(targetPosition);

--- a/src/ScrambleCoin.Domain/Entities/Piece.cs
+++ b/src/ScrambleCoin.Domain/Entities/Piece.cs
@@ -69,6 +69,11 @@ public sealed class Piece
     /// <param name="movementType">Allowed movement directions.</param>
     /// <param name="maxDistance">Maximum tiles per move action; must be ≥ 1.</param>
     /// <param name="movesPerTurn">Move actions per turn; must be ≥ 1.</param>
+    /// <param name="availableFromTurn">
+    /// Earliest turn (1-based) at which this piece may be placed on the board.
+    /// <c>null</c> means the piece is available from turn 1 (no restriction).
+    /// When set, must be ≥ 1.
+    /// </param>
     public Piece(
         Guid id,
         string name,
@@ -76,7 +81,8 @@ public sealed class Piece
         EntryPointType entryPointType,
         MovementType movementType,
         int maxDistance,
-        int movesPerTurn)
+        int movesPerTurn,
+        int? availableFromTurn = null)
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new DomainException("Piece name must not be null or whitespace.");
@@ -87,6 +93,9 @@ public sealed class Piece
         if (movesPerTurn < 1)
             throw new DomainException($"MovesPerTurn must be at least 1, but was {movesPerTurn}.");
 
+        if (availableFromTurn is < 1)
+            throw new DomainException($"AvailableFromTurn must be at least 1, but was {availableFromTurn}.");
+
         Id = id;
         Name = name;
         PlayerId = playerId;
@@ -94,6 +103,7 @@ public sealed class Piece
         MovementType = movementType;
         MaxDistance = maxDistance;
         MovesPerTurn = movesPerTurn;
+        AvailableFromTurn = availableFromTurn;
     }
 
     /// <summary>
@@ -105,10 +115,18 @@ public sealed class Piece
         EntryPointType entryPointType,
         MovementType movementType,
         int maxDistance,
-        int movesPerTurn)
-        : this(Guid.NewGuid(), name, playerId, entryPointType, movementType, maxDistance, movesPerTurn)
+        int movesPerTurn,
+        int? availableFromTurn = null)
+        : this(Guid.NewGuid(), name, playerId, entryPointType, movementType, maxDistance, movesPerTurn, availableFromTurn)
     {
     }
+
+    /// <summary>
+    /// Earliest turn (1-based) at which this piece may be placed on the board.
+    /// <c>null</c> means there is no restriction (piece is placeable from turn 1).
+    /// Enforced in <see cref="Game.PlacePiece"/> and <see cref="Game.ReplacePiece"/>.
+    /// </summary>
+    public int? AvailableFromTurn { get; }
 
     /// <summary>Places this piece at the given board position.</summary>
     /// <exception cref="DomainException">Thrown when <paramref name="position"/> is null.</exception>

--- a/src/ScrambleCoin.Domain/Factories/PieceFactory.cs
+++ b/src/ScrambleCoin.Domain/Factories/PieceFactory.cs
@@ -23,14 +23,14 @@ public static class PieceFactory
             ["Donald"]    = new(EntryPointType.Corners, MovementType.AnyDirection, MaxDistance: 3, MovesPerTurn: 1),
             ["Goofy"]     = new(EntryPointType.Corners, MovementType.Jump, MaxDistance: 3, MovesPerTurn: 1),
             ["Scrooge"]   = new(EntryPointType.Corners, MovementType.AnyDirection, MaxDistance: 2, MovesPerTurn: 1),
-            ["Elsa"]      = new(EntryPointType.Borders, MovementType.Orthogonal, MaxDistance: 4, MovesPerTurn: 1),
+            ["Elsa"]      = new(EntryPointType.Borders, MovementType.Orthogonal, MaxDistance: 4, MovesPerTurn: 1, AvailableFromTurn: 2),
             // Multistep movement pieces
             ["Cogsworth"] = new(EntryPointType.Borders, MovementType.AnyDirection, MaxDistance: 1, MovesPerTurn: 2, SegmentTypes: [MovementType.AnyDirection, MovementType.Orthogonal], SegmentMaxDistances:
                 [1, 2]),
             ["Lumiere"]   = new(EntryPointType.Borders, MovementType.AnyDirection, MaxDistance: 1, MovesPerTurn: 2, SegmentTypes: [MovementType.AnyDirection, MovementType.Diagonal], SegmentMaxDistances:
                 [1, 2]),
             ["Remy"]      = new(EntryPointType.Borders, MovementType.Diagonal, MaxDistance: 2, MovesPerTurn: 2, SegmentTypes: [MovementType.Diagonal, MovementType.Diagonal], SegmentMaxDistances: [2, 2
-            ]),
+            ], AvailableFromTurn: 2),
             ["Anna"]      = new(EntryPointType.Borders, MovementType.Orthogonal, MaxDistance: 1, MovesPerTurn: 3, SegmentTypes: [MovementType.Orthogonal, MovementType.Orthogonal, MovementType.Orthogonal
             ], SegmentMaxDistances: [1, 1, 1]),
             ["Olaf"]      = new(EntryPointType.Anywhere, MovementType.AnyDirection, MaxDistance: 1, MovesPerTurn: 2, SegmentTypes: [MovementType.AnyDirection, MovementType.AnyDirection], SegmentMaxDistances:
@@ -44,21 +44,21 @@ public static class PieceFactory
             ["WALL•E"]    = new(EntryPointType.Borders, MovementType.Charge, MaxDistance: 8, MovesPerTurn: 1),
             ["Sulley"]    = new(EntryPointType.Borders, MovementType.AnyDirection, MaxDistance: 2, MovesPerTurn: 1),
             ["Rafiki"]    = new(EntryPointType.Corners, MovementType.Jump, MaxDistance: 4, MovesPerTurn: 1),
-            ["Scar"]      = new(EntryPointType.Corners, MovementType.Jump, MaxDistance: 4, MovesPerTurn: 1),
-            ["Daisy"]     = new(EntryPointType.Anywhere, MovementType.Jump, MaxDistance: 3, MovesPerTurn: 1),
+            ["Scar"]      = new(EntryPointType.Corners, MovementType.Jump, MaxDistance: 4, MovesPerTurn: 1, AvailableFromTurn: 3),
+            ["Daisy"]     = new(EntryPointType.Anywhere, MovementType.Jump, MaxDistance: 3, MovesPerTurn: 1, AvailableFromTurn: 2),
             ["Stitch"]    = new(EntryPointType.Borders, MovementType.Orthogonal, MaxDistance: 3, MovesPerTurn: 1),
 
             // Passive & turn-based ability pieces (Issue #50)
             ["Flynn"]           = new(EntryPointType.Anywhere, MovementType.AnyDirection, MaxDistance: 1, MovesPerTurn: 1),
             ["Moana"]           = new(EntryPointType.Anywhere, MovementType.AnyDirection, MaxDistance: 1, MovesPerTurn: 1),
             ["Jafar"]           = new(EntryPointType.Borders, MovementType.AnyDirection, MaxDistance: 2, MovesPerTurn: 1), // Jafar multistep movement (grows)
-            ["Merlin"]          = new(EntryPointType.Anywhere, MovementType.Ethereal, MaxDistance: 2, MovesPerTurn: 1),
-            ["Rapunzel"]        = new(EntryPointType.Anywhere, MovementType.AnyDirection, MaxDistance: 1, MovesPerTurn: 1),
+            ["Merlin"]          = new(EntryPointType.Anywhere, MovementType.Ethereal, MaxDistance: 2, MovesPerTurn: 1, AvailableFromTurn: 4),
+            ["Rapunzel"]        = new(EntryPointType.Anywhere, MovementType.AnyDirection, MaxDistance: 1, MovesPerTurn: 1, AvailableFromTurn: 3),
             ["Cinderella"]      = new(EntryPointType.Corners, MovementType.AnyDirection, MaxDistance: 2, MovesPerTurn: 2, SegmentTypes: [MovementType.AnyDirection, MovementType.AnyDirection], SegmentMaxDistances:
                 [2, 1]),
             ["Fairy Godmother"] = new(EntryPointType.Anywhere, MovementType.Ethereal, MaxDistance: 2, MovesPerTurn: 1),
             ["Ursula"]          = new(EntryPointType.Anywhere, MovementType.Ethereal, MaxDistance: 2, MovesPerTurn: 1),
-            ["Mike Wazowski"]   = new(EntryPointType.Corners, MovementType.AnyDirection, MaxDistance: 2, MovesPerTurn: 1),
+            ["Mike Wazowski"]   = new(EntryPointType.Corners, MovementType.AnyDirection, MaxDistance: 2, MovesPerTurn: 1, AvailableFromTurn: 3),
             ["Forky"]           = new(EntryPointType.Anywhere, MovementType.AnyDirection, MaxDistance: 2, MovesPerTurn: 1)
         };
 
@@ -87,7 +87,8 @@ public static class PieceFactory
             template.EntryPointType,
             template.MovementType,
             template.MaxDistance,
-            template.MovesPerTurn);
+            template.MovesPerTurn,
+            template.AvailableFromTurn);
 
         // If the template specifies per-segment movement types, set them
         if (template.SegmentTypes is { Length: > 0 })
@@ -149,5 +150,6 @@ public static class PieceFactory
         int MaxDistance,
         int MovesPerTurn,
         MovementType[]? SegmentTypes = null,
-        int[]? SegmentMaxDistances = null);
+        int[]? SegmentMaxDistances = null,
+        int? AvailableFromTurn = null);
 }

--- a/src/ScrambleCoin.Infrastructure/Persistence/GameRepository.cs
+++ b/src/ScrambleCoin.Infrastructure/Persistence/GameRepository.cs
@@ -291,7 +291,8 @@ public sealed class GameRepository : IGameRepository
             MaxDistance: p.MaxDistance,
             MovesPerTurn: p.MovesPerTurn,
             PositionRow: p.Position?.Row,
-            PositionCol: p.Position?.Col)).ToList();
+            PositionCol: p.Position?.Col,
+            AvailableFromTurn: p.AvailableFromTurn)).ToList();
 
         return JsonSerializer.Serialize(dtos, JsonOptions);
     }
@@ -367,7 +368,8 @@ public sealed class GameRepository : IGameRepository
             entryPointType: (EntryPointType)dto.EntryPointType,
             movementType: (MovementType)dto.MovementType,
             maxDistance: dto.MaxDistance,
-            movesPerTurn: dto.MovesPerTurn);
+            movesPerTurn: dto.MovesPerTurn,
+            availableFromTurn: dto.AvailableFromTurn);
     }
 
     // ── Reflection helpers ────────────────────────────────────────────────────

--- a/src/ScrambleCoin.Infrastructure/Persistence/Records/PersistenceDtos.cs
+++ b/src/ScrambleCoin.Infrastructure/Persistence/Records/PersistenceDtos.cs
@@ -49,4 +49,5 @@ internal sealed record PieceDto(
     int MaxDistance,
     int MovesPerTurn,
     int? PositionRow,
-    int? PositionCol);
+    int? PositionCol,
+    int? AvailableFromTurn = null);

--- a/src/ScrambleCoin.Web/Pages/Tournament.razor
+++ b/src/ScrambleCoin.Web/Pages/Tournament.razor
@@ -535,8 +535,8 @@
                                     for (var mi2 = 0; mi2 < matchesThisRound; mi2 += 2)
                                     {
                                         // Two matches in this round feed one match in the next
-                                        var topY = MatchCenterY(ri, mi2, firstCount);
-                                        var botY = MatchCenterY(ri, mi2 + 1 < matchesThisRound ? mi2 + 1 : mi2, firstCount);
+                                        var topY = MatchCenterY(ri, mi2);
+                                        var botY = MatchCenterY(ri, mi2 + 1 < matchesThisRound ? mi2 + 1 : mi2);
                                         var midY = (topY + botY) / 2;
                                         const int halfConn = (ConnW + RoundPad * 2) / 2;
                                         const int fullConn = ConnW + RoundPad * 2;
@@ -693,7 +693,7 @@
     }
 
     /// <summary>Vertical centre pixel for match [roundIndex, matchIndex].</summary>
-    private static int MatchCenterY(int roundIndex, int matchIndex, int firstCount)
+    private static int MatchCenterY(int roundIndex, int matchIndex)
     {
         var slotH = SlotH(roundIndex);
         return matchIndex * slotH + slotH / 2;

--- a/src/ScrambleCoin.Web/Program.cs
+++ b/src/ScrambleCoin.Web/Program.cs
@@ -132,9 +132,3 @@ finally
 {
     Log.CloseAndFlush();
 }
-
-
-namespace ScrambleCoin.Web
-{
-    internal partial class Program;
-}

--- a/tests/ScrambleCoin.Application.Tests/MultiStepMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/MultiStepMovementIntegrationTests.cs
@@ -64,8 +64,7 @@ public class MultiStepMovementIntegrationTests
         {
             game.SkipPlacement(p1);
             game.SkipPlacement(p2);
-            game.AdvancePhase(); // MovePhase → next-turn CoinSpawn
-            game.AdvancePhase(); // CoinSpawn → PlacePhase
+            game.AdvancePhase(); // CoinSpawn → PlacePhase (SkipPlacement-both already advanced through MovePhase to next-turn CoinSpawn)
         }
 
         // Choose the appropriate starting position based on an entry point type

--- a/tests/ScrambleCoin.Application.Tests/MultiStepMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/MultiStepMovementIntegrationTests.cs
@@ -59,8 +59,18 @@ public class MultiStepMovementIntegrationTests
         game.Start();
         game.AdvancePhase(); // CoinSpawn → PlacePhase
 
+        // Advance turns until the test piece can legally be placed (Issue #59).
+        while (piece.AvailableFromTurn is { } from && game.TurnNumber < from)
+        {
+            game.SkipPlacement(p1);
+            game.SkipPlacement(p2);
+            game.AdvancePhase(); // MovePhase → next-turn CoinSpawn
+            game.AdvancePhase(); // CoinSpawn → PlacePhase
+        }
+
         // Choose the appropriate starting position based on an entry point type
         var startPos = piece.EntryPointType == EntryPointType.Corners 
+
             ? new Position(0, 0) 
             : new Position(0, 3);
 

--- a/tests/ScrambleCoin.Application.Tests/PieceTurnAvailabilityBoardStateTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/PieceTurnAvailabilityBoardStateTests.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using ScrambleCoin.Application.BotRegistration;
+using ScrambleCoin.Application.Games.GetBoardState;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Factories;
+using ScrambleCoin.Domain.ValueObjects;
+using DomainBotReg = ScrambleCoin.Domain.BotRegistrations.BotRegistration;
+
+namespace ScrambleCoin.Application.Tests;
+
+/// <summary>
+/// Application-layer tests for Issue #59: <see cref="GetBoardStateQueryHandler"/>
+/// must expose <c>AvailableFromTurn</c> on every <see cref="PieceDto"/> it returns.
+/// </summary>
+public class PieceTurnAvailabilityBoardStateTests
+{
+    private static (Game game, Guid p1, Guid p2) NewStartedGameWithRestrictedLineup()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        // Mix unrestricted starter pieces with restricted ones so we can assert both branches.
+        // Lineup must contain exactly Lineup.RequiredPieceCount (= 5) pieces.
+        string[] lineup1 = ["Mickey", "Elsa", "Scar", "Merlin", "Goofy"];
+        string[] lineup2 = ["Mickey", "Minnie", "Donald", "Goofy", "Scrooge"];
+
+        var pieces1 = lineup1.Select(n => PieceFactory.Create(n, p1)).ToList();
+        var pieces2 = lineup2.Select(n => PieceFactory.Create(n, p2)).ToList();
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(pieces1));
+        game.SetLineup(p2, new Lineup(pieces2));
+        game.Start();
+
+        return (game, p1, p2);
+    }
+
+    private static GetBoardStateQueryHandler BuildHandlerFor(Game game, DomainBotReg reg)
+    {
+        var gameRepo = Substitute.For<IGameRepository>();
+        var botRepo = Substitute.For<IBotRegistrationRepository>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+        botRepo.GetByTokenAsync(reg.Token, Arg.Any<CancellationToken>()).Returns(reg);
+
+        var logger = Substitute.For<ILogger<GetBoardStateQueryHandler>>();
+        return new GetBoardStateQueryHandler(gameRepo, botRepo, logger);
+    }
+
+    [Fact]
+    public async Task Handle_YourPieces_IncludesAvailableFromTurnForRestrictedPiece()
+    {
+        var (game, p1, _) = NewStartedGameWithRestrictedLineup();
+        var reg = new DomainBotReg(Guid.NewGuid(), p1, game.Id);
+        var handler = BuildHandlerFor(game, reg);
+
+        var dto = await handler.Handle(new GetBoardStateQuery(game.Id, reg.Token), CancellationToken.None);
+
+        var elsa = dto.YourPieces.Single(p => p.Name == "Elsa");
+        Assert.Equal(2, elsa.AvailableFromTurn);
+    }
+
+    [Fact]
+    public async Task Handle_YourPieces_NullAvailableFromTurnForUnrestrictedPiece()
+    {
+        var (game, p1, _) = NewStartedGameWithRestrictedLineup();
+        var reg = new DomainBotReg(Guid.NewGuid(), p1, game.Id);
+        var handler = BuildHandlerFor(game, reg);
+
+        var dto = await handler.Handle(new GetBoardStateQuery(game.Id, reg.Token), CancellationToken.None);
+
+        var mickey = dto.YourPieces.Single(p => p.Name == "Mickey");
+        Assert.Null(mickey.AvailableFromTurn);
+    }
+
+    [Theory]
+    [InlineData("Scar", 3)]
+    [InlineData("Merlin", 4)]
+    public async Task Handle_YourPieces_ExposesEachRestrictedPieceCorrectly(string name, int expected)
+    {
+        var (game, p1, _) = NewStartedGameWithRestrictedLineup();
+        var reg = new DomainBotReg(Guid.NewGuid(), p1, game.Id);
+        var handler = BuildHandlerFor(game, reg);
+
+        var dto = await handler.Handle(new GetBoardStateQuery(game.Id, reg.Token), CancellationToken.None);
+
+        var piece = dto.YourPieces.Single(p => p.Name == name);
+        Assert.Equal(expected, piece.AvailableFromTurn);
+    }
+
+    [Fact]
+    public async Task Handle_OpponentPieces_AlsoExposesAvailableFromTurn()
+    {
+        var (game, p1, _) = NewStartedGameWithRestrictedLineup();
+        var reg = new DomainBotReg(Guid.NewGuid(), p1, game.Id);
+        var handler = BuildHandlerFor(game, reg);
+
+        var dto = await handler.Handle(new GetBoardStateQuery(game.Id, reg.Token), CancellationToken.None);
+
+        // Opponent lineup is all starters → every piece must have null AvailableFromTurn.
+        Assert.All(dto.OpponentPieces, p => Assert.Null(p.AvailableFromTurn));
+    }
+}

--- a/tests/ScrambleCoin.Application.Tests/PieceTurnAvailabilityBoardStateTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/PieceTurnAvailabilityBoardStateTests.cs
@@ -4,7 +4,6 @@ using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Games.GetBoardState;
 using ScrambleCoin.Application.Interfaces;
 using ScrambleCoin.Domain.Entities;
-using ScrambleCoin.Domain.Enums;
 using ScrambleCoin.Domain.Factories;
 using ScrambleCoin.Domain.ValueObjects;
 using DomainBotReg = ScrambleCoin.Domain.BotRegistrations.BotRegistration;

--- a/tests/ScrambleCoin.Domain.Tests/CoinSpawningTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/CoinSpawningTests.cs
@@ -18,7 +18,7 @@ public class CoinSpawningTests
     /// Creates a Game that has been started. After Start() the game is in
     /// TurnPhase.CoinSpawn on turn 1, ready to accept <see cref="Game.SpawnCoins"/>.
     /// </summary>
-    private static (Game game, Guid p1, Guid p2) StartedGame()
+    private static Game StartedGame()
     {
         var p1 = Guid.NewGuid();
         var p2 = Guid.NewGuid();
@@ -26,13 +26,13 @@ public class CoinSpawningTests
         game.SetLineup(p1, NewLineup());
         game.SetLineup(p2, NewLineup());
         game.Start();
-        return (game, p1, p2);
+        return game;
     }
 
     /// <summary>
     /// Creates a Game that has been started with a custom Board (so obstacles can be pre-added).
     /// </summary>
-    private static (Game game, Guid p1, Guid p2) StartedGameWithBoard(Board board)
+    private static Game StartedGameWithBoard(Board board)
     {
         var p1 = Guid.NewGuid();
         var p2 = Guid.NewGuid();
@@ -40,7 +40,7 @@ public class CoinSpawningTests
         game.SetLineup(p1, NewLineup());
         game.SetLineup(p2, NewLineup());
         game.Start();
-        return (game, p1, p2);
+        return game;
     }
 
     // ── Phase guard ───────────────────────────────────────────────────────────
@@ -48,7 +48,7 @@ public class CoinSpawningTests
     [Fact]
     public void SpawnCoins_OutsideCoinSpawnPhase_ThrowsDomainException()
     {
-        var (game, _, _) = StartedGame();
+        var game = StartedGame();
         game.AdvancePhase(); // CoinSpawn → PlacePhase
 
         Assert.Throws<DomainException>(() =>
@@ -64,7 +64,7 @@ public class CoinSpawningTests
         var rockPosition = new Position(3, 3);
         board.AddRock(new Rock(rockPosition));
 
-        var (game, _, _) = StartedGameWithBoard(board);
+        var game = StartedGameWithBoard(board);
 
         Assert.Throws<DomainException>(() =>
             game.SpawnCoins([(rockPosition, CoinType.Silver)]));
@@ -77,7 +77,7 @@ public class CoinSpawningTests
         board.AddLake(new Lake(new Position(2, 2)));
         var lakeCoveredPosition = new Position(2, 2); // top-left of the 2×2 lake
 
-        var (game, _, _) = StartedGameWithBoard(board);
+        var game = StartedGameWithBoard(board);
 
         Assert.Throws<DomainException>(() =>
             game.SpawnCoins([(lakeCoveredPosition, CoinType.Silver)]));
@@ -90,7 +90,7 @@ public class CoinSpawningTests
         board.AddLake(new Lake(new Position(2, 2)));
         var interiorLakePosition = new Position(3, 3); // bottom-right of 2×2 lake at (2,2)
 
-        var (game, _, _) = StartedGameWithBoard(board);
+        var game = StartedGameWithBoard(board);
 
         Assert.Throws<DomainException>(() =>
             game.SpawnCoins([(interiorLakePosition, CoinType.Silver)]));
@@ -103,7 +103,7 @@ public class CoinSpawningTests
         var coinPosition = new Position(1, 1);
         board.GetTile(coinPosition).SetOccupant(new Coin(CoinType.Silver));
 
-        var (game, _, _) = StartedGameWithBoard(board);
+        var game = StartedGameWithBoard(board);
 
         Assert.Throws<DomainException>(() =>
             game.SpawnCoins([(coinPosition, CoinType.Silver)]));
@@ -116,7 +116,7 @@ public class CoinSpawningTests
         var piecePosition = new Position(4, 4);
         board.GetTile(piecePosition).SetOccupant(PieceFactory.Any("Blocker"));
 
-        var (game, _, _) = StartedGameWithBoard(board);
+        var game = StartedGameWithBoard(board);
 
         Assert.Throws<DomainException>(() =>
             game.SpawnCoins([(piecePosition, CoinType.Silver)]));
@@ -127,7 +127,7 @@ public class CoinSpawningTests
     [Fact]
     public void SpawnCoins_OnFreeTile_PlacesCoin()
     {
-        var (game, _, _) = StartedGame();
+        var game = StartedGame();
         var spawnPosition = new Position(5, 5);
 
         game.SpawnCoins([(spawnPosition, CoinType.Silver)]);
@@ -140,7 +140,7 @@ public class CoinSpawningTests
     [Fact]
     public void SpawnCoins_OnFreeTile_PlacesGoldCoin()
     {
-        var (game, _, _) = StartedGame();
+        var game = StartedGame();
         var spawnPosition = new Position(0, 0);
 
         game.SpawnCoins([(spawnPosition, CoinType.Gold)]);
@@ -155,7 +155,7 @@ public class CoinSpawningTests
     [Fact]
     public void SpawnCoins_RaisesCoinsSpawnedEvent()
     {
-        var (game, _, _) = StartedGame();
+        var game = StartedGame();
         game.ClearDomainEvents();
 
         game.SpawnCoins([(new Position(0, 0), CoinType.Silver)]);
@@ -167,7 +167,7 @@ public class CoinSpawningTests
     [Fact]
     public void SpawnCoins_CoinsSpawnedEvent_HasCorrectGameId()
     {
-        var (game, _, _) = StartedGame();
+        var game = StartedGame();
         game.ClearDomainEvents();
 
         game.SpawnCoins([(new Position(0, 0), CoinType.Silver)]);
@@ -179,7 +179,7 @@ public class CoinSpawningTests
     [Fact]
     public void SpawnCoins_CoinsSpawnedEvent_HasCorrectTurnNumber()
     {
-        var (game, _, _) = StartedGame();
+        var game = StartedGame();
         game.ClearDomainEvents();
 
         game.SpawnCoins([(new Position(0, 0), CoinType.Silver)]);
@@ -191,7 +191,7 @@ public class CoinSpawningTests
     [Fact]
     public void SpawnCoins_CoinsSpawnedEvent_HasCorrectCoinCount()
     {
-        var (game, _, _) = StartedGame();
+        var game = StartedGame();
         game.ClearDomainEvents();
         var positions = new[]
         {
@@ -209,7 +209,7 @@ public class CoinSpawningTests
     [Fact]
     public void SpawnCoins_CoinsSpawnedEvent_ContainsSpawnedPositions()
     {
-        var (game, _, _) = StartedGame();
+        var game = StartedGame();
         game.ClearDomainEvents();
         var spawnPosition = new Position(3, 3);
 

--- a/tests/ScrambleCoin.Domain.Tests/IcePatchesTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/IcePatchesTests.cs
@@ -135,8 +135,7 @@ public class IcePatchesTests
         // Elsa is restricted to turn ≥ 2 (Issue #59); skip turn 1 placement.
         game.SkipPlacement(p1);
         game.SkipPlacement(p2);
-        game.AdvancePhase(); // MovePhase → CoinSpawn (turn 2)
-        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.AdvancePhase(); // CoinSpawn (turn 2) → PlacePhase
         game.PlacePiece(p1, elsaPiece.Id, new Position(0, 0));
         game.PlacePiece(p2, p2Piece.Id, new Position(7, 7));
 
@@ -213,8 +212,7 @@ public class IcePatchesTests
         // Elsa is restricted to turn ≥ 2 (Issue #59); skip turn 1 placement.
         game.SkipPlacement(p1);
         game.SkipPlacement(p2);
-        game.AdvancePhase(); // MovePhase → CoinSpawn (turn 2)
-        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.AdvancePhase(); // CoinSpawn (turn 2) → PlacePhase
         // Place Elsa at (0,0) on the border, move to (0,2)
         game.PlacePiece(p1, elsaPiece.Id, new Position(0, 0));
         game.PlacePiece(p2, p2Piece.Id, new Position(7, 7));

--- a/tests/ScrambleCoin.Domain.Tests/IcePatchesTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/IcePatchesTests.cs
@@ -132,6 +132,11 @@ public class IcePatchesTests
         game.Start();
 
         game.AdvancePhase(); // CoinSpawn → PlacePhase
+        // Elsa is restricted to turn ≥ 2 (Issue #59); skip turn 1 placement.
+        game.SkipPlacement(p1);
+        game.SkipPlacement(p2);
+        game.AdvancePhase(); // MovePhase → CoinSpawn (turn 2)
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
         game.PlacePiece(p1, elsaPiece.Id, new Position(0, 0));
         game.PlacePiece(p2, p2Piece.Id, new Position(7, 7));
 
@@ -204,6 +209,11 @@ public class IcePatchesTests
         game.SetLineup(p2, new Lineup(new List<Piece> { p2Piece }.Concat(p2Fillers).ToList()));
         game.Start();
 
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        // Elsa is restricted to turn ≥ 2 (Issue #59); skip turn 1 placement.
+        game.SkipPlacement(p1);
+        game.SkipPlacement(p2);
+        game.AdvancePhase(); // MovePhase → CoinSpawn (turn 2)
         game.AdvancePhase(); // CoinSpawn → PlacePhase
         // Place Elsa at (0,0) on the border, move to (0,2)
         game.PlacePiece(p1, elsaPiece.Id, new Position(0, 0));

--- a/tests/ScrambleCoin.Domain.Tests/MultiStepMovementTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/MultiStepMovementTests.cs
@@ -41,6 +41,15 @@ public class MultiStepMovementTests
         game.Start();
         game.AdvancePhase(); // CoinSpawn → PlacePhase
 
+        // Advance turns until the test piece can legally be placed (Issue #59).
+        while (p1Piece.AvailableFromTurn is { } from && game.TurnNumber < from)
+        {
+            game.SkipPlacement(p1);
+            game.SkipPlacement(p2);
+            game.AdvancePhase(); // MovePhase → next-turn CoinSpawn
+            game.AdvancePhase(); // CoinSpawn → PlacePhase
+        }
+
         // Choose the appropriate starting position based on an entry point type
         var p1StartPos = p1Piece.EntryPointType == EntryPointType.Corners ? new Position(0, 0) : new Position(0, 3);
         var p2StartPos = new Position(7, 3);

--- a/tests/ScrambleCoin.Domain.Tests/MultiStepMovementTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/MultiStepMovementTests.cs
@@ -46,8 +46,7 @@ public class MultiStepMovementTests
         {
             game.SkipPlacement(p1);
             game.SkipPlacement(p2);
-            game.AdvancePhase(); // MovePhase → next-turn CoinSpawn
-            game.AdvancePhase(); // CoinSpawn → PlacePhase
+            game.AdvancePhase(); // CoinSpawn → PlacePhase (SkipPlacement-both already advanced through MovePhase to next-turn CoinSpawn)
         }
 
         // Choose the appropriate starting position based on an entry point type

--- a/tests/ScrambleCoin.Domain.Tests/OnStopAbilitiesIntegrationTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/OnStopAbilitiesIntegrationTests.cs
@@ -55,6 +55,15 @@ public class OnStopAbilitiesIntegrationTests
         game.Start();
         game.AdvancePhase(); // CoinSpawn → PlacePhase
 
+        // Advance turns until the test piece can legally be placed (Issue #59).
+        while (testPiece.AvailableFromTurn is { } from && game.TurnNumber < from)
+        {
+            game.SkipPlacement(p1);
+            game.SkipPlacement(p2);
+            game.AdvancePhase(); // MovePhase → next-turn CoinSpawn
+            game.AdvancePhase(); // CoinSpawn → PlacePhase
+        }
+
         // Place both pieces to auto-advance to MovePhase
         var actualP2Pos = p2Position ?? new Position(7, 3); // Valid Border entry point
         game.PlacePiece(p1, testPiece.Id, p1Position);

--- a/tests/ScrambleCoin.Domain.Tests/OnStopAbilitiesIntegrationTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/OnStopAbilitiesIntegrationTests.cs
@@ -60,8 +60,7 @@ public class OnStopAbilitiesIntegrationTests
         {
             game.SkipPlacement(p1);
             game.SkipPlacement(p2);
-            game.AdvancePhase(); // MovePhase → next-turn CoinSpawn
-            game.AdvancePhase(); // CoinSpawn → PlacePhase
+            game.AdvancePhase(); // CoinSpawn → PlacePhase (SkipPlacement-both already advanced through MovePhase to next-turn CoinSpawn)
         }
 
         // Place both pieces to auto-advance to MovePhase

--- a/tests/ScrambleCoin.Domain.Tests/PassiveAbilitiesTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/PassiveAbilitiesTests.cs
@@ -58,8 +58,7 @@ public class PassiveAbilitiesTests
         {
             game.SkipPlacement(p1);
             game.SkipPlacement(p2);
-            game.AdvancePhase(); // MovePhase → next-turn CoinSpawn
-            game.AdvancePhase(); // CoinSpawn → PlacePhase
+            game.AdvancePhase(); // CoinSpawn → PlacePhase (SkipPlacement-both already advanced through MovePhase to next-turn CoinSpawn)
         }
 
         var actualP1Pos = p1Position ?? new Position(0, 3);

--- a/tests/ScrambleCoin.Domain.Tests/PassiveAbilitiesTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/PassiveAbilitiesTests.cs
@@ -53,6 +53,15 @@ public class PassiveAbilitiesTests
         game.Start();
         game.AdvancePhase(); // CoinSpawn → PlacePhase
 
+        // Advance turns until the test piece can legally be placed (Issue #59).
+        while (testPiece.AvailableFromTurn is { } from && game.TurnNumber < from)
+        {
+            game.SkipPlacement(p1);
+            game.SkipPlacement(p2);
+            game.AdvancePhase(); // MovePhase → next-turn CoinSpawn
+            game.AdvancePhase(); // CoinSpawn → PlacePhase
+        }
+
         var actualP1Pos = p1Position ?? new Position(0, 3);
         var actualP2Pos = p2Position ?? new Position(7, 3);
 

--- a/tests/ScrambleCoin.Domain.Tests/PieceTurnAvailabilityTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/PieceTurnAvailabilityTests.cs
@@ -161,8 +161,7 @@ public class PieceTurnAvailabilityTests
             game.SkipPlacement(p2);
             // SkipPlacement auto-advances PlacePhase → MovePhase when both players act.
             // From MovePhase advance → next turn CoinSpawn → PlacePhase.
-            game.AdvancePhase(); // MovePhase → next-turn CoinSpawn
-            game.AdvancePhase(); // CoinSpawn → PlacePhase
+            game.AdvancePhase(); // CoinSpawn → PlacePhase (SkipPlacement-both already advanced through MovePhase to next-turn CoinSpawn)
         }
 
         game.ClearDomainEvents();
@@ -187,10 +186,11 @@ public class PieceTurnAvailabilityTests
         var existing = p1Pieces[0]; // unrestricted starter
         game.PlacePiece(p1, existing.Id, new Position(0, 0));
         game.SkipPlacement(p2);
-        // Now in MovePhase. Advance to next turn's PlacePhase if needed.
+        // p1 placed (has a piece on board), p2 skipped (no pieces). PlacePhase → MovePhase auto-fired.
+        // p1 still has an unmoved piece, so MovePhase does NOT auto-advance. Need 2 manual phase advances.
         if (currentTurn > seedTurn)
         {
-            game.AdvancePhase(); // MovePhase → next-turn CoinSpawn
+            game.SkipMovement(p1);
             game.AdvancePhase(); // CoinSpawn → PlacePhase
         }
 

--- a/tests/ScrambleCoin.Domain.Tests/PieceTurnAvailabilityTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/PieceTurnAvailabilityTests.cs
@@ -1,0 +1,200 @@
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Exceptions;
+using ScrambleCoin.Domain.Factories;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Domain.Tests;
+
+/// <summary>
+/// Tests for Piece turn-availability conditions (Issue #59).
+/// A piece with <see cref="Piece.AvailableFromTurn"/> set may only be placed on or after
+/// that turn; placing earlier must throw a <see cref="DomainException"/>.
+///
+/// Authoritative turn values are taken from <c>SCRAMBLECOIN_OVERVIEW.md</c>.
+/// </summary>
+public class PieceTurnAvailabilityTests
+{
+    // ── Constructor / factory wiring ──────────────────────────────────────────
+
+    [Fact]
+    public void Piece_DefaultsAvailableFromTurn_ToNull()
+    {
+        var piece = new Piece("Mickey", Guid.NewGuid(), EntryPointType.Borders, MovementType.Orthogonal, 3, 1);
+        Assert.Null(piece.AvailableFromTurn);
+    }
+
+    [Fact]
+    public void Piece_ExplicitAvailableFromTurn_IsPreserved()
+    {
+        var piece = new Piece("Elsa", Guid.NewGuid(), EntryPointType.Borders, MovementType.Orthogonal, 4, 1, availableFromTurn: 2);
+        Assert.Equal(2, piece.AvailableFromTurn);
+    }
+
+    [Fact]
+    public void Piece_AvailableFromTurnBelowOne_Throws()
+    {
+        Assert.Throws<DomainException>(() =>
+            new Piece("X", Guid.NewGuid(), EntryPointType.Borders, MovementType.Orthogonal, 1, 1, availableFromTurn: 0));
+    }
+
+    [Theory]
+    [InlineData("Mickey", null)]
+    [InlineData("Goofy", null)]
+    [InlineData("Scrooge", null)]
+    [InlineData("Elsa", 2)]
+    [InlineData("Remy", 2)]
+    [InlineData("Daisy", 2)]
+    [InlineData("Scar", 3)]
+    [InlineData("Rapunzel", 3)]
+    [InlineData("Mike Wazowski", 3)]
+    [InlineData("Merlin", 4)]
+    public void PieceFactory_SetsAvailableFromTurn_PerOverview(string name, int? expected)
+    {
+        var piece = PieceFactory.Create(name, Guid.NewGuid());
+        Assert.Equal(expected, piece.AvailableFromTurn);
+    }
+
+    // ── Placement guard ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void PlacePiece_RestrictedPieceOnEarlierTurn_Rejected()
+    {
+        var (game, p1, _, _, _, restricted) = BuildGameWithRestrictedPieceAtTurn(restrictedFromTurn: 3, currentTurn: 2);
+
+        var ex = Assert.Throws<DomainException>(() =>
+            game.PlacePiece(p1, restricted.Id, new Position(0, 0)));
+
+        Assert.Contains("cannot be placed before turn 3", ex.Message);
+        Assert.False(restricted.IsOnBoard);
+    }
+
+    [Fact]
+    public void PlacePiece_RestrictedPieceOnExactTurn_Accepted()
+    {
+        var (game, p1, _, _, _, restricted) = BuildGameWithRestrictedPieceAtTurn(restrictedFromTurn: 2, currentTurn: 2);
+
+        game.PlacePiece(p1, restricted.Id, new Position(0, 0));
+
+        Assert.True(restricted.IsOnBoard);
+        Assert.Equal(new Position(0, 0), restricted.Position);
+    }
+
+    [Fact]
+    public void PlacePiece_RestrictedPieceOnLaterTurn_Accepted()
+    {
+        var (game, p1, _, _, _, restricted) = BuildGameWithRestrictedPieceAtTurn(restrictedFromTurn: 2, currentTurn: 3);
+
+        game.PlacePiece(p1, restricted.Id, new Position(0, 0));
+
+        Assert.True(restricted.IsOnBoard);
+    }
+
+    // ── Replacement guard ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void ReplacePiece_WithRestrictedPieceOnEarlierTurn_Rejected()
+    {
+        // Game seeded at turn 4, in PlacePhase, with an unrestricted piece already on the board.
+        // The "restricted" replacement requires turn 5, so this must be rejected.
+        var (game, p1, _, _, _, restricted, existing) = BuildGameWithExistingPlacedAndRestrictedPiece(
+            restrictedFromTurn: 5, currentTurn: 4);
+
+        var ex = Assert.Throws<DomainException>(() =>
+            game.ReplacePiece(p1, existing.Id, restricted.Id));
+
+        Assert.Contains("cannot be placed before turn 5", ex.Message);
+        Assert.True(existing.IsOnBoard);
+        Assert.False(restricted.IsOnBoard);
+    }
+
+    [Fact]
+    public void ReplacePiece_WithRestrictedPieceOnExactTurn_Accepted()
+    {
+        var (game, p1, _, _, _, restricted, existing) =
+            BuildGameWithExistingPlacedAndRestrictedPiece(restrictedFromTurn: 3, currentTurn: 3);
+
+        game.ReplacePiece(p1, existing.Id, restricted.Id);
+
+        Assert.True(restricted.IsOnBoard);
+        Assert.False(existing.IsOnBoard);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a Game seeded at the given <paramref name="currentTurn"/>, in PlacePhase,
+    /// with a "restricted" piece available only from <paramref name="restrictedFromTurn"/>.
+    /// Both players have 5 lineup pieces. The restricted piece replaces p1Pieces[1] in p1's lineup.
+    /// </summary>
+    private static (Game game, Guid p1, Guid p2, List<Piece> p1Pieces, List<Piece> p2Pieces, Piece restricted)
+        BuildGameWithRestrictedPieceAtTurn(int restrictedFromTurn, int currentTurn)
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var board = new Board();
+
+        var restricted = new Piece(
+            Guid.NewGuid(), "Restricted", p1,
+            EntryPointType.Borders, MovementType.Orthogonal, 1, 1,
+            availableFromTurn: restrictedFromTurn);
+
+        var p1Pieces = Enumerable.Range(0, 4)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Piece{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+        p1Pieces.Add(restricted);
+
+        var p2Pieces = Enumerable.Range(0, 5)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Piece{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, board);
+        game.SetLineup(p1, new Lineup(p1Pieces));
+        game.SetLineup(p2, new Lineup(p2Pieces));
+        game.Start();          // → turn 1, CoinSpawn
+        game.AdvancePhase();   // → PlacePhase
+
+        // Walk forward to the desired turn by skipping placement and move phases.
+        while (game.TurnNumber < currentTurn)
+        {
+            game.SkipPlacement(p1);
+            game.SkipPlacement(p2);
+            // SkipPlacement auto-advances PlacePhase → MovePhase when both players act.
+            // From MovePhase advance → next turn CoinSpawn → PlacePhase.
+            game.AdvancePhase(); // MovePhase → next-turn CoinSpawn
+            game.AdvancePhase(); // CoinSpawn → PlacePhase
+        }
+
+        game.ClearDomainEvents();
+        return (game, p1, p2, p1Pieces, p2Pieces, restricted);
+    }
+
+    /// <summary>
+    /// Like <see cref="BuildGameWithRestrictedPieceAtTurn"/> but also places one unrestricted
+    /// piece on the board (so ReplacePiece can be tested) on the current turn.
+    /// </summary>
+    private static (Game game, Guid p1, Guid p2, List<Piece> p1Pieces, List<Piece> p2Pieces, Piece restricted, Piece existing)
+        BuildGameWithExistingPlacedAndRestrictedPiece(int restrictedFromTurn, int currentTurn)
+    {
+        // Seed at currentTurn-1 PlacePhase so we can place the "existing" piece on turn currentTurn-1,
+        // then advance once more so we're back in PlacePhase on currentTurn with that piece on the board.
+        // Edge case: if currentTurn == 1 (no restriction test cares about this), just seed at turn 1 and place.
+
+        var seedTurn = Math.Max(1, currentTurn - 1);
+        var (game, p1, p2, p1Pieces, p2Pieces, restricted) =
+            BuildGameWithRestrictedPieceAtTurn(restrictedFromTurn, seedTurn);
+
+        var existing = p1Pieces[0]; // unrestricted starter
+        game.PlacePiece(p1, existing.Id, new Position(0, 0));
+        game.SkipPlacement(p2);
+        // Now in MovePhase. Advance to next turn's PlacePhase if needed.
+        if (currentTurn > seedTurn)
+        {
+            game.AdvancePhase(); // MovePhase → next-turn CoinSpawn
+            game.AdvancePhase(); // CoinSpawn → PlacePhase
+        }
+
+        game.ClearDomainEvents();
+        return (game, p1, p2, p1Pieces, p2Pieces, restricted, existing);
+    }
+}

--- a/tests/ScrambleCoin.Domain.Tests/TournamentTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/TournamentTests.cs
@@ -6,7 +6,7 @@ namespace ScrambleCoin.Domain.Tests;
 
 /// <summary>
 /// Unit tests for the <see cref="Tournament"/> aggregate (Issue #52).
-/// Covers round-robin scheduling, standings computation, knockout bracket generation,
+/// Covers round-robin scheduling, standing computation, knockout bracket generation,
 /// bye propagation, result recording, and lifecycle transitions.
 /// </summary>
 public class TournamentTests
@@ -165,7 +165,7 @@ public class TournamentTests
         var t = NewTournament(2);
         t.Start();
 
-        Assert.Throws<TournamentInvalidStateException>(() => t.Start());
+        Assert.Throws<TournamentInvalidStateException>(t.Start);
     }
 
     [Fact]
@@ -174,7 +174,7 @@ public class TournamentTests
         // Create a tournament with 0 participants (NewTournament with 0 bots)
         var t = NewTournament(0);
 
-        Assert.Throws<TournamentInvalidStateException>(() => t.Start());
+        Assert.Throws<TournamentInvalidStateException>(t.Start);
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -306,7 +306,7 @@ public class TournamentTests
         t.Start();
         // Do not complete any group matches
 
-        Assert.Throws<TournamentInvalidStateException>(() => t.AdvanceToKnockout());
+        Assert.Throws<TournamentInvalidStateException>(t.AdvanceToKnockout);
     }
 
     [Fact]
@@ -454,7 +454,7 @@ public class TournamentTests
         t.RecordKnockoutResult(t.KnockoutMatches.Single().Id, null, isDraw: true);
         // t is now Completed
 
-        Assert.Throws<TournamentInvalidStateException>(() => t.Cancel());
+        Assert.Throws<TournamentInvalidStateException>(t.Cancel);
     }
 
     [Fact]
@@ -463,7 +463,7 @@ public class TournamentTests
         var t = NewTournament(2);
         t.Cancel();
 
-        Assert.Throws<TournamentInvalidStateException>(() => t.Cancel());
+        Assert.Throws<TournamentInvalidStateException>(t.Cancel);
     }
 
     // ══════════════════════════════════════════════════════════════════════════

--- a/tests/ScrambleCoin.Infrastructure.Tests/BotUnlocksRepositoryTests.cs
+++ b/tests/ScrambleCoin.Infrastructure.Tests/BotUnlocksRepositoryTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Interfaces;
 using ScrambleCoin.Domain.Entities;
 using ScrambleCoin.Infrastructure.Persistence;

--- a/tests/ScrambleCoin.Infrastructure.Tests/Persistence/PieceTurnAvailabilityPersistenceTests.cs
+++ b/tests/ScrambleCoin.Infrastructure.Tests/Persistence/PieceTurnAvailabilityPersistenceTests.cs
@@ -22,7 +22,7 @@ public sealed class PieceTurnAvailabilityPersistenceTests
     /// Builds a started game where player one's lineup contains a mix of restricted
     /// (Elsa: turn 2, Merlin: turn 4) and unrestricted (Mickey, Goofy, Scrooge) pieces.
     /// </summary>
-    private static (Game game, Guid p1, Guid p2) BuildStartedGameWithRestrictedLineup()
+    private static Game BuildStartedGameWithRestrictedLineup()
     {
         var p1 = Guid.NewGuid();
         var p2 = Guid.NewGuid();
@@ -36,14 +36,14 @@ public sealed class PieceTurnAvailabilityPersistenceTests
         game.SetLineup(p1, new Lineup(pieces1));
         game.SetLineup(p2, new Lineup(pieces2));
         game.Start();
-        return (game, p1, p2);
+        return game;
     }
 
     [Fact]
     public async Task SaveThenLoad_RestrictedPiece_PreservesAvailableFromTurn()
     {
         var options = BuildOptions(nameof(SaveThenLoad_RestrictedPiece_PreservesAvailableFromTurn));
-        var (game, _, _) = BuildStartedGameWithRestrictedLineup();
+        var game = BuildStartedGameWithRestrictedLineup();
 
         await using (var writeCtx = new ScrambleCoinDbContext(options))
             await new GameRepository(writeCtx).SaveAsync(game);
@@ -59,7 +59,7 @@ public sealed class PieceTurnAvailabilityPersistenceTests
     public async Task SaveThenLoad_HighRestrictionPiece_PreservesAvailableFromTurn()
     {
         var options = BuildOptions(nameof(SaveThenLoad_HighRestrictionPiece_PreservesAvailableFromTurn));
-        var (game, _, _) = BuildStartedGameWithRestrictedLineup();
+        var game = BuildStartedGameWithRestrictedLineup();
 
         await using (var writeCtx = new ScrambleCoinDbContext(options))
             await new GameRepository(writeCtx).SaveAsync(game);
@@ -75,7 +75,7 @@ public sealed class PieceTurnAvailabilityPersistenceTests
     public async Task SaveThenLoad_UnrestrictedPiece_PreservesNullAvailableFromTurn()
     {
         var options = BuildOptions(nameof(SaveThenLoad_UnrestrictedPiece_PreservesNullAvailableFromTurn));
-        var (game, _, _) = BuildStartedGameWithRestrictedLineup();
+        var game = BuildStartedGameWithRestrictedLineup();
 
         await using (var writeCtx = new ScrambleCoinDbContext(options))
             await new GameRepository(writeCtx).SaveAsync(game);
@@ -96,7 +96,7 @@ public sealed class PieceTurnAvailabilityPersistenceTests
     public async Task Load_LegacyLineupJsonWithoutAvailableFromTurn_DeserialisesAsNull()
     {
         var options = BuildOptions(nameof(Load_LegacyLineupJsonWithoutAvailableFromTurn_DeserialisesAsNull));
-        var (game, _, _) = BuildStartedGameWithRestrictedLineup();
+        var game = BuildStartedGameWithRestrictedLineup();
 
         // Save normally, then strip the AvailableFromTurn property from the stored JSON
         // to simulate a row that was written before the field existed.
@@ -135,8 +135,8 @@ public sealed class PieceTurnAvailabilityPersistenceTests
     private static string StripAvailableFromTurn(string json)
     {
         // Matches: ,"AvailableFromTurn":<number-or-null>   OR   "AvailableFromTurn":<value>,
-        var pattern = "(,\\s*\"AvailableFromTurn\"\\s*:\\s*(?:null|-?\\d+))" +
-                      "|(\"AvailableFromTurn\"\\s*:\\s*(?:null|-?\\d+)\\s*,)";
+        const string pattern = "(,\\s*\"AvailableFromTurn\"\\s*:\\s*(?:null|-?\\d+))" +
+            "|(\"AvailableFromTurn\"\\s*:\\s*(?:null|-?\\d+)\\s*,)";
         return System.Text.RegularExpressions.Regex.Replace(json, pattern, string.Empty);
     }
 }

--- a/tests/ScrambleCoin.Infrastructure.Tests/Persistence/PieceTurnAvailabilityPersistenceTests.cs
+++ b/tests/ScrambleCoin.Infrastructure.Tests/Persistence/PieceTurnAvailabilityPersistenceTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.EntityFrameworkCore;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Factories;
+using ScrambleCoin.Domain.ValueObjects;
+using ScrambleCoin.Infrastructure.Persistence;
+
+namespace ScrambleCoin.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// Persistence round-trip tests for Issue #59 — verifies <see cref="Piece.AvailableFromTurn"/>
+/// survives save+load through <see cref="GameRepository"/>, and that pre-#59 stored JSON
+/// (missing the property) still deserialises without crashing.
+/// </summary>
+public sealed class PieceTurnAvailabilityPersistenceTests
+{
+    private static DbContextOptions<ScrambleCoinDbContext> BuildOptions(string dbName) =>
+        new DbContextOptionsBuilder<ScrambleCoinDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+
+    /// <summary>
+    /// Builds a started game where player one's lineup contains a mix of restricted
+    /// (Elsa: turn 2, Merlin: turn 4) and unrestricted (Mickey, Goofy, Scrooge) pieces.
+    /// </summary>
+    private static (Game game, Guid p1, Guid p2) BuildStartedGameWithRestrictedLineup()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        string[] lineup1 = ["Mickey", "Elsa", "Merlin", "Goofy", "Scrooge"];
+        string[] lineup2 = ["Mickey", "Minnie", "Donald", "Goofy", "Scrooge"];
+
+        var pieces1 = lineup1.Select(n => PieceFactory.Create(n, p1)).ToList();
+        var pieces2 = lineup2.Select(n => PieceFactory.Create(n, p2)).ToList();
+
+        var game = new Game(Guid.NewGuid(), p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(pieces1));
+        game.SetLineup(p2, new Lineup(pieces2));
+        game.Start();
+        return (game, p1, p2);
+    }
+
+    [Fact]
+    public async Task SaveThenLoad_RestrictedPiece_PreservesAvailableFromTurn()
+    {
+        var options = BuildOptions(nameof(SaveThenLoad_RestrictedPiece_PreservesAvailableFromTurn));
+        var (game, _, _) = BuildStartedGameWithRestrictedLineup();
+
+        await using (var writeCtx = new ScrambleCoinDbContext(options))
+            await new GameRepository(writeCtx).SaveAsync(game);
+
+        await using var readCtx = new ScrambleCoinDbContext(options);
+        var loaded = await new GameRepository(readCtx).GetByIdAsync(game.Id);
+
+        var elsa = loaded.LineupPlayerOne!.Pieces.Single(p => p.Name == "Elsa");
+        Assert.Equal(2, elsa.AvailableFromTurn);
+    }
+
+    [Fact]
+    public async Task SaveThenLoad_HighRestrictionPiece_PreservesAvailableFromTurn()
+    {
+        var options = BuildOptions(nameof(SaveThenLoad_HighRestrictionPiece_PreservesAvailableFromTurn));
+        var (game, _, _) = BuildStartedGameWithRestrictedLineup();
+
+        await using (var writeCtx = new ScrambleCoinDbContext(options))
+            await new GameRepository(writeCtx).SaveAsync(game);
+
+        await using var readCtx = new ScrambleCoinDbContext(options);
+        var loaded = await new GameRepository(readCtx).GetByIdAsync(game.Id);
+
+        var merlin = loaded.LineupPlayerOne!.Pieces.Single(p => p.Name == "Merlin");
+        Assert.Equal(4, merlin.AvailableFromTurn);
+    }
+
+    [Fact]
+    public async Task SaveThenLoad_UnrestrictedPiece_PreservesNullAvailableFromTurn()
+    {
+        var options = BuildOptions(nameof(SaveThenLoad_UnrestrictedPiece_PreservesNullAvailableFromTurn));
+        var (game, _, _) = BuildStartedGameWithRestrictedLineup();
+
+        await using (var writeCtx = new ScrambleCoinDbContext(options))
+            await new GameRepository(writeCtx).SaveAsync(game);
+
+        await using var readCtx = new ScrambleCoinDbContext(options);
+        var loaded = await new GameRepository(readCtx).GetByIdAsync(game.Id);
+
+        var mickey = loaded.LineupPlayerOne!.Pieces.Single(p => p.Name == "Mickey");
+        Assert.Null(mickey.AvailableFromTurn);
+    }
+
+    /// <summary>
+    /// Backward-compatibility: a stored lineup JSON that pre-dates Issue #59
+    /// (and therefore lacks the <c>AvailableFromTurn</c> property entirely) must
+    /// deserialise without error and yield <c>null</c> for that property.
+    /// </summary>
+    [Fact]
+    public async Task Load_LegacyLineupJsonWithoutAvailableFromTurn_DeserialisesAsNull()
+    {
+        var options = BuildOptions(nameof(Load_LegacyLineupJsonWithoutAvailableFromTurn_DeserialisesAsNull));
+        var (game, _, _) = BuildStartedGameWithRestrictedLineup();
+
+        // Save normally, then strip the AvailableFromTurn property from the stored JSON
+        // to simulate a row that was written before the field existed.
+        await using (var writeCtx = new ScrambleCoinDbContext(options))
+            await new GameRepository(writeCtx).SaveAsync(game);
+
+        await using (var mutateCtx = new ScrambleCoinDbContext(options))
+        {
+            var record = await mutateCtx.Games.SingleAsync(g => g.Id == game.Id);
+            // Remove every occurrence of `,"AvailableFromTurn":<value>` or `"AvailableFromTurn":<value>,`
+            record.LineupPlayerOneJson = StripAvailableFromTurn(record.LineupPlayerOneJson!);
+            record.LineupPlayerTwoJson = StripAvailableFromTurn(record.LineupPlayerTwoJson!);
+            await mutateCtx.SaveChangesAsync();
+        }
+
+        // Sanity: legacy JSON really lacks the field.
+        await using (var verifyCtx = new ScrambleCoinDbContext(options))
+        {
+            var raw = (await verifyCtx.Games.SingleAsync(g => g.Id == game.Id)).LineupPlayerOneJson!;
+            Assert.DoesNotContain("AvailableFromTurn", raw, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Loading via the repository must not throw, and every piece's
+        // AvailableFromTurn must default to null.
+        await using var readCtx = new ScrambleCoinDbContext(options);
+        var loaded = await new GameRepository(readCtx).GetByIdAsync(game.Id);
+
+        Assert.All(loaded.LineupPlayerOne!.Pieces, p => Assert.Null(p.AvailableFromTurn));
+        Assert.All(loaded.LineupPlayerTwo!.Pieces, p => Assert.Null(p.AvailableFromTurn));
+    }
+
+    /// <summary>
+    /// Strips the <c>AvailableFromTurn</c> JSON property (whatever its value, including null)
+    /// from a serialised lineup payload, handling leading- and trailing-comma cases.
+    /// </summary>
+    private static string StripAvailableFromTurn(string json)
+    {
+        // Matches: ,"AvailableFromTurn":<number-or-null>   OR   "AvailableFromTurn":<value>,
+        var pattern = "(,\\s*\"AvailableFromTurn\"\\s*:\\s*(?:null|-?\\d+))" +
+                      "|(\"AvailableFromTurn\"\\s*:\\s*(?:null|-?\\d+)\\s*,)";
+        return System.Text.RegularExpressions.Regex.Replace(json, pattern, string.Empty);
+    }
+}

--- a/tests/ScrambleCoin.Infrastructure.Tests/QueueServiceTests.cs
+++ b/tests/ScrambleCoin.Infrastructure.Tests/QueueServiceTests.cs
@@ -40,7 +40,7 @@ public class QueueServiceTests
         var sender = Substitute.For<ISender>();
         sender
             .Send(Arg.Any<StartMatchCommand>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo => new StartMatchResult(
+            .Returns(_ => new StartMatchResult(
                 Guid.NewGuid(),
                 Guid.NewGuid(),
                 Guid.NewGuid(),

--- a/tests/ScrambleCoin.Web.Tests/PieceTurnAvailabilityEndpointTests.cs
+++ b/tests/ScrambleCoin.Web.Tests/PieceTurnAvailabilityEndpointTests.cs
@@ -1,0 +1,157 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ScrambleCoin.Application.BotRegistration;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Domain.BotRegistrations;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Factories;
+using ScrambleCoin.Domain.ValueObjects;
+using ScrambleCoin.Infrastructure.Persistence;
+
+namespace ScrambleCoin.Web.Tests;
+
+/// <summary>
+/// API-level tests for Issue #59 — verifies <c>GET /api/games/{id}/state</c> exposes
+/// <c>availableFromTurn</c> per piece in camelCase, with the correct values from the
+/// piece factory (Elsa = 2, Mickey = null, Merlin = 4).
+/// </summary>
+public class PieceTurnAvailabilityEndpointTests : IClassFixture<PieceTurnAvailabilityEndpointTests.TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public PieceTurnAvailabilityEndpointTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public sealed class TestWebApplicationFactory : WebApplicationFactory<Api.ApiMarker>
+    {
+        private readonly string _dbName = $"PieceTurnAvailabilityTestDb_{Guid.NewGuid()}";
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                var descriptorsToRemove = services
+                    .Where(d =>
+                        d.ServiceType == typeof(DbContextOptions<ScrambleCoinDbContext>) ||
+                        d.ServiceType == typeof(DbContextOptions) ||
+                        d.ServiceType == typeof(ScrambleCoinDbContext))
+                    .ToList();
+
+                foreach (var d in descriptorsToRemove)
+                    services.Remove(d);
+
+                var dbName = _dbName;
+                services.AddScoped<ScrambleCoinDbContext>(_ =>
+                {
+                    var opts = new DbContextOptionsBuilder<ScrambleCoinDbContext>()
+                        .UseInMemoryDatabase(dbName)
+                        .Options;
+                    return new ScrambleCoinDbContext(opts);
+                });
+
+                services.Configure<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckServiceOptions>(
+                    opts => opts.Registrations.Clear());
+            });
+
+            builder.UseUrls("http://127.0.0.1:0");
+        }
+    }
+
+    /// <summary>
+    /// Seeds a started game whose player-one lineup mixes restricted and unrestricted
+    /// pieces, plus a bot registration token for player one.
+    /// </summary>
+    private async Task<(Game game, Guid tokenP1)> SeedGameAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var gameRepo = scope.ServiceProvider.GetRequiredService<IGameRepository>();
+        var botRepo = scope.ServiceProvider.GetRequiredService<IBotRegistrationRepository>();
+
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        string[] lineup1 = ["Mickey", "Elsa", "Scar", "Merlin", "Goofy"];
+        string[] lineup2 = ["Mickey", "Minnie", "Donald", "Goofy", "Scrooge"];
+
+        var pieces1 = lineup1.Select(n => PieceFactory.Create(n, p1)).ToList();
+        var pieces2 = lineup2.Select(n => PieceFactory.Create(n, p2)).ToList();
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(pieces1));
+        game.SetLineup(p2, new Lineup(pieces2));
+        game.Start();
+
+        await gameRepo.SaveAsync(game);
+
+        var tokenP1 = Guid.NewGuid();
+        await botRepo.SaveAsync(new BotRegistration(tokenP1, p1, game.Id));
+        await botRepo.SaveAsync(new BotRegistration(Guid.NewGuid(), p2, game.Id));
+
+        return (game, tokenP1);
+    }
+
+    private async Task<JsonElement> FetchStateAsync()
+    {
+        var (game, token) = await SeedGameAsync();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Bot-Token", token.ToString());
+
+        var response = await client.GetAsync($"/api/games/{game.Id}/state");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return json.RootElement.Clone();
+    }
+
+    [Fact]
+    public async Task GetBoardState_EachPiece_ContainsAvailableFromTurnField()
+    {
+        var root = await FetchStateAsync();
+
+        foreach (var piece in root.GetProperty("yourPieces").EnumerateArray())
+        {
+            Assert.True(piece.TryGetProperty("availableFromTurn", out _),
+                "Each piece in 'yourPieces' must include an 'availableFromTurn' field (camelCase).");
+        }
+    }
+
+    [Fact]
+    public async Task GetBoardState_RestrictedPiece_HasCorrectAvailableFromTurn()
+    {
+        var root = await FetchStateAsync();
+
+        var elsa = root.GetProperty("yourPieces").EnumerateArray()
+            .Single(p => p.GetProperty("name").GetString() == "Elsa");
+
+        Assert.Equal(2, elsa.GetProperty("availableFromTurn").GetInt32());
+    }
+
+    [Fact]
+    public async Task GetBoardState_UnrestrictedPiece_HasNullAvailableFromTurn()
+    {
+        var root = await FetchStateAsync();
+
+        var mickey = root.GetProperty("yourPieces").EnumerateArray()
+            .Single(p => p.GetProperty("name").GetString() == "Mickey");
+
+        Assert.Equal(JsonValueKind.Null, mickey.GetProperty("availableFromTurn").ValueKind);
+    }
+
+    [Fact]
+    public async Task GetBoardState_HighRestrictionPiece_HasCorrectAvailableFromTurn()
+    {
+        var root = await FetchStateAsync();
+
+        var merlin = root.GetProperty("yourPieces").EnumerateArray()
+            .Single(p => p.GetProperty("name").GetString() == "Merlin");
+
+        Assert.Equal(4, merlin.GetProperty("availableFromTurn").GetInt32());
+    }
+}

--- a/tests/ScrambleCoin.Web.Tests/PieceTurnAvailabilityEndpointTests.cs
+++ b/tests/ScrambleCoin.Web.Tests/PieceTurnAvailabilityEndpointTests.cs
@@ -103,7 +103,7 @@ public class PieceTurnAvailabilityEndpointTests : IClassFixture<PieceTurnAvailab
         var client = _factory.CreateClient();
         client.DefaultRequestHeaders.Add("X-Bot-Token", token.ToString());
 
-        var response = await client.GetAsync($"/api/games/{game.Id}/state");
+        var response = await client.GetAsync(new Uri($"/api/games/{game.Id}/state", UriKind.Relative));
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());


### PR DESCRIPTION
## Summary
Closes #59.

Adds turn-availability validation for pieces with a Play Condition. A piece may now declare `AvailableFromTurn` (nullable int); attempting to place it before that turn is rejected with a clear `DomainException`. The restriction is enforced in both `Game.PlacePiece` and `Game.ReplacePiece` (against the incoming piece), and `availableFromTurn` is exposed per piece in both the bot-facing `/api/games/{id}/state` response and the spectator board state DTO so bots can plan accordingly.

## Pieces wired up (per SCRAMBLECOIN_OVERVIEW.md)
| Piece | Available from turn |
|---|---|
| Elsa, Remy, Daisy | 2 |
| Mike Wazowski, Scar, Rapunzel | 3 |
| Merlin | 4 |

## Changes
- `src/ScrambleCoin.Domain/Entities/Piece.cs` — new `AvailableFromTurn` (nullable int, ≥1 when set)
- `src/ScrambleCoin.Domain/Entities/Game.TurnPhases.cs` — guards in `PlacePiece` and `ReplacePiece`
- `src/ScrambleCoin.Domain/Factories/PieceFactory.cs` — wired the restricted pieces
- `src/ScrambleCoin.Application/Games/GetBoardState/BoardStateDto.cs` + handler — DTO field
- `src/ScrambleCoin.Application/Games/GetBoardState/GetSpectatorBoardStateQueryHandler.cs` — spectator DTO mapping
- `src/ScrambleCoin.Infrastructure/Persistence/Records/PersistenceDtos.cs` + `GameRepository.cs` — backward-compatible persistence (default null)
- Tests: Domain (18 dedicated + helper updates), Application (4), Infrastructure (4), Web (4)

## Testing
- Domain.Tests: **673 passed**
- Application.Tests: **284 passed**
- Infrastructure.Tests: **136 passed**
- Web.Tests: **273 passed**
- StarterBot.Tests: **37 passed**

All targeted suites green ✅. E2E not run (separate manual step).

## Assumptions (flagged for reviewer)
1. **Mike Wazowski = turn 3** — issue body said 2, but `SCRAMBLECOIN_OVERVIEW.md` says 3. Used overview as authoritative.
2. **Oswald = unrestricted** — issue body assumed turn 2; overview shows no Play Cond. Left unrestricted.
3. **EVE = not wired** — listed in issue with turn 2 but not present in `PieceFactory` yet. Mechanism is in place; will be picked up when EVE is added.
4. **Additive REST change** — `availableFromTurn` appended as nullable to existing `PieceDto`; no version bump.
5. **Persistence is backward-compatible** — existing serialized games deserialize cleanly (missing field → null).

## Review cycles
- Implementation + tests: 1 cycle on `main`, then rebased onto `milestone/event-ready` (event-ready has different phase auto-advance behavior — helper loops were adjusted accordingly).

## Manual testing
Manual test plan posted as a comment on #59. Move the project card to `🧪 Needs Manual Test` and execute before merging to `✅ Done`.

## Wiki
Updated: Pieces, Bot-API, SignalR-Hub, Game-Rules, Home (wiki commit `2c7fe18`).

## Version bump
`minor` (new feature). Not breaking — DTO change is additive.