### PR TITLE
CPU villain opponent — server-controlled AI for solo mode games

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -511,27 +511,15 @@ dotnet_diagnostic.CA1515.severity = none
 # ─────────────────────────────────────────────────────────────────────────────
 # Path-based overrides
 # ─────────────────────────────────────────────────────────────────────────────
+# Migrations: class names and file names follow the FluentMigrator timestamp
+# convention and may contain underscores (e.g. M20240101_AddRegistrationTable).
 
-[tests/**/*.cs]
+[{tests/**/*.cs,src/ScrambleCoin.Infrastructure/Migrations/*.cs}]
 dotnet_diagnostic.IDE1006.severity = none
 dotnet_diagnostic.CA1707.severity = none
 resharper_inconsistent_naming_highlighting = none
 
-# Migrations: class names and file names follow the FluentMigrator timestamp
-# convention and may contain underscores (e.g. M20240101_AddRegistrationTable).
-[src/ScrambleCoin.Infrastructure/Migrations/*.cs]
-dotnet_diagnostic.IDE1006.severity = none
-resharper_inconsistent_naming_highlighting = none
-
-
-[src/ScrambleCoin.Domain/Events/*.cs]
-dotnet_diagnostic.CS8907.severity = none
-resharper_not_accessed_positional_property_global_highlighting = none
-dotnet_diagnostic.IDE0051.severity = none
-csharp_style_unused_value_assignment_preference = discard_variable:none
-
-
-[{src/ScrambleCoin.Application/**/*Dto.cs,src/ScrambleCoin.Infrastructure/Persistence/Records/*Dtos.cs}]
+[{src/ScrambleCoin.Application/**/*Dto.cs,src/ScrambleCoin.Infrastructure/Persistence/Records/*Dtos.cs,src/ScrambleCoin.Domain/Events/*.cs}]
 dotnet_diagnostic.CS8907.severity = none
 resharper_not_accessed_positional_property_global_highlighting = none
 dotnet_diagnostic.IDE0051.severity = none
@@ -554,3 +542,6 @@ resharper_class_never_instantiated_global_highlighting = none
 
 [src/ScrambleCoin.Infrastructure/Persistence/Records/*.cs]
 resharper_entity_framework_model_validation_unlimited_string_length_highlighting = none
+
+[tests/ScrambleCoin.Web.Tests/*Tests.cs]
+resharper_class_never_instantiated_global_highlighting = none

--- a/ScrambleCoin.sln.DotSettings
+++ b/ScrambleCoin.sln.DotSettings
@@ -1,2 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cogsworth/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kristoff/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pumbaa/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/ScrambleCoin.Api/Program.cs
+++ b/src/ScrambleCoin.Api/Program.cs
@@ -61,6 +61,10 @@ builder.Services.AddScoped<IRankingRepository, RankingRepository>();
 builder.Services.AddScoped<ScrambleCoin.Application.Games.Replay.IGameSnapshotRepository,
     GameSnapshotRepository>();
 builder.Services.AddScoped<ICoinSpawnService, CoinSpawnService>();
+builder.Services.AddScoped<ScrambleCoin.Application.Services.Villains.IVillainStrategyFactory,
+    ScrambleCoin.Application.Services.Villains.VillainStrategyFactory>();
+builder.Services.AddScoped<IVillainActionDispatcher, VillainActionDispatcher>();
+builder.Services.AddScoped<IVillainAutomationService, VillainAutomationService>();
 builder.Services.AddScoped<IUnitOfWork>(sp => sp.GetRequiredService<ScrambleCoinDbContext>());
 builder.Services.Configure<QueueOptions>(builder.Configuration.GetSection("Queue"));
 builder.Services.AddSingleton<IQueueService, QueueService>();

--- a/src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommandHandler.cs
@@ -99,9 +99,9 @@ public sealed class MovePieceCommandHandler : IRequestHandler<MovePieceCommand, 
         // No-op for non-solo games (the service early-returns when VillainId is null).
         await _villainAutomationService.EnsureVillainActsIfNeededAsync(request.GameId, cancellationToken);
 
-        var yourScore = game.Scores.TryGetValue(playerId, out var s) ? s : 0;
+        var yourScore = game.Scores.GetValueOrDefault(playerId, 0);
         var opponentId = game.PlayerOne == playerId ? game.PlayerTwo : game.PlayerOne;
-        var opponentScore = game.Scores.TryGetValue(opponentId, out var os) ? os : 0;
+        var opponentScore = game.Scores.GetValueOrDefault(opponentId, 0);
 
         return new MoveResult(
             game.CurrentPhase?.ToString(),

--- a/src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommandHandler.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Interfaces;
 using ScrambleCoin.Application.Notifications;
+using ScrambleCoin.Application.Services;
 using ScrambleCoin.Domain.Enums;
 using ScrambleCoin.Domain.Events;
 using ScrambleCoin.Domain.Exceptions;
@@ -25,17 +26,20 @@ public sealed class MovePieceCommandHandler : IRequestHandler<MovePieceCommand, 
     private readonly IGameRepository _gameRepository;
     private readonly IBotRegistrationRepository _botRegistrationRepository;
     private readonly IPublisher _publisher;
+    private readonly IVillainAutomationService _villainAutomationService;
     private readonly ILogger<MovePieceCommandHandler> _logger;
 
     public MovePieceCommandHandler(
         IGameRepository gameRepository,
         IBotRegistrationRepository botRegistrationRepository,
         IPublisher publisher,
+        IVillainAutomationService villainAutomationService,
         ILogger<MovePieceCommandHandler> logger)
     {
         _gameRepository = gameRepository;
         _botRegistrationRepository = botRegistrationRepository;
         _publisher = publisher;
+        _villainAutomationService = villainAutomationService;
         _logger = logger;
     }
 
@@ -90,6 +94,10 @@ public sealed class MovePieceCommandHandler : IRequestHandler<MovePieceCommand, 
             await _publisher.Publish(
                 new GameFinished(game.Id, gameEndedEvent.WinnerId, gameEndedEvent.IsDraw),
                 cancellationToken);
+
+        // In solo games, let the CPU villain take its move turn once the bot has finished moving.
+        // No-op for non-solo games (the service early-returns when VillainId is null).
+        await _villainAutomationService.EnsureVillainActsIfNeededAsync(request.GameId, cancellationToken);
 
         var yourScore = game.Scores.TryGetValue(playerId, out var s) ? s : 0;
         var opponentId = game.PlayerOne == playerId ? game.PlayerTwo : game.PlayerOne;

--- a/src/ScrambleCoin.Application/Games/SoloMode/CreateSoloGame/CreateSoloGameCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/SoloMode/CreateSoloGame/CreateSoloGameCommandHandler.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
 using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Application.Services.Villains;
 using ScrambleCoin.Domain.Entities;
 using ScrambleCoin.Domain.Enums;
 using ScrambleCoin.Domain.Exceptions;
@@ -62,6 +63,11 @@ public sealed class CreateSoloGameCommandHandler : IRequestHandler<CreateSoloGam
             GameMode = GameMode.Solo,
             VillainId = request.VillainId
         };
+
+        // Register the villain's hardcoded lineup (PlayerTwo) before saving, so that when the bot
+        // joins as PlayerOne the game can start. Falls back to a generic lineup for villains that do
+        // not yet have a bespoke one defined, so solo-game creation never fails.
+        game.SetLineup(villainPlayerId, VillainRegistry.GetLineupForVillainOrDefault(request.VillainId, villainPlayerId));
 
         await _gameRepository.SaveAsync(game, cancellationToken);
 

--- a/src/ScrambleCoin.Application/Games/SubmitPlacement/SubmitPlacementCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/SubmitPlacement/SubmitPlacementCommandHandler.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Interfaces;
 using ScrambleCoin.Application.Notifications;
+using ScrambleCoin.Application.Services;
 using ScrambleCoin.Domain.Events;
 using ScrambleCoin.Domain.Exceptions;
 using ScrambleCoin.Domain.ValueObjects;
@@ -18,17 +19,20 @@ public sealed class SubmitPlacementCommandHandler : IRequestHandler<SubmitPlacem
     private readonly IGameRepository _gameRepository;
     private readonly IBotRegistrationRepository _botRegistrationRepository;
     private readonly IPublisher _publisher;
+    private readonly IVillainAutomationService _villainAutomationService;
     private readonly ILogger<SubmitPlacementCommandHandler> _logger;
 
     public SubmitPlacementCommandHandler(
         IGameRepository gameRepository,
         IBotRegistrationRepository botRegistrationRepository,
         IPublisher publisher,
+        IVillainAutomationService villainAutomationService,
         ILogger<SubmitPlacementCommandHandler> logger)
     {
         _gameRepository = gameRepository;
         _botRegistrationRepository = botRegistrationRepository;
         _publisher = publisher;
+        _villainAutomationService = villainAutomationService;
         _logger = logger;
     }
 
@@ -88,6 +92,10 @@ public sealed class SubmitPlacementCommandHandler : IRequestHandler<SubmitPlacem
                     phaseEvent.PreviousPhase.ToString(),
                     phaseEvent.NewPhase?.ToString()),
                 cancellationToken);
+
+        // In solo games, let the CPU villain react after the bot's placement.
+        // No-op for non-solo games (the service early-returns when VillainId is null).
+        await _villainAutomationService.EnsureVillainActsIfNeededAsync(request.GameId, cancellationToken);
 
         return new PlacementResult(game.CurrentPhase?.ToString(), game.MovePhaseActivePlayer?.ToString());
     }

--- a/src/ScrambleCoin.Application/Services/IVillainStrategy.cs
+++ b/src/ScrambleCoin.Application/Services/IVillainStrategy.cs
@@ -1,0 +1,46 @@
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Services;
+
+/// <summary>
+/// Defines the contract for CPU villain AI strategies.
+/// A villain strategy decides what action a villain should take during their turn,
+/// reading the (read-only) domain state and computing a single legal action.
+/// </summary>
+public interface IVillainStrategy
+{
+    /// <summary>
+    /// Decides the villain's next action given the current game state.
+    /// </summary>
+    /// <param name="game">The current game state (read-only view).</param>
+    /// <param name="villainPlayerId">The player ID controlled by the villain (PlayerTwo in solo games).</param>
+    /// <returns>A <see cref="VillainAction"/> representing the villain's decision.</returns>
+    VillainAction DecideAction(Game game, Guid villainPlayerId);
+}
+
+/// <summary>
+/// Base type for all villain actions. Concrete record types form a closed discriminated union.
+/// </summary>
+public abstract record VillainAction;
+
+/// <summary>
+/// Villain decides to place a piece on the board at the specified position during PlacePhase.
+/// </summary>
+public sealed record PlacementAction(Guid PieceId, Position Position) : VillainAction;
+
+/// <summary>
+/// Villain decides to skip placement (e.g. at the 3-piece cap or no legal placement exists).
+/// </summary>
+public sealed record SkipPlacementAction : VillainAction;
+
+/// <summary>
+/// Villain decides to move one piece, expressed as one or more movement segments.
+/// Each segment is an ordered list of step positions (not including the start position).
+/// </summary>
+public sealed record MovementAction(Guid PieceId, IReadOnlyList<IReadOnlyList<Position>> Segments) : VillainAction;
+
+/// <summary>
+/// Villain decides to skip movement (e.g. no on-board pieces, or no legal move exists).
+/// </summary>
+public sealed record SkipMovementAction : VillainAction;

--- a/src/ScrambleCoin.Application/Services/VillainActionDispatcher.cs
+++ b/src/ScrambleCoin.Application/Services/VillainActionDispatcher.cs
@@ -1,0 +1,76 @@
+using MediatR;
+using ScrambleCoin.Application.Games.VillainActions.VillainMovePiece;
+using ScrambleCoin.Application.Games.VillainActions.VillainPlacePiece;
+using ScrambleCoin.Application.Games.VillainActions.VillainSkipMovement;
+using ScrambleCoin.Application.Games.VillainActions.VillainSkipPlacement;
+using ScrambleCoin.Domain.Exceptions;
+
+namespace ScrambleCoin.Application.Services;
+
+/// <summary>
+/// Translates a decided <see cref="VillainAction"/> into the corresponding villain MediatR command
+/// and dispatches it. Villain actions go through the same command pipeline as bot actions — there
+/// is no special domain path.
+/// </summary>
+public interface IVillainActionDispatcher
+{
+    /// <summary>
+    /// Executes a villain action by dispatching the appropriate MediatR command.
+    /// </summary>
+    Task ExecuteVillainActionAsync(
+        VillainAction action,
+        Guid gameId,
+        Guid villainPlayerId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Default implementation of <see cref="IVillainActionDispatcher"/>.
+/// </summary>
+public sealed class VillainActionDispatcher : IVillainActionDispatcher
+{
+    private readonly IMediator _mediator;
+
+    public VillainActionDispatcher(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    /// <inheritdoc/>
+    public async Task ExecuteVillainActionAsync(
+        VillainAction action,
+        Guid gameId,
+        Guid villainPlayerId,
+        CancellationToken cancellationToken = default)
+    {
+        switch (action)
+        {
+            case PlacementAction placement:
+                await _mediator.Send(
+                    new VillainPlacePieceCommand(gameId, villainPlayerId, placement.PieceId, placement.Position),
+                    cancellationToken);
+                break;
+
+            case SkipPlacementAction:
+                await _mediator.Send(
+                    new VillainSkipPlacementCommand(gameId, villainPlayerId),
+                    cancellationToken);
+                break;
+
+            case MovementAction movement:
+                await _mediator.Send(
+                    new VillainMovePieceCommand(gameId, villainPlayerId, movement.PieceId, movement.Segments),
+                    cancellationToken);
+                break;
+
+            case SkipMovementAction:
+                await _mediator.Send(
+                    new VillainSkipMovementCommand(gameId, villainPlayerId),
+                    cancellationToken);
+                break;
+
+            default:
+                throw new DomainException($"Unknown villain action type: {action.GetType().Name}");
+        }
+    }
+}

--- a/src/ScrambleCoin.Application/Services/VillainAutomationService.cs
+++ b/src/ScrambleCoin.Application/Services/VillainAutomationService.cs
@@ -90,13 +90,51 @@ public sealed class VillainAutomationService : IVillainAutomationService
                 break;
 
             var phaseBeforeAction = game.CurrentPhase;
-            var action = strategy.DecideAction(game, villainPlayerId);
 
-            _logger.LogDebug(
-                "Villain {VillainId} acting in game {GameId} (turn {Turn}, phase {Phase}): {Action}",
-                villainId, gameId, game.CurrentTurnNumber, game.CurrentPhase, action.GetType().Name);
+            try
+            {
+                var action = strategy.DecideAction(game, villainPlayerId);
 
-            await _villainActionDispatcher.ExecuteVillainActionAsync(action, gameId, villainPlayerId, cancellationToken);
+                _logger.LogDebug(
+                    "Villain {VillainId} acting in game {GameId} (turn {Turn}, phase {Phase}): {Action}",
+                    villainId, gameId, game.CurrentTurnNumber, game.CurrentPhase, action.GetType().Name);
+
+                await _villainActionDispatcher.ExecuteVillainActionAsync(action, gameId, villainPlayerId, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                // A villain decision/dispatch failure must never surface to the bot's request (the
+                // bot shares this same call path). Swallowing alone would deadlock the game because
+                // the villain may still be the active mover, so fall back to skipping the villain's
+                // turn to keep control moving.
+                _logger.LogError(
+                    ex,
+                    "Villain action failed in game {GameId} (villain {VillainId}, turn {Turn}); skipping the villain's turn.",
+                    gameId, villainId, game.CurrentTurnNumber);
+
+                var skipAction = phaseBeforeAction == TurnPhase.PlacePhase
+                    ? (VillainAction)new SkipPlacementAction()
+                    : new SkipMovementAction();
+
+                try
+                {
+                    // Dispatches VillainSkipPlacementCommand (PlacePhase) or VillainSkipMovementCommand
+                    // (MovePhase) so the villain advances past its turn instead of deadlocking.
+                    await _villainActionDispatcher.ExecuteVillainActionAsync(
+                        skipAction, gameId, villainPlayerId, cancellationToken);
+                }
+                catch (Exception skipEx)
+                {
+                    // Even the skip failed — stop driving the villain rather than rethrowing into
+                    // the bot's request. The action cap / turn guards prevent an infinite loop, but
+                    // breaking here avoids spinning on a permanently stuck villain.
+                    _logger.LogError(
+                        skipEx,
+                        "Villain skip fallback failed in game {GameId} (villain {VillainId}, turn {Turn}); abandoning villain automation for this invocation.",
+                        gameId, villainId, game.CurrentTurnNumber);
+                    break;
+                }
+            }
 
             if (phaseBeforeAction == TurnPhase.PlacePhase)
                 actedInCurrentPlacePhase = true;

--- a/src/ScrambleCoin.Application/Services/VillainAutomationService.cs
+++ b/src/ScrambleCoin.Application/Services/VillainAutomationService.cs
@@ -1,0 +1,114 @@
+using Microsoft.Extensions.Logging;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Application.Services.Villains;
+using ScrambleCoin.Domain.Enums;
+
+namespace ScrambleCoin.Application.Services;
+
+/// <summary>
+/// Drives the CPU villain's turns in solo games. After a bot acts, the bot-facing command handlers
+/// call <see cref="EnsureVillainActsIfNeededAsync"/>, which repeatedly asks the villain strategy for
+/// an action and dispatches it (via the same MediatR commands bots use) until control returns to the
+/// bot, the phase advances past the villain, or the game ends.
+/// </summary>
+public interface IVillainAutomationService
+{
+    /// <summary>
+    /// Ensures the villain (PlayerTwo) acts whenever it is its turn in the given game.
+    /// No-op for non-solo games (those without a <c>VillainId</c>).
+    /// </summary>
+    Task EnsureVillainActsIfNeededAsync(Guid gameId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Default implementation of <see cref="IVillainAutomationService"/>.
+/// </summary>
+public sealed class VillainAutomationService : IVillainAutomationService
+{
+    /// <summary>Hard upper bound on villain actions per invocation, guarding against any loop bug.</summary>
+    private const int MaxActionsPerInvocation = 32;
+
+    private readonly IGameRepository _gameRepository;
+    private readonly IVillainStrategyFactory _villainStrategyFactory;
+    private readonly IVillainActionDispatcher _villainActionDispatcher;
+    private readonly ILogger<VillainAutomationService> _logger;
+
+    public VillainAutomationService(
+        IGameRepository gameRepository,
+        IVillainStrategyFactory villainStrategyFactory,
+        IVillainActionDispatcher villainActionDispatcher,
+        ILogger<VillainAutomationService> logger)
+    {
+        _gameRepository = gameRepository;
+        _villainStrategyFactory = villainStrategyFactory;
+        _villainActionDispatcher = villainActionDispatcher;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task EnsureVillainActsIfNeededAsync(Guid gameId, CancellationToken cancellationToken = default)
+    {
+        var game = await _gameRepository.GetByIdAsync(gameId, cancellationToken);
+
+        // Only solo games have a CPU villain.
+        if (game.VillainId is null)
+            return;
+
+        var villainId = game.VillainId;
+        if (!VillainRegistry.IsKnown(villainId))
+        {
+            _logger.LogWarning(
+                "Game {GameId} has unknown villain '{VillainId}'; skipping villain automation.",
+                gameId, villainId);
+            return;
+        }
+
+        var strategy = _villainStrategyFactory.CreateStrategy(villainId);
+        var villainPlayerId = game.PlayerTwo;
+
+        // Tracks whether the villain has already acted during the current PlacePhase, to guarantee
+        // exactly one placement/skip per PlacePhase (the domain throws on a double placement).
+        var actedInCurrentPlacePhase = false;
+
+        for (var iteration = 0; iteration < MaxActionsPerInvocation; iteration++)
+        {
+            game = await _gameRepository.GetByIdAsync(gameId, cancellationToken);
+
+            if (game.Status != GameStatus.InProgress)
+                break;
+
+            var isVillainsTurn = game.CurrentPhase switch
+            {
+                // A player may act exactly once per PlacePhase. The villain acts after the bot, so a
+                // single villain action advances the phase; this flag is a belt-and-braces guard.
+                TurnPhase.PlacePhase => !actedInCurrentPlacePhase,
+                TurnPhase.MovePhase => game.MovePhaseActivePlayer == villainPlayerId,
+                _ => false
+            };
+
+            if (!isVillainsTurn)
+                break;
+
+            var phaseBeforeAction = game.CurrentPhase;
+            var action = strategy.DecideAction(game, villainPlayerId);
+
+            _logger.LogDebug(
+                "Villain {VillainId} acting in game {GameId} (turn {Turn}, phase {Phase}): {Action}",
+                villainId, gameId, game.CurrentTurnNumber, game.CurrentPhase, action.GetType().Name);
+
+            await _villainActionDispatcher.ExecuteVillainActionAsync(action, gameId, villainPlayerId, cancellationToken);
+
+            if (phaseBeforeAction == TurnPhase.PlacePhase)
+                actedInCurrentPlacePhase = true;
+        }
+
+        if (game.Status == GameStatus.InProgress &&
+            game.CurrentPhase == TurnPhase.MovePhase &&
+            game.MovePhaseActivePlayer == villainPlayerId)
+        {
+            _logger.LogWarning(
+                "Villain automation for game {GameId} hit the action cap ({Cap}) while still the villain's turn.",
+                gameId, MaxActionsPerInvocation);
+        }
+    }
+}

--- a/src/ScrambleCoin.Application/Services/VillainAutomationService.cs
+++ b/src/ScrambleCoin.Application/Services/VillainAutomationService.cs
@@ -66,7 +66,7 @@ public sealed class VillainAutomationService : IVillainAutomationService
         var strategy = _villainStrategyFactory.CreateStrategy(villainId);
         var villainPlayerId = game.PlayerTwo;
 
-        // Tracks whether the villain has already acted during the current PlacePhase, to guarantee
+        // Tracks whether the villain has already acted during the current PlacePhase to guarantee
         // exactly one placement/skip per PlacePhase (the domain throws on a double placement).
         var actedInCurrentPlacePhase = false;
 
@@ -112,8 +112,8 @@ public sealed class VillainAutomationService : IVillainAutomationService
                     "Villain action failed in game {GameId} (villain {VillainId}, turn {Turn}); skipping the villain's turn.",
                     gameId, villainId, game.CurrentTurnNumber);
 
-                var skipAction = phaseBeforeAction == TurnPhase.PlacePhase
-                    ? (VillainAction)new SkipPlacementAction()
+                VillainAction skipAction = phaseBeforeAction == TurnPhase.PlacePhase
+                    ? new SkipPlacementAction()
                     : new SkipMovementAction();
 
                 try
@@ -140,8 +140,7 @@ public sealed class VillainAutomationService : IVillainAutomationService
                 actedInCurrentPlacePhase = true;
         }
 
-        if (game.Status == GameStatus.InProgress &&
-            game.CurrentPhase == TurnPhase.MovePhase &&
+        if (game is { Status: GameStatus.InProgress, CurrentPhase: TurnPhase.MovePhase } &&
             game.MovePhaseActivePlayer == villainPlayerId)
         {
             _logger.LogWarning(

--- a/src/ScrambleCoin.Application/Services/Villains/GreedyVillainStrategy.cs
+++ b/src/ScrambleCoin.Application/Services/Villains/GreedyVillainStrategy.cs
@@ -1,0 +1,274 @@
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Exceptions;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Services.Villains;
+
+/// <summary>
+/// Base class for greedy villain strategies. Villains use a simple, deterministic greedy algorithm:
+/// <list type="bullet">
+///   <item><description>PlacePhase: place the next unplaced (and currently available) piece on the
+///   free, legal entry tile nearest to the closest coin — or skip when capped/blocked.</description></item>
+///   <item><description>MovePhase: move the next unmoved on-board piece one legal step toward the
+///   nearest coin — or skip movement when no on-board piece can move.</description></item>
+/// </list>
+/// All candidate moves are validated against the same <see cref="Board"/> passability and
+/// movement rules the domain enforces, so every produced action is legal for the domain to apply.
+/// </summary>
+public abstract class GreedyVillainStrategy : IVillainStrategy
+{
+    /// <inheritdoc/>
+    public VillainAction DecideAction(Game game, Guid villainPlayerId) =>
+        game.CurrentPhase switch
+        {
+            TurnPhase.PlacePhase => DecidePlacement(game, villainPlayerId),
+            TurnPhase.MovePhase => DecideMovement(game, villainPlayerId),
+            _ => throw new DomainException(
+                $"Villain cannot act during phase '{game.CurrentPhase?.ToString() ?? "None"}'.")
+        };
+
+    // ── Placement ─────────────────────────────────────────────────────────────
+
+    private static VillainAction DecidePlacement(Game game, Guid villainPlayerId)
+    {
+        var lineup = GetLineup(game, villainPlayerId);
+        if (lineup is null)
+            return new SkipPlacementAction();
+
+        // Respect the 3-piece-on-board cap.
+        if (game.GetPiecesOnBoardCount(villainPlayerId) >= Game.MaxPiecesOnBoard)
+            return new SkipPlacementAction();
+
+        // Pick the first lineup piece that is off-board and currently available this turn.
+        var nextPiece = lineup.Pieces.FirstOrDefault(p =>
+            !p.IsOnBoard &&
+            (p.AvailableFromTurn is null || game.CurrentTurnNumber >= p.AvailableFromTurn));
+
+        if (nextPiece is null)
+            return new SkipPlacementAction();
+
+        var position = FindBestEntryTile(game.Board, nextPiece);
+        return position is null
+            ? new SkipPlacementAction()
+            : new PlacementAction(nextPiece.Id, position);
+    }
+
+    /// <summary>
+    /// Finds the free, legal entry tile for <paramref name="piece"/> that is closest to the
+    /// nearest coin (or, when no coins exist, closest to the board centre).
+    /// </summary>
+    private static Position? FindBestEntryTile(Board board, Piece piece)
+    {
+        var freeEntryTiles = new List<Position>();
+        for (var row = 0; row < Board.Size; row++)
+        for (var col = 0; col < Board.Size; col++)
+        {
+            var position = new Position(row, col);
+            if (!Board.IsValidEntryPoint(position, piece.EntryPointType))
+                continue;
+            if (!board.IsEmpty(position) || board.IsObstacleCovering(position))
+                continue;
+            freeEntryTiles.Add(position);
+        }
+
+        if (freeEntryTiles.Count == 0)
+            return null;
+
+        var reference = NearestCoinPosition(board, freeEntryTiles[0])
+                        ?? new Position(Board.Size / 2, Board.Size / 2);
+
+        return freeEntryTiles
+            .OrderBy(p => ManhattanDistance(p, reference))
+            .ThenBy(p => p.Row)
+            .ThenBy(p => p.Col)
+            .First();
+    }
+
+    // ── Movement ──────────────────────────────────────────────────────────────
+
+    private static VillainAction DecideMovement(Game game, Guid villainPlayerId)
+    {
+        var lineup = GetLineup(game, villainPlayerId);
+        if (lineup is null)
+            return new SkipMovementAction();
+
+        // Only consider on-board pieces that have not already moved this turn.
+        var piece = lineup.Pieces
+            .FirstOrDefault(p => p.IsOnBoard && !game.HasPieceMovedThisTurn(p.Id));
+
+        if (piece is null)
+            return new SkipMovementAction();
+
+        var target = NearestCoinPosition(game.Board, piece.Position!);
+        if (target is null)
+            return new SkipMovementAction();
+
+        var segments = BuildSegmentsToward(game.Board, piece, target);
+        return segments is null
+            ? new SkipMovementAction()
+            : new MovementAction(piece.Id, segments);
+    }
+
+    /// <summary>
+    /// Builds one segment per <see cref="Piece.MovesPerTurn"/>, each a single legal step toward
+    /// <paramref name="target"/>. A segment is left empty only when the piece has no legal move at
+    /// that point (mirroring the domain's "stuck" allowance). Returns <c>null</c> when the piece
+    /// cannot make any move at all (so the caller can skip movement instead).
+    /// </summary>
+    private static IReadOnlyList<IReadOnlyList<Position>>? BuildSegmentsToward(
+        Board board, Piece piece, Position target)
+    {
+        var segments = new List<IReadOnlyList<Position>>();
+        var current = piece.Position!;
+        var producedAnyMove = false;
+
+        for (var segIndex = 0; segIndex < piece.MovesPerTurn; segIndex++)
+        {
+            var segType = piece.GetSegmentMovementType(segIndex);
+            var segMax = piece.GetSegmentMaxDistance(segIndex);
+
+            var step = BuildStep(board, current, segType, segMax, target);
+            if (step is null)
+            {
+                // No legal move from here for this segment type → leave it empty (allowed by domain).
+                segments.Add(Array.Empty<Position>());
+                continue;
+            }
+
+            segments.Add(step);
+            current = step[^1];
+            producedAnyMove = true;
+        }
+
+        return producedAnyMove ? segments : null;
+    }
+
+    /// <summary>
+    /// Builds a single legal step from <paramref name="from"/> toward <paramref name="target"/> for
+    /// the given <paramref name="movementType"/>, or <c>null</c> when no legal move exists.
+    /// </summary>
+    private static IReadOnlyList<Position>? BuildStep(
+        Board board, Position from, MovementType movementType, int maxDistance, Position target) =>
+        movementType switch
+        {
+            MovementType.Jump => BuildJumpStep(board, from, maxDistance, target),
+            MovementType.Charge => BuildChargeStep(board, from, target),
+            _ => BuildSteppedStep(board, from, movementType, target)
+        };
+
+    /// <summary>
+    /// One-tile step for Orthogonal/Diagonal/AnyDirection/Ethereal movement types.
+    /// </summary>
+    private static IReadOnlyList<Position>? BuildSteppedStep(
+        Board board, Position from, MovementType movementType, Position target)
+    {
+        var best = AdjacentDeltas(movementType)
+            .Select(d => (row: from.Row + d.dr, col: from.Col + d.dc))
+            .Where(c => c.row is >= 0 and < Board.Size && c.col is >= 0 and < Board.Size)
+            .Select(c => new Position(c.row, c.col))
+            .Where(to => IsSteppedStepLegal(board, from, to, movementType))
+            .OrderBy(to => ManhattanDistance(to, target))
+            .ThenBy(to => to.Row)
+            .ThenBy(to => to.Col)
+            .FirstOrDefault();
+
+        return best is null ? null : new[] { best };
+    }
+
+    private static bool IsSteppedStepLegal(Board board, Position from, Position to, MovementType movementType)
+    {
+        if (movementType == MovementType.Ethereal)
+        {
+            // Ethereal ignores obstacles en route but must end on a free tile and respect fences.
+            if (board.IsFenceBlocked(from, to))
+                return false;
+            return !board.IsObstacleCovering(to) && board.GetTile(to).AsPiece is null;
+        }
+
+        // Passability covers rocks, lakes, and fences; the destination must also be unoccupied.
+        return board.IsPassable(from, to) && board.GetTile(to).AsPiece is null;
+    }
+
+    /// <summary>
+    /// Jump step: choose an unoccupied destination within range that minimises distance to the target.
+    /// </summary>
+    private static IReadOnlyList<Position>? BuildJumpStep(
+        Board board, Position from, int maxDistance, Position target)
+    {
+        if (maxDistance <= 0)
+            return null;
+
+        Position? best = null;
+        var bestDistance = int.MaxValue;
+
+        for (var row = 0; row < Board.Size; row++)
+        for (var col = 0; col < Board.Size; col++)
+        {
+            var to = new Position(row, col);
+            if (to.Equals(from))
+                continue;
+            if (from.ChebyshevDistance(to) > maxDistance)
+                continue;
+            if (board.IsObstacleCovering(to) || board.GetTile(to).AsPiece is not null)
+                continue;
+
+            var distance = ManhattanDistance(to, target);
+            if (distance >= bestDistance)
+                continue;
+            bestDistance = distance;
+            best = to;
+        }
+
+        return best is null ? null : new[] { best };
+    }
+
+    /// <summary>
+    /// Charge step: choose an adjacent first-step direction (the piece then slides automatically)
+    /// that reduces distance to the target. The segment is the single first-step position.
+    /// </summary>
+    private static IReadOnlyList<Position>? BuildChargeStep(Board board, Position from, Position target)
+    {
+        var best = AdjacentDeltas(MovementType.AnyDirection)
+            .Select(d => (row: from.Row + d.dr, col: from.Col + d.dc))
+            .Where(c => c.row is >= 0 and < Board.Size && c.col is >= 0 and < Board.Size)
+            .Select(c => new Position(c.row, c.col))
+            .Where(to => board.IsPassable(from, to) && board.GetTile(to).AsPiece is null)
+            .OrderBy(to => ManhattanDistance(to, target))
+            .ThenBy(to => to.Row)
+            .ThenBy(to => to.Col)
+            .FirstOrDefault();
+
+        return best is null ? null : new[] { best };
+    }
+
+    // ── Shared helpers ────────────────────────────────────────────────────────
+
+    private static Lineup? GetLineup(Game game, Guid villainPlayerId) =>
+        villainPlayerId == game.PlayerOne ? game.LineupPlayerOne : game.LineupPlayerTwo;
+
+    private static Position? NearestCoinPosition(Board board, Position from)
+    {
+        var coins = board.GetAllCoins();
+        if (coins.Count == 0)
+            return null;
+
+        return coins
+            .Select(tile => tile.Position)
+            .OrderBy(pos => ManhattanDistance(from, pos))
+            .ThenBy(pos => pos.Row)
+            .ThenBy(pos => pos.Col)
+            .First();
+    }
+
+    private static IReadOnlyList<(int dr, int dc)> AdjacentDeltas(MovementType movementType) =>
+        movementType switch
+        {
+            MovementType.Orthogonal => new[] { (-1, 0), (1, 0), (0, -1), (0, 1) },
+            MovementType.Diagonal => new[] { (-1, -1), (-1, 1), (1, -1), (1, 1) },
+            _ => new[] { (-1, 0), (1, 0), (0, -1), (0, 1), (-1, -1), (-1, 1), (1, -1), (1, 1) }
+        };
+
+    private static int ManhattanDistance(Position from, Position to) =>
+        Math.Abs(from.Row - to.Row) + Math.Abs(from.Col - to.Col);
+}

--- a/src/ScrambleCoin.Application/Services/Villains/GreedyVillainStrategy.cs
+++ b/src/ScrambleCoin.Application/Services/Villains/GreedyVillainStrategy.cs
@@ -137,11 +137,73 @@ public abstract class GreedyVillainStrategy : IVillainStrategy
             }
 
             segments.Add(step);
-            current = step[^1];
+            // Advance the cursor exactly as the domain does. For stepped movement
+            // (Orthogonal/Diagonal/AnyDirection/Ethereal) the domain slides a piece one extra
+            // tile whenever a step lands on an ice patch (see Game.ResolveIcePatchSlideDestination),
+            // and the NEXT segment's first step must be adjacent to that POST-slide position.
+            // Mirror that here so multi-segment moves stay legal when ice patches exist.
+            current = AdvanceCursorAfterStep(board, segType, current, step);
             producedAnyMove = true;
         }
 
         return producedAnyMove ? segments : null;
+    }
+
+    /// <summary>
+    /// Computes the post-step cursor position for the next segment, mirroring the domain's
+    /// movement resolution. For stepped movement types the domain applies an ice-patch slide after
+    /// each step (<c>Game.ResolveIcePatchSlideDestination</c>); Jump and Charge first-steps do not
+    /// slide here (Jump never slides; Charge pieces are single-segment in practice).
+    /// </summary>
+    private static Position AdvanceCursorAfterStep(
+        Board board, MovementType movementType, Position from, IReadOnlyList<Position> step)
+    {
+        if (movementType is not (MovementType.Orthogonal or MovementType.Diagonal
+            or MovementType.AnyDirection or MovementType.Ethereal))
+        {
+            // Jump destinations (and other non-stepped steps) are taken as-is.
+            return step[^1];
+        }
+
+        // Replay each step the way ValidateSteppedSegment does, applying the ice-patch slide so the
+        // cursor matches the domain's post-slide segment-end position.
+        var segFrom = from;
+        foreach (var stepTo in step)
+        {
+            var positionAfterStep = stepTo;
+            if (board.HasIcePatch(positionAfterStep))
+                positionAfterStep = ResolveIcePatchSlideDestination(board, positionAfterStep, segFrom);
+            segFrom = positionAfterStep;
+        }
+
+        return segFrom;
+    }
+
+    /// <summary>
+    /// Faithful replica of <c>Game.ResolveIcePatchSlideDestination</c> (with no Stitch fence
+    /// destruction, matching the <c>destroyedFencePositions == null</c> path): the piece slides one
+    /// extra tile in the same direction as the step. The slide is cancelled — leaving the piece on
+    /// the ice tile — when it would leave the board, hit an obstacle, be blocked by a fence, or land
+    /// on another piece.
+    /// </summary>
+    private static Position ResolveIcePatchSlideDestination(
+        Board board, Position currentPosition, Position previousPosition)
+    {
+        var rowDelta = Math.Sign(currentPosition.Row - previousPosition.Row);
+        var colDelta = Math.Sign(currentPosition.Col - previousPosition.Col);
+
+        var slideRow = currentPosition.Row + rowDelta;
+        var slideCol = currentPosition.Col + colDelta;
+        if (slideRow < 0 || slideRow >= Board.Size || slideCol < 0 || slideCol >= Board.Size)
+            return currentPosition;
+
+        var slideTarget = new Position(slideRow, slideCol);
+        if (board.IsObstacleCovering(slideTarget)
+            || board.IsFenceBlocked(currentPosition, slideTarget)
+            || board.GetTile(slideTarget).AsPiece is not null)
+            return currentPosition;
+
+        return slideTarget;
     }
 
     /// <summary>

--- a/src/ScrambleCoin.Application/Services/Villains/GreedyVillainStrategy.cs
+++ b/src/ScrambleCoin.Application/Services/Villains/GreedyVillainStrategy.cs
@@ -24,6 +24,10 @@ public abstract class GreedyVillainStrategy : IVillainStrategy
         {
             TurnPhase.PlacePhase => DecidePlacement(game, villainPlayerId),
             TurnPhase.MovePhase => DecideMovement(game, villainPlayerId),
+            TurnPhase.CoinSpawn => throw new DomainException(
+                $"Villain cannot act during phase '{game.CurrentPhase?.ToString() ?? "None"}'."),
+            null => throw new DomainException(
+                $"Villain cannot act during phase '{game.CurrentPhase?.ToString() ?? "None"}'."),
             _ => throw new DomainException(
                 $"Villain cannot act during phase '{game.CurrentPhase?.ToString() ?? "None"}'.")
         };
@@ -116,7 +120,7 @@ public abstract class GreedyVillainStrategy : IVillainStrategy
     /// that point (mirroring the domain's "stuck" allowance). Returns <c>null</c> when the piece
     /// cannot make any move at all (so the caller can skip movement instead).
     /// </summary>
-    private static IReadOnlyList<IReadOnlyList<Position>>? BuildSegmentsToward(
+    private static List<IReadOnlyList<Position>>? BuildSegmentsToward(
         Board board, Piece piece, Position target)
     {
         var segments = new List<IReadOnlyList<Position>>();
@@ -132,7 +136,7 @@ public abstract class GreedyVillainStrategy : IVillainStrategy
             if (step is null)
             {
                 // No legal move from here for this segment type → leave it empty (allowed by domain).
-                segments.Add(Array.Empty<Position>());
+                segments.Add([]);
                 continue;
             }
 
@@ -210,7 +214,7 @@ public abstract class GreedyVillainStrategy : IVillainStrategy
     /// Builds a single legal step from <paramref name="from"/> toward <paramref name="target"/> for
     /// the given <paramref name="movementType"/>, or <c>null</c> when no legal move exists.
     /// </summary>
-    private static IReadOnlyList<Position>? BuildStep(
+    private static Position[]? BuildStep(
         Board board, Position from, MovementType movementType, int maxDistance, Position target) =>
         movementType switch
         {
@@ -222,7 +226,7 @@ public abstract class GreedyVillainStrategy : IVillainStrategy
     /// <summary>
     /// One-tile step for Orthogonal/Diagonal/AnyDirection/Ethereal movement types.
     /// </summary>
-    private static IReadOnlyList<Position>? BuildSteppedStep(
+    private static Position[]? BuildSteppedStep(
         Board board, Position from, MovementType movementType, Position target)
     {
         var best = AdjacentDeltas(movementType)
@@ -235,27 +239,27 @@ public abstract class GreedyVillainStrategy : IVillainStrategy
             .ThenBy(to => to.Col)
             .FirstOrDefault();
 
-        return best is null ? null : new[] { best };
+        return best is null ? null : [best];
     }
 
     private static bool IsSteppedStepLegal(Board board, Position from, Position to, MovementType movementType)
     {
-        if (movementType == MovementType.Ethereal)
+        if (movementType != MovementType.Ethereal)
         {
-            // Ethereal ignores obstacles en route but must end on a free tile and respect fences.
-            if (board.IsFenceBlocked(from, to))
-                return false;
-            return !board.IsObstacleCovering(to) && board.GetTile(to).AsPiece is null;
+            return board.IsPassable(from, to) && board.GetTile(to).AsPiece is null;
         }
+        // Ethereal ignores obstacles en route but must end on a free tile and respect fences.
+        if (board.IsFenceBlocked(from, to))
+            return false;
+        return !board.IsObstacleCovering(to) && board.GetTile(to).AsPiece is null;
 
         // Passability covers rocks, lakes, and fences; the destination must also be unoccupied.
-        return board.IsPassable(from, to) && board.GetTile(to).AsPiece is null;
     }
 
     /// <summary>
-    /// Jump step: choose an unoccupied destination within range that minimises distance to the target.
+    /// Jump step: choose an unoccupied destination within range that minimizes distance to the target.
     /// </summary>
-    private static IReadOnlyList<Position>? BuildJumpStep(
+    private static Position[]? BuildJumpStep(
         Board board, Position from, int maxDistance, Position target)
     {
         if (maxDistance <= 0)
@@ -282,14 +286,14 @@ public abstract class GreedyVillainStrategy : IVillainStrategy
             best = to;
         }
 
-        return best is null ? null : new[] { best };
+        return best is null ? null : [best];
     }
 
     /// <summary>
     /// Charge step: choose an adjacent first-step direction (the piece then slides automatically)
     /// that reduces distance to the target. The segment is the single first-step position.
     /// </summary>
-    private static IReadOnlyList<Position>? BuildChargeStep(Board board, Position from, Position target)
+    private static Position[]? BuildChargeStep(Board board, Position from, Position target)
     {
         var best = AdjacentDeltas(MovementType.AnyDirection)
             .Select(d => (row: from.Row + d.dr, col: from.Col + d.dc))
@@ -301,7 +305,7 @@ public abstract class GreedyVillainStrategy : IVillainStrategy
             .ThenBy(to => to.Col)
             .FirstOrDefault();
 
-        return best is null ? null : new[] { best };
+        return best is null ? null : [best];
     }
 
     // ── Shared helpers ────────────────────────────────────────────────────────
@@ -323,7 +327,7 @@ public abstract class GreedyVillainStrategy : IVillainStrategy
             .First();
     }
 
-    private static IReadOnlyList<(int dr, int dc)> AdjacentDeltas(MovementType movementType) =>
+    private static (int dr, int dc)[] AdjacentDeltas(MovementType movementType) =>
         movementType switch
         {
             MovementType.Orthogonal => new[] { (-1, 0), (1, 0), (0, -1), (0, 1) },

--- a/src/ScrambleCoin.Application/Services/Villains/IVillainStrategyFactory.cs
+++ b/src/ScrambleCoin.Application/Services/Villains/IVillainStrategyFactory.cs
@@ -1,0 +1,44 @@
+using ScrambleCoin.Application.Services.Villains.Implementations;
+using ScrambleCoin.Domain.Exceptions;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Services.Villains;
+
+/// <summary>
+/// Factory that resolves a villain ID to its AI strategy, display name, and hardcoded lineup.
+/// </summary>
+public interface IVillainStrategyFactory
+{
+    /// <summary>Creates the villain AI strategy for the given villain ID.</summary>
+    IVillainStrategy CreateStrategy(string villainId);
+
+    /// <summary>Gets the display name for the given villain ID.</summary>
+    string GetDisplayName(string villainId);
+
+    /// <summary>Gets the villain's hardcoded 5-piece lineup, owned by <paramref name="playerId"/>.</summary>
+    Lineup GetVillainLineup(string villainId, Guid playerId);
+}
+
+/// <summary>
+/// Default implementation of <see cref="IVillainStrategyFactory"/>.
+/// </summary>
+public sealed class VillainStrategyFactory : IVillainStrategyFactory
+{
+    /// <inheritdoc/>
+    public IVillainStrategy CreateStrategy(string villainId) =>
+        VillainRegistry.Normalize(villainId) switch
+        {
+            VillainRegistry.Elsa.Id => new ElsaStrategy(),
+            VillainRegistry.Ursula.Id => new UrsulaStrategy(),
+            VillainRegistry.Gaston.Id => new GastonStrategy(),
+            _ => throw new DomainException($"Unknown villain ID: {villainId}")
+        };
+
+    /// <inheritdoc/>
+    public string GetDisplayName(string villainId) =>
+        VillainRegistry.GetDisplayName(villainId);
+
+    /// <inheritdoc/>
+    public Lineup GetVillainLineup(string villainId, Guid playerId) =>
+        VillainRegistry.GetLineupForVillain(villainId, playerId);
+}

--- a/src/ScrambleCoin.Application/Services/Villains/Implementations/ElsaStrategy.cs
+++ b/src/ScrambleCoin.Application/Services/Villains/Implementations/ElsaStrategy.cs
@@ -1,0 +1,7 @@
+namespace ScrambleCoin.Application.Services.Villains.Implementations;
+
+/// <summary>
+/// Elsa villain — uses the greedy strategy with her themed lineup
+/// (Mickey, Donald, WALL•E, Merlin, Scrooge).
+/// </summary>
+public sealed class ElsaStrategy : GreedyVillainStrategy;

--- a/src/ScrambleCoin.Application/Services/Villains/Implementations/GastonStrategy.cs
+++ b/src/ScrambleCoin.Application/Services/Villains/Implementations/GastonStrategy.cs
@@ -1,0 +1,7 @@
+namespace ScrambleCoin.Application.Services.Villains.Implementations;
+
+/// <summary>
+/// Gaston villain — uses the greedy strategy with his themed lineup
+/// (Minnie, Goofy, Donald, Scrooge, Mickey).
+/// </summary>
+public sealed class GastonStrategy : GreedyVillainStrategy;

--- a/src/ScrambleCoin.Application/Services/Villains/Implementations/UrsulaStrategy.cs
+++ b/src/ScrambleCoin.Application/Services/Villains/Implementations/UrsulaStrategy.cs
@@ -1,0 +1,7 @@
+namespace ScrambleCoin.Application.Services.Villains.Implementations;
+
+/// <summary>
+/// Ursula villain — uses the greedy strategy with her themed lineup
+/// (Mickey, Donald, Anna, Goofy, Cinderella).
+/// </summary>
+public sealed class UrsulaStrategy : GreedyVillainStrategy;

--- a/src/ScrambleCoin.Application/Services/Villains/VillainRegistry.cs
+++ b/src/ScrambleCoin.Application/Services/Villains/VillainRegistry.cs
@@ -1,0 +1,120 @@
+using ScrambleCoin.Domain.Factories;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Services.Villains;
+
+/// <summary>
+/// Registry of the predefined villain identities and their hardcoded 5-piece lineups.
+/// Villain IDs use the same slug format produced by <see cref="VillainCatalogue.ToId"/>
+/// (e.g. "Elsa" → "elsa"), matching the <c>VillainId</c> stored on solo games.
+/// </summary>
+public static class VillainRegistry
+{
+    /// <summary>Elsa villain with her themed lineup.</summary>
+    public static class Elsa
+    {
+        public const string Id = "elsa";
+        public const string DisplayName = "Elsa";
+
+        public static Lineup GetLineup(Guid playerId) =>
+            new([
+                PieceFactory.Create("Mickey", playerId),
+                PieceFactory.Create("Donald", playerId),
+                PieceFactory.Create("WALL•E", playerId),
+                PieceFactory.Create("Merlin", playerId),
+                PieceFactory.Create("Scrooge", playerId)
+            ]);
+    }
+
+    /// <summary>Ursula villain with her themed lineup.</summary>
+    public static class Ursula
+    {
+        public const string Id = "ursula";
+        public const string DisplayName = "Ursula";
+
+        public static Lineup GetLineup(Guid playerId) =>
+            new([
+                PieceFactory.Create("Mickey", playerId),
+                PieceFactory.Create("Donald", playerId),
+                PieceFactory.Create("Anna", playerId),
+                PieceFactory.Create("Goofy", playerId),
+                PieceFactory.Create("Cinderella", playerId)
+            ]);
+    }
+
+    /// <summary>Gaston villain with his themed lineup.</summary>
+    public static class Gaston
+    {
+        public const string Id = "gaston";
+        public const string DisplayName = "Gaston";
+
+        public static Lineup GetLineup(Guid playerId) =>
+            new([
+                PieceFactory.Create("Minnie", playerId),
+                PieceFactory.Create("Goofy", playerId),
+                PieceFactory.Create("Donald", playerId),
+                PieceFactory.Create("Scrooge", playerId),
+                PieceFactory.Create("Mickey", playerId)
+            ]);
+    }
+
+    /// <summary>
+    /// Generic fallback lineup used for villains that do not yet have a bespoke lineup defined.
+    /// Ensures any solo game can still be created and started; such villains simply use this lineup
+    /// (and, lacking a bespoke strategy, are driven by the default greedy behaviour or remain idle).
+    /// </summary>
+    public static Lineup GetDefaultLineup(Guid playerId) =>
+        new([
+            PieceFactory.Create("Mickey", playerId),
+            PieceFactory.Create("Minnie", playerId),
+            PieceFactory.Create("Donald", playerId),
+            PieceFactory.Create("Goofy", playerId),
+            PieceFactory.Create("Scrooge", playerId)
+        ]);
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="villainId"/> matches one of the registered villains.
+    /// </summary>
+    public static bool IsKnown(string villainId) => Normalize(villainId) is Elsa.Id or Ursula.Id or Gaston.Id;
+
+    /// <summary>
+    /// Gets the bespoke lineup for a known villain, or the <see cref="GetDefaultLineup"/> otherwise.
+    /// Never throws, so solo-game creation works for every villain in the tree.
+    /// </summary>
+    public static Lineup GetLineupForVillainOrDefault(string villainId, Guid playerId) =>
+        IsKnown(villainId)
+            ? GetLineupForVillain(villainId, playerId)
+            : GetDefaultLineup(playerId);
+
+    /// <summary>
+    /// Gets the hardcoded lineup for a villain by ID, or throws if the villain is not recognised.
+    /// Tolerant of the actual slug format used by created solo games (case/spacing/diacritics).
+    /// </summary>
+    public static Lineup GetLineupForVillain(string villainId, Guid playerId) =>
+        Normalize(villainId) switch
+        {
+            Elsa.Id => Elsa.GetLineup(playerId),
+            Ursula.Id => Ursula.GetLineup(playerId),
+            Gaston.Id => Gaston.GetLineup(playerId),
+            _ => throw new ArgumentException($"Unknown villain ID: {villainId}", nameof(villainId))
+        };
+
+    /// <summary>
+    /// Gets the display name for a villain by ID, or throws if the villain is not recognised.
+    /// </summary>
+    public static string GetDisplayName(string villainId) =>
+        Normalize(villainId) switch
+        {
+            Elsa.Id => Elsa.DisplayName,
+            Ursula.Id => Ursula.DisplayName,
+            Gaston.Id => Gaston.DisplayName,
+            _ => throw new ArgumentException($"Unknown villain ID: {villainId}", nameof(villainId))
+        };
+
+    /// <summary>
+    /// Normalises an arbitrary villain identifier to the canonical slug form
+    /// (e.g. "Elsa", "ELSA", "elsa" all map to "elsa").
+    /// </summary>
+    public static string Normalize(string villainId) =>
+        VillainCatalogue.ToId((villainId ?? string.Empty).Trim());
+}

--- a/src/ScrambleCoin.Application/Services/Villains/VillainRegistry.cs
+++ b/src/ScrambleCoin.Application/Services/Villains/VillainRegistry.cs
@@ -115,6 +115,6 @@ public static class VillainRegistry
     /// Normalises an arbitrary villain identifier to the canonical slug form
     /// (e.g. "Elsa", "ELSA", "elsa" all map to "elsa").
     /// </summary>
-    public static string Normalize(string villainId) =>
+    public static string Normalize(string? villainId) =>
         VillainCatalogue.ToId((villainId ?? string.Empty).Trim());
 }

--- a/src/ScrambleCoin.Domain/Entities/Game.Movement.cs
+++ b/src/ScrambleCoin.Domain/Entities/Game.Movement.cs
@@ -12,6 +12,13 @@ namespace ScrambleCoin.Domain.Entities;
 public partial class Game
 {
     /// <summary>
+    /// Returns <c>true</c> when <paramref name="pieceId"/> has already been moved (or skipped)
+    /// during the current MovePhase. Read-only query used by CPU/automation callers to decide
+    /// which on-board piece to move next without attempting a disallowed second move.
+    /// </summary>
+    public bool HasPieceMovedThisTurn(Guid pieceId) => _movedPieceIds.Contains(pieceId);
+
+    /// <summary>
     /// Moves a single on-board piece during MovePhase, applying direction validation,
     /// obstacle/fence blocking, and coin collection along the path.
     /// Auto-advances to the next turn (or ends the game) once all on-board pieces

--- a/src/ScrambleCoin.Web/Program.cs
+++ b/src/ScrambleCoin.Web/Program.cs
@@ -85,6 +85,10 @@ try
     // ── Application Services ───────────────────────────────────────────────────
     builder.Services.AddScoped<ICoinSpawnService,
         CoinSpawnService>();
+    builder.Services.AddScoped<ScrambleCoin.Application.Services.Villains.IVillainStrategyFactory,
+        ScrambleCoin.Application.Services.Villains.VillainStrategyFactory>();
+    builder.Services.AddScoped<IVillainActionDispatcher, VillainActionDispatcher>();
+    builder.Services.AddScoped<IVillainAutomationService, VillainAutomationService>();
     builder.Services.AddSingleton<Random>();
     
     // ── SignalR Broadcaster ───────────────────────────────────────────────────

--- a/tests/ScrambleCoin.Application.Tests/CreateSoloGameCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/CreateSoloGameCommandHandlerTests.cs
@@ -348,6 +348,8 @@ public class CreateSoloGameCommandHandlerTests
         Assert.Equal("stitch", result.VillainId);
     }
 
+    private static readonly string[] expected = ["Mickey", "Donald", "WALL•E", "Merlin", "Scrooge"];
+
     [Fact]
     public async Task Handle_RegistersVillainLineupForPlayerTwo()
     {
@@ -397,7 +399,7 @@ public class CreateSoloGameCommandHandlerTests
         Assert.NotNull(capturedGame);
         Assert.NotNull(capturedGame.LineupPlayerTwo);
         Assert.Equal(
-            new[] { "Mickey", "Donald", "WALL•E", "Merlin", "Scrooge" },
+            expected,
             capturedGame.LineupPlayerTwo!.Pieces.Select(p => p.Name).ToList());
         Assert.All(capturedGame.LineupPlayerTwo.Pieces,
             p => Assert.Equal(capturedGame.PlayerTwo, p.PlayerId));

--- a/tests/ScrambleCoin.Application.Tests/CreateSoloGameCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/CreateSoloGameCommandHandlerTests.cs
@@ -349,6 +349,101 @@ public class CreateSoloGameCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_RegistersVillainLineupForPlayerTwo()
+    {
+        // Arrange: Elsa is a registry villain with a bespoke lineup; unlock her via a defeated parent.
+        var botId = Guid.NewGuid();
+        Game? capturedGame = null;
+
+        var gameRepo = Substitute.For<IGameRepository>();
+        await gameRepo.SaveAsync(Arg.Do<Game>(g => capturedGame = g), Arg.Any<CancellationToken>());
+
+        var villainRepo = Substitute.For<IVillainTreeRepository>();
+        var unlocksRepo = Substitute.For<IBotUnlocksRepository>();
+
+        var elsaNode = new VillainTreeNode
+        {
+            Id = Guid.NewGuid(),
+            VillainId = "elsa",
+            VillainName = "Elsa",
+            ParentLinks = [new VillainNodeParent { ChildVillainId = "elsa", ParentVillainId = "stitch" }],
+            UnlockedPieceId = "Merlin",
+            DisplayOrder = 3,
+            CreatedAtUtc = DateTime.UtcNow
+        };
+
+        villainRepo.GetNodeByVillainIdAsync("elsa", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<VillainTreeNode?>(elsaNode));
+        unlocksRepo.GetDefeatedVillainsAsync(botId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new[]
+            {
+                new BotUnlock
+                {
+                    Id = Guid.NewGuid(),
+                    BotId = botId,
+                    VillainId = "stitch",
+                    UnlockedPieceId = null,
+                    DefeatedAtUtc = DateTime.UtcNow
+                }
+            }.AsEnumerable()));
+
+        var handler = BuildHandler(gameRepo, villainRepo, unlocksRepo);
+        var command = new CreateSoloGameCommand(botId, "elsa");
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert: PlayerTwo's lineup is registered with Elsa's confirmed pieces, owned by the villain.
+        Assert.NotNull(capturedGame);
+        Assert.NotNull(capturedGame.LineupPlayerTwo);
+        Assert.Equal(
+            new[] { "Mickey", "Donald", "WALL•E", "Merlin", "Scrooge" },
+            capturedGame.LineupPlayerTwo!.Pieces.Select(p => p.Name).ToList());
+        Assert.All(capturedGame.LineupPlayerTwo.Pieces,
+            p => Assert.Equal(capturedGame.PlayerTwo, p.PlayerId));
+    }
+
+    [Fact]
+    public async Task Handle_UnknownRegistryVillain_RegistersDefaultLineup()
+    {
+        // Arrange: "stitch" exists in the tree but has no bespoke registry lineup → default lineup.
+        var botId = Guid.NewGuid();
+        Game? capturedGame = null;
+
+        var gameRepo = Substitute.For<IGameRepository>();
+        await gameRepo.SaveAsync(Arg.Do<Game>(g => capturedGame = g), Arg.Any<CancellationToken>());
+
+        var villainRepo = Substitute.For<IVillainTreeRepository>();
+        var unlocksRepo = Substitute.For<IBotUnlocksRepository>();
+
+        var stitchNode = new VillainTreeNode
+        {
+            Id = Guid.NewGuid(),
+            VillainId = "stitch",
+            VillainName = "Stitch",
+            UnlockedPieceId = null,
+            DisplayOrder = 1,
+            CreatedAtUtc = DateTime.UtcNow
+        };
+
+        villainRepo.GetNodeByVillainIdAsync("stitch", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<VillainTreeNode?>(stitchNode));
+        unlocksRepo.GetDefeatedVillainsAsync(botId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Enumerable.Empty<BotUnlock>()));
+
+        var handler = BuildHandler(gameRepo, villainRepo, unlocksRepo);
+        var command = new CreateSoloGameCommand(botId, "stitch");
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert: a full 5-piece lineup is still registered so the game can start.
+        Assert.NotNull(capturedGame);
+        Assert.NotNull(capturedGame.LineupPlayerTwo);
+        Assert.Equal(5, capturedGame.LineupPlayerTwo!.Pieces.Count);
+    }
+
+    [Fact]
     public async Task Handle_SavesGameToRepository()
     {
         // Arrange

--- a/tests/ScrambleCoin.Application.Tests/EtherealMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/EtherealMovementIntegrationTests.cs
@@ -94,6 +94,7 @@ public class EtherealMovementIntegrationTests
         => new(gameRepo,
             botRepo,
             publisher ?? Substitute.For<IPublisher>(),
+            Substitute.For<ScrambleCoin.Application.Services.IVillainAutomationService>(),
             Substitute.For<ILogger<MovePieceCommandHandler>>());
 
     /// <summary>

--- a/tests/ScrambleCoin.Application.Tests/EtherealMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/EtherealMovementIntegrationTests.cs
@@ -94,7 +94,7 @@ public class EtherealMovementIntegrationTests
         => new(gameRepo,
             botRepo,
             publisher ?? Substitute.For<IPublisher>(),
-            Substitute.For<ScrambleCoin.Application.Services.IVillainAutomationService>(),
+            Substitute.For<Services.IVillainAutomationService>(),
             Substitute.For<ILogger<MovePieceCommandHandler>>());
 
     /// <summary>

--- a/tests/ScrambleCoin.Application.Tests/GreedyVillainStrategyTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/GreedyVillainStrategyTests.cs
@@ -1,0 +1,191 @@
+using ScrambleCoin.Application.Services;
+using ScrambleCoin.Application.Services.Villains;
+using ScrambleCoin.Application.Services.Villains.Implementations;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Obstacles;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Tests;
+
+/// <summary>
+/// Integration-style unit tests for <see cref="GreedyVillainStrategy"/> (Issue #41).
+/// The strategy is exercised against a real <see cref="Game"/>/<see cref="Board"/> so that every
+/// action it produces is verified to be legal for the domain to apply. Covers the four acceptance
+/// criteria: placing a piece, skipping placement at the 3-piece cap, moving toward the nearest coin,
+/// and skipping movement when no legal move exists.
+/// </summary>
+public class GreedyVillainStrategyTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a solo-style game (bot = PlayerOne, villain = PlayerTwo) using the Elsa lineup for the
+    /// villain and the default lineup for the bot, then advances it to <see cref="TurnPhase.CoinSpawn"/>
+    /// on turn 1. Any supplied coins are spawned before the caller advances further.
+    /// </summary>
+    private static (Game game, Guid bot, Guid villain, Lineup villainLineup) NewGameAtCoinSpawn(
+        IReadOnlyList<Rock>? rocks = null,
+        IEnumerable<(Position Position, CoinType CoinType)>? coins = null)
+    {
+        var bot = Guid.NewGuid();
+        var villain = Guid.NewGuid();
+
+        var board = new Board();
+        if (rocks is not null)
+            foreach (var rock in rocks)
+                board.AddRock(rock);
+
+        var game = new Game(Guid.NewGuid(), bot, villain, board)
+        {
+            GameMode = GameMode.Solo,
+            VillainId = VillainRegistry.Elsa.Id
+        };
+
+        var villainLineup = VillainRegistry.Elsa.GetLineup(villain);
+        game.SetLineup(bot, VillainRegistry.GetDefaultLineup(bot));
+        game.SetLineup(villain, villainLineup);
+
+        game.Start(); // → CoinSpawn, turn 1
+
+        if (coins is not null)
+            game.SpawnCoins(coins);
+
+        return (game, bot, villain, villainLineup);
+    }
+
+    private static int ManhattanDistance(Position a, Position b) =>
+        Math.Abs(a.Row - b.Row) + Math.Abs(a.Col - b.Col);
+
+    // ── 1. Placement ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DecideAction_InPlacePhase_ReturnsPlacementOnLegalEntryTileForLineupPiece()
+    {
+        // Arrange: game in PlacePhase, villain has acted nothing yet.
+        var (game, _, villain, villainLineup) = NewGameAtCoinSpawn(
+            coins: [(new Position(3, 3), CoinType.Silver)]);
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        var strategy = new ElsaStrategy();
+
+        // Act
+        var action = strategy.DecideAction(game, villain);
+
+        // Assert: a real lineup piece is placed on a legal, empty entry tile.
+        var placement = Assert.IsType<PlacementAction>(action);
+        var piece = Assert.Single(villainLineup.Pieces, p => p.Id == placement.PieceId);
+        Assert.True(
+            Board.IsValidEntryPoint(placement.Position, piece.EntryPointType),
+            $"Position {placement.Position} must be a legal entry point for {piece.EntryPointType}.");
+        Assert.True(game.Board.IsEmpty(placement.Position));
+    }
+
+    // ── 2. Skip placement at the 3-piece cap ────────────────────────────────────
+
+    [Fact]
+    public void DecideAction_InPlacePhaseAtThreePieceCap_ReturnsSkipPlacement()
+    {
+        // Arrange: drive three turns, letting the villain place one piece per PlacePhase using its
+        // own (domain-legal) decisions, until it holds the maximum of three pieces on the board.
+        var (game, bot, villain, _) = NewGameAtCoinSpawn();
+        var strategy = new ElsaStrategy();
+
+        for (var turn = 0; turn < Game.MaxPiecesOnBoard; turn++)
+        {
+            game.AdvancePhase(); // CoinSpawn → PlacePhase
+            var placement = Assert.IsType<PlacementAction>(strategy.DecideAction(game, villain));
+            game.PlacePiece(villain, placement.PieceId, placement.Position);
+            game.SkipPlacement(bot); // both acted → MovePhase (bot has 0 pieces, villain becomes active)
+            game.SkipMovement(villain); // advance to the next turn's CoinSpawn
+        }
+
+        // Now in turn 4's CoinSpawn with three villain pieces on the board.
+        Assert.Equal(Game.MaxPiecesOnBoard, game.GetPiecesOnBoardCount(villain));
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+
+        // Act
+        var action = strategy.DecideAction(game, villain);
+
+        // Assert
+        Assert.IsType<SkipPlacementAction>(action);
+    }
+
+    // ── 3. Move toward the nearest coin ─────────────────────────────────────────
+
+    [Fact]
+    public void DecideAction_InMovePhase_MovesPieceTowardNearestCoin()
+    {
+        // Arrange: Mickey (orthogonal) at (0,0); the only coin is at (0,5).
+        var coin = new Position(0, 5);
+        var (game, bot, villain, villainLineup) = NewGameAtCoinSpawn(
+            coins: [(coin, CoinType.Silver)]);
+        var mickey = villainLineup.Pieces[0]; // Mickey is first in Elsa's lineup
+        var start = new Position(0, 0);
+
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.PlacePiece(villain, mickey.Id, start);
+        game.SkipPlacement(bot); // → MovePhase (bot has 0 pieces; villain becomes the active mover)
+
+        var strategy = new ElsaStrategy();
+
+        // Act
+        var action = strategy.DecideAction(game, villain);
+
+        // Assert: the chosen step strictly reduces the distance to the nearest coin.
+        var movement = Assert.IsType<MovementAction>(action);
+        Assert.Equal(mickey.Id, movement.PieceId);
+        var destination = movement.Segments.SelectMany(s => s).Last();
+        Assert.True(
+            ManhattanDistance(destination, coin) < ManhattanDistance(start, coin),
+            $"Destination {destination} (dist {ManhattanDistance(destination, coin)}) must be closer " +
+            $"to coin {coin} than start {start} (dist {ManhattanDistance(start, coin)}).");
+    }
+
+    // ── 4. Skip movement when no legal move exists ─────────────────────────────
+
+    [Fact]
+    public void DecideAction_InMovePhaseWithFullyBlockedPiece_ReturnsSkipMovement()
+    {
+        // Arrange: Mickey (orthogonal) cornered at (0,0); both in-bounds neighbours are rocked,
+        // so no legal step exists even though a coin is present at (7,7).
+        var rocks = new[] { new Rock(new Position(0, 1)), new Rock(new Position(1, 0)) };
+        var (game, bot, villain, villainLineup) = NewGameAtCoinSpawn(
+            rocks: rocks,
+            coins: [(new Position(7, 7), CoinType.Silver)]);
+        var mickey = villainLineup.Pieces[0];
+
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.PlacePiece(villain, mickey.Id, new Position(0, 0));
+        game.SkipPlacement(bot); // → MovePhase, villain active
+
+        var strategy = new ElsaStrategy();
+
+        // Act
+        var action = strategy.DecideAction(game, villain);
+
+        // Assert
+        Assert.IsType<SkipMovementAction>(action);
+    }
+
+    // ── Extra: no coins on board → skip movement ────────────────────────────────
+
+    [Fact]
+    public void DecideAction_InMovePhaseWithNoCoins_ReturnsSkipMovement()
+    {
+        // Arrange: Mickey on board but no coins exist anywhere.
+        var (game, bot, villain, villainLineup) = NewGameAtCoinSpawn();
+        var mickey = villainLineup.Pieces[0];
+
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.PlacePiece(villain, mickey.Id, new Position(0, 0));
+        game.SkipPlacement(bot); // → MovePhase, villain active
+
+        var strategy = new ElsaStrategy();
+
+        // Act
+        var action = strategy.DecideAction(game, villain);
+
+        // Assert
+        Assert.IsType<SkipMovementAction>(action);
+    }
+}

--- a/tests/ScrambleCoin.Application.Tests/GreedyVillainStrategyTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/GreedyVillainStrategyTests.cs
@@ -3,6 +3,7 @@ using ScrambleCoin.Application.Services.Villains;
 using ScrambleCoin.Application.Services.Villains.Implementations;
 using ScrambleCoin.Domain.Entities;
 using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.Factories;
 using ScrambleCoin.Domain.Obstacles;
 using ScrambleCoin.Domain.ValueObjects;
 
@@ -56,6 +57,49 @@ public class GreedyVillainStrategyTests
 
     private static int ManhattanDistance(Position a, Position b) =>
         Math.Abs(a.Row - b.Row) + Math.Abs(a.Col - b.Col);
+
+    /// <summary>
+    /// Builds a solo game (bot = PlayerOne, villain = PlayerTwo) where the villain owns the piece
+    /// produced by <paramref name="villainPieceFactory"/> (placed first in a 5-piece lineup padded with
+    /// orthogonal border fillers), spawns the given coins, places only that villain piece on
+    /// <paramref name="villainStart"/>, and drives the game into the villain's
+    /// <see cref="TurnPhase.MovePhase"/>. The bot places nothing, so the villain becomes the active mover.
+    /// Returns the live <see cref="Game"/>, the player ids, and the placed villain piece.
+    /// </summary>
+    private static (Game game, Guid bot, Guid villain, Piece villainPiece) NewGameInVillainMovePhase(
+        Func<Guid, Piece> villainPieceFactory,
+        Position villainStart,
+        IEnumerable<(Position Position, CoinType CoinType)> coins)
+    {
+        var bot = Guid.NewGuid();
+        var villain = Guid.NewGuid();
+        var board = new Board();
+
+        var villainPiece = villainPieceFactory(villain);
+        var fillers = Enumerable.Range(0, Lineup.RequiredPieceCount - 1)
+            .Select(i => new Piece(
+                Guid.NewGuid(), $"VillainFill{i}", villain,
+                EntryPointType.Borders, MovementType.Orthogonal, 1, 1))
+            .ToList();
+        var villainLineup = new Lineup(new[] { villainPiece }.Concat(fillers));
+
+        var game = new Game(Guid.NewGuid(), bot, villain, board)
+        {
+            GameMode = GameMode.Solo,
+            VillainId = VillainRegistry.Elsa.Id
+        };
+        game.SetLineup(bot, VillainRegistry.GetDefaultLineup(bot));
+        game.SetLineup(villain, villainLineup);
+
+        game.Start(); // → CoinSpawn, turn 1
+        game.SpawnCoins(coins);
+
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.PlacePiece(villain, villainPiece.Id, villainStart);
+        game.SkipPlacement(bot); // → MovePhase (bot has 0 pieces; villain becomes the active mover)
+
+        return (game, bot, villain, villainPiece);
+    }
 
     // ── 1. Placement ──────────────────────────────────────────────────────────
 
@@ -139,9 +183,58 @@ public class GreedyVillainStrategyTests
             ManhattanDistance(destination, coin) < ManhattanDistance(start, coin),
             $"Destination {destination} (dist {ManhattanDistance(destination, coin)}) must be closer " +
             $"to coin {coin} than start {start} (dist {ManhattanDistance(start, coin)}).");
+
+        // Round-trip through the real domain engine: the produced single-segment move must be legal to
+        // apply, and the piece must actually land on the destination tile the strategy reported.
+        var applyMove = () => game.MovePiece(villain, movement.PieceId, movement.Segments);
+        var exception = Record.Exception(applyMove);
+        Assert.Null(exception);
+        Assert.Equal(destination, mickey.Position);
     }
 
-    // ── 4. Skip movement when no legal move exists ─────────────────────────────
+    // ── 3b. Multi-segment move stays domain-legal across an ice-patch slide ──────
+
+    [Fact]
+    public void DecideAction_InMovePhaseWithMultiSegmentPieceOverIcePatch_ProducesDomainLegalSlideMove()
+    {
+        // Arrange: Anna (3× Orthogonal, MovesPerTurn 3) starts in the corner at (0,0); the only coin is
+        // far to the east at (0,7). An ice patch sits at (0,1) — the very tile Anna's first step toward
+        // the coin lands on. The domain slides the piece one extra tile (→ (0,2)) after that step, so the
+        // strategy MUST start its second segment from the post-slide tile. If it instead advanced the
+        // cursor naively to (0,1), the second segment would target (0,2) — the tile the piece already
+        // occupies after the slide — and the domain would reject the multi-segment move.
+        var coin = new Position(0, 7);
+        var icePatch = new Position(0, 1);
+        var start = new Position(0, 0);
+
+        var (game, _, villain, anna) = NewGameInVillainMovePhase(
+            owner => PieceFactory.Create("Anna", owner),
+            start,
+            [(coin, CoinType.Silver)]);
+
+        game.Board.PlaceIcePatch(icePatch);
+
+        var strategy = new ElsaStrategy();
+
+        // Act
+        var action = strategy.DecideAction(game, villain);
+
+        // Assert: a multi-segment movement is produced whose first step lands on the ice patch.
+        var movement = Assert.IsType<MovementAction>(action);
+        Assert.Equal(anna.Id, movement.PieceId);
+        Assert.Equal(icePatch, movement.Segments[0][^1]);
+
+        // The whole point: applying the strategy's move to the real domain must NOT throw, proving the
+        // ice-slide simulation kept every inter-segment cursor aligned with the domain's resolution.
+        var applyMove = () => game.MovePiece(villain, movement.PieceId, movement.Segments);
+        var exception = Record.Exception(applyMove);
+        Assert.Null(exception);
+
+        // After: step 1 (0,0)→(0,1) slides to (0,2); step 2 → (0,3); step 3 → (0,4).
+        Assert.Equal(new Position(0, 4), anna.Position);
+    }
+
+
 
     [Fact]
     public void DecideAction_InMovePhaseWithFullyBlockedPiece_ReturnsSkipMovement()

--- a/tests/ScrambleCoin.Application.Tests/GreedyVillainStrategyTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/GreedyVillainStrategyTests.cs
@@ -66,7 +66,7 @@ public class GreedyVillainStrategyTests
     /// <see cref="TurnPhase.MovePhase"/>. The bot places nothing, so the villain becomes the active mover.
     /// Returns the live <see cref="Game"/>, the player ids, and the placed villain piece.
     /// </summary>
-    private static (Game game, Guid bot, Guid villain, Piece villainPiece) NewGameInVillainMovePhase(
+    private static (Game game, Guid villain, Piece villainPiece) NewGameInVillainMovePhase(
         Func<Guid, Piece> villainPieceFactory,
         Position villainStart,
         IEnumerable<(Position Position, CoinType CoinType)> coins)
@@ -98,7 +98,7 @@ public class GreedyVillainStrategyTests
         game.PlacePiece(villain, villainPiece.Id, villainStart);
         game.SkipPlacement(bot); // → MovePhase (bot has 0 pieces; villain becomes the active mover)
 
-        return (game, bot, villain, villainPiece);
+        return (game, villain, villainPiece);
     }
 
     // ── 1. Placement ──────────────────────────────────────────────────────────
@@ -184,12 +184,14 @@ public class GreedyVillainStrategyTests
             $"Destination {destination} (dist {ManhattanDistance(destination, coin)}) must be closer " +
             $"to coin {coin} than start {start} (dist {ManhattanDistance(start, coin)}).");
 
-        // Round-trip through the real domain engine: the produced single-segment move must be legal to
-        // apply, and the piece must actually land on the destination tile the strategy reported.
-        var applyMove = () => game.MovePiece(villain, movement.PieceId, movement.Segments);
-        var exception = Record.Exception(applyMove);
+        var exception = Record.Exception((Action?)ApplyMove);
         Assert.Null(exception);
         Assert.Equal(destination, mickey.Position);
+        return;
+
+        // Round-trip through the real domain engine: the produced single-segment move must be legal to
+        // apply, and the piece must actually land on the destination tile, the strategy reported.
+        void ApplyMove() => game.MovePiece(villain, movement.PieceId, movement.Segments);
     }
 
     // ── 3b. Multi-segment move stays domain-legal across an ice-patch slide ──────
@@ -207,7 +209,7 @@ public class GreedyVillainStrategyTests
         var icePatch = new Position(0, 1);
         var start = new Position(0, 0);
 
-        var (game, _, villain, anna) = NewGameInVillainMovePhase(
+        var (game, villain, anna) = NewGameInVillainMovePhase(
             owner => PieceFactory.Create("Anna", owner),
             start,
             [(coin, CoinType.Silver)]);
@@ -224,14 +226,16 @@ public class GreedyVillainStrategyTests
         Assert.Equal(anna.Id, movement.PieceId);
         Assert.Equal(icePatch, movement.Segments[0][^1]);
 
-        // The whole point: applying the strategy's move to the real domain must NOT throw, proving the
-        // ice-slide simulation kept every inter-segment cursor aligned with the domain's resolution.
-        var applyMove = () => game.MovePiece(villain, movement.PieceId, movement.Segments);
-        var exception = Record.Exception(applyMove);
+        var exception = Record.Exception((Action?)ApplyMove);
         Assert.Null(exception);
 
         // After: step 1 (0,0)→(0,1) slides to (0,2); step 2 → (0,3); step 3 → (0,4).
         Assert.Equal(new Position(0, 4), anna.Position);
+        return;
+
+        // The whole point: applying the strategy's move to the real domain must NOT throw, proving the
+        // ice-slide simulation kept every inter-segment cursor aligned with the domain's resolution.
+        void ApplyMove() => game.MovePiece(villain, movement.PieceId, movement.Segments);
     }
 
 

--- a/tests/ScrambleCoin.Application.Tests/IcePatchMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/IcePatchMovementIntegrationTests.cs
@@ -251,6 +251,7 @@ public class IcePatchMovementIntegrationTests
         => new(gameRepo,
             botRepo,
             Substitute.For<IPublisher>(),
+            Substitute.For<ScrambleCoin.Application.Services.IVillainAutomationService>(),
             Substitute.For<ILogger<MovePieceCommandHandler>>());
 
     /// <summary>

--- a/tests/ScrambleCoin.Application.Tests/IcePatchMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/IcePatchMovementIntegrationTests.cs
@@ -251,7 +251,7 @@ public class IcePatchMovementIntegrationTests
         => new(gameRepo,
             botRepo,
             Substitute.For<IPublisher>(),
-            Substitute.For<ScrambleCoin.Application.Services.IVillainAutomationService>(),
+            Substitute.For<Services.IVillainAutomationService>(),
             Substitute.For<ILogger<MovePieceCommandHandler>>());
 
     /// <summary>

--- a/tests/ScrambleCoin.Application.Tests/MovePieceCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/MovePieceCommandHandlerTests.cs
@@ -94,6 +94,7 @@ public class MovePieceCommandHandlerTests
         => new(repo,
                botRepo ?? Substitute.For<IBotRegistrationRepository>(),
                publisher ?? Substitute.For<IPublisher>(),
+               Substitute.For<IVillainAutomationService>(),
                Substitute.For<ILogger<MovePieceCommandHandler>>());
 
     // ── Test 1: Handler delegates to domain and saves ──────────────────────────

--- a/tests/ScrambleCoin.Application.Tests/MultiStepMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/MultiStepMovementIntegrationTests.cs
@@ -15,7 +15,7 @@ using DomainBotReg = ScrambleCoin.Domain.BotRegistrations.BotRegistration;
 namespace ScrambleCoin.Application.Tests;
 
 /// <summary>
-/// Integration tests for multi-step movement sequences (Issue #48).
+/// Integration tests for multistep movement sequences (Issue #48).
 /// Tests full Application layer flow for pieces with multiple movement segments:
 /// Cogsworth (Any→Orthogonal), Lumiere (Any→Diagonal), Anna (Orthogonal×3),
 /// Remy (Diagonal×2), Olaf (Any×2), Kristoff (Diagonal×3).
@@ -31,8 +31,8 @@ public class MultiStepMovementIntegrationTests
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Creates a game in MovePhase with a specific multi-step piece.
-    /// Returns (game, p1, p2, piece, startPos).
+    /// Creates a game in MovePhase with a specific multistep piece.
+    /// Returns (game, p. 1, p. 2, piece, startPos).
     /// </summary>
     private static (Game game, Guid p1, Guid p2, Piece piece, Position startPos)
         GameInMovePhaseWithMultiStepPiece(string pieceName)
@@ -109,7 +109,7 @@ public class MultiStepMovementIntegrationTests
         => new(gameRepo,
             botRepo,
             Substitute.For<IPublisher>(),
-            Substitute.For<ScrambleCoin.Application.Services.IVillainAutomationService>(),
+            Substitute.For<Services.IVillainAutomationService>(),
             Substitute.For<ILogger<MovePieceCommandHandler>>());
 
     /// <summary>
@@ -140,8 +140,8 @@ public class MultiStepMovementIntegrationTests
         await handler.Handle(
             new MovePieceCommand(game.Id, token, cogsworth.Id,
                 BuildSegments(
-                    new[] { new Position(0, 4) },  // Segment 1: Any direction 1
-                    new[] { new Position(1, 4), new Position(2, 4) }  // Segment 2: Orthogonal 2
+                    [new Position(0, 4)],                    // Segment 1: Any direction 1
+                    [new Position(1, 4), new Position(2, 4)] // Segment 2: Orthogonal 2
                 )),
             CancellationToken.None);
 
@@ -168,8 +168,8 @@ public class MultiStepMovementIntegrationTests
             handler.Handle(
                 new MovePieceCommand(game.Id, token, cogsworth.Id,
                     BuildSegments(
-                        new[] { new Position(0, 4) },  // Segment 1: OK
-                        new[] { new Position(1, 5) }   // Segment 2: Diagonal (wrong)
+                        [new Position(0, 4)], // Segment 1: OK
+                        [new Position(1, 5)]  // Segment 2: Diagonal (wrong)
                     )),
                 CancellationToken.None));
 
@@ -182,7 +182,7 @@ public class MultiStepMovementIntegrationTests
     [Fact]
     public async Task LumiereTwoSegmentMove_ValidSequence_BothSegmentsExecute()
     {
-        // Arrange: Lumiere at (0,3), will move Any 1 right → (0,4), then Diagonal 2 NE → (2,6)
+        // Arrange: Lumiere at (0,3) will move Any 1 right → (0,4), then Diagonal 2 NE → (2,6)
         var (game, p1, _, lumiere, _) = GameInMovePhaseWithMultiStepPiece("Lumiere");
 
         var token = Guid.NewGuid();
@@ -194,8 +194,8 @@ public class MultiStepMovementIntegrationTests
         await handler.Handle(
             new MovePieceCommand(game.Id, token, lumiere.Id,
                 BuildSegments(
-                    new[] { new Position(0, 4) },  // Segment 1: Any direction 1
-                    new[] { new Position(1, 5), new Position(2, 6) }  // Segment 2: Diagonal 2
+                    [new Position(0, 4)],                    // Segment 1: Any direction 1
+                    [new Position(1, 5), new Position(2, 6)] // Segment 2: Diagonal 2
                 )),
             CancellationToken.None);
 
@@ -222,8 +222,8 @@ public class MultiStepMovementIntegrationTests
             handler.Handle(
                 new MovePieceCommand(game.Id, token, lumiere.Id,
                     BuildSegments(
-                        new[] { new Position(0, 4) },  // Segment 1: OK
-                        new[] { new Position(1, 4), new Position(2, 4) }  // Segment 2: Orthogonal (wrong)
+                        [new Position(0, 4)],                    // Segment 1: OK
+                        [new Position(1, 4), new Position(2, 4)] // Segment 2: Orthogonal (wrong)
                     )),
                 CancellationToken.None));
 
@@ -234,9 +234,9 @@ public class MultiStepMovementIntegrationTests
     // ── Test 5: Anna 3-Segment Move (All Required) ────────────────────────────
 
     [Fact]
-    public async Task AnnaThrreeSegmentMove_ValidSequence_AllSegmentsExecute()
+    public async Task AnnaThreeSegmentMove_ValidSequence_AllSegmentsExecute()
     {
-        // Arrange: Anna at (0,3), will move Orthogonal 1 three times
+        // Arrange: Anna at (0,3) will move Orthogonal 1 three times
         var (game, p1, _, anna, _) = GameInMovePhaseWithMultiStepPiece("Anna");
 
         var token = Guid.NewGuid();
@@ -248,9 +248,9 @@ public class MultiStepMovementIntegrationTests
         await handler.Handle(
             new MovePieceCommand(game.Id, token, anna.Id,
                 BuildSegments(
-                    new[] { new Position(0, 4) },  // Segment 1: Orthogonal 1
-                    new[] { new Position(1, 4) },  // Segment 2: Orthogonal 1
-                    new[] { new Position(1, 5) }   // Segment 3: Orthogonal 1
+                    [new Position(0, 4)], // Segment 1: Orthogonal 1
+                    [new Position(1, 4)], // Segment 2: Orthogonal 1
+                    [new Position(1, 5)]  // Segment 3: Orthogonal 1
                 )),
             CancellationToken.None);
 
@@ -277,8 +277,8 @@ public class MultiStepMovementIntegrationTests
             handler.Handle(
                 new MovePieceCommand(game.Id, token, anna.Id,
                     BuildSegments(
-                        new[] { new Position(0, 4) },  // Segment 1
-                        new[] { new Position(1, 4) }   // Segment 2 (missing 3)
+                        [new Position(0, 4)], // Segment 1
+                        [new Position(1, 4)]  // Segment 2 (missing 3)
                     )),
                 CancellationToken.None));
 
@@ -304,9 +304,9 @@ public class MultiStepMovementIntegrationTests
             handler.Handle(
                 new MovePieceCommand(game.Id, token, anna.Id,
                     BuildSegments(
-                        new[] { new Position(0, 4) },  // Segment 1: OK
-                        new[] { new Position(1, 5) },  // Segment 2: Diagonal (wrong)
-                        new[] { new Position(1, 5) }   // Segment 3
+                        [new Position(0, 4)], // Segment 1: OK
+                        [new Position(1, 5)], // Segment 2: Diagonal (wrong)
+                        [new Position(1, 5)]  // Segment 3
                     )),
                 CancellationToken.None));
 
@@ -319,7 +319,7 @@ public class MultiStepMovementIntegrationTests
     [Fact]
     public async Task RemyTwoSegmentMove_DiagonalThenDiagonal_BothSegmentsExecute()
     {
-        // Arrange: Remy at (0,3), will move Diagonal 2 SE → (2,5), then Diagonal 2 SW → (4,3)
+        // Arrange: Remy at (0,3) will move Diagonal 2 SE → (2,5), then Diagonal 2 SW → (4,3)
         var (game, p1, _, remy, _) = GameInMovePhaseWithMultiStepPiece("Remy");
 
         var token = Guid.NewGuid();
@@ -331,8 +331,8 @@ public class MultiStepMovementIntegrationTests
         await handler.Handle(
             new MovePieceCommand(game.Id, token, remy.Id,
                 BuildSegments(
-                    new[] { new Position(1, 4), new Position(2, 5) },  // Segment 1: Diagonal 2
-                    new[] { new Position(3, 4), new Position(4, 3) }   // Segment 2: Diagonal 2
+                    [new Position(1, 4), new Position(2, 5)], // Segment 1: Diagonal 2
+                    [new Position(3, 4), new Position(4, 3)]  // Segment 2: Diagonal 2
                 )),
             CancellationToken.None);
 
@@ -346,7 +346,7 @@ public class MultiStepMovementIntegrationTests
     [Fact]
     public async Task OlafTwoSegmentMove_AnyThenAny_BothSegmentsExecute()
     {
-        // Arrange: Olaf at (0,3), will move Any 1 east → (0,4), then Any 1 north → (1,4)
+        // Arrange: Olaf at (0,3) will move Any 1 east → (0,4), then Any 1 north → (1,4)
         var (game, p1, _, olaf, _) = GameInMovePhaseWithMultiStepPiece("Olaf");
 
         var token = Guid.NewGuid();
@@ -358,8 +358,8 @@ public class MultiStepMovementIntegrationTests
         await handler.Handle(
             new MovePieceCommand(game.Id, token, olaf.Id,
                 BuildSegments(
-                    new[] { new Position(0, 4) },  // Segment 1: Any 1
-                    new[] { new Position(1, 4) }   // Segment 2: Any 1
+                    [new Position(0, 4)], // Segment 1: Any 1
+                    [new Position(1, 4)]  // Segment 2: Any 1
                 )),
             CancellationToken.None);
 
@@ -385,9 +385,9 @@ public class MultiStepMovementIntegrationTests
         await handler.Handle(
             new MovePieceCommand(game.Id, token, kristoff.Id,
                 BuildSegments(
-                    new[] { new Position(1, 4) },  // Segment 1: Diagonal 1
-                    new[] { new Position(2, 5) },  // Segment 2: Diagonal 1
-                    new[] { new Position(3, 6) }   // Segment 3: Diagonal 1
+                    [new Position(1, 4)], // Segment 1: Diagonal 1
+                    [new Position(2, 5)], // Segment 2: Diagonal 1
+                    [new Position(3, 6)]  // Segment 3: Diagonal 1
                 )),
             CancellationToken.None);
 
@@ -414,8 +414,8 @@ public class MultiStepMovementIntegrationTests
             handler.Handle(
                 new MovePieceCommand(game.Id, token, remy.Id,
                     BuildSegments(
-                        new[] { new Position(0, 4), new Position(0, 5) },  // Segment 1: Orthogonal (wrong)
-                        new[] { new Position(1, 6), new Position(2, 7) }   // Segment 2
+                        [new Position(0, 4), new Position(0, 5)], // Segment 1: Orthogonal (wrong)
+                        [new Position(1, 6), new Position(2, 7)]  // Segment 2
                     )),
                 CancellationToken.None));
 
@@ -441,8 +441,8 @@ public class MultiStepMovementIntegrationTests
             handler.Handle(
                 new MovePieceCommand(game.Id, token, kristoff.Id,
                     BuildSegments(
-                        new[] { new Position(1, 4) },  // Segment 1
-                        new[] { new Position(2, 5) }   // Segment 2 (missing 3)
+                        [new Position(1, 4)], // Segment 1
+                        [new Position(2, 5)]  // Segment 2 (missing 3)
                     )),
                 CancellationToken.None));
 
@@ -468,8 +468,8 @@ public class MultiStepMovementIntegrationTests
             handler.Handle(
                 new MovePieceCommand(game.Id, token, cogsworth.Id,
                     BuildSegments(
-                        new[] { new Position(0, 4) },  // Segment 1: OK
-                        new[] { new Position(1, 4), new Position(2, 4), new Position(3, 4) }  // Segment 2: 3 (max is 2)
+                        [new Position(0, 4)],                                        // Segment 1: OK
+                        [new Position(1, 4), new Position(2, 4), new Position(3, 4)] // Segment 2: 3 (max is 2)
                     )),
                 CancellationToken.None));
 
@@ -495,8 +495,8 @@ public class MultiStepMovementIntegrationTests
             handler.Handle(
                 new MovePieceCommand(game.Id, token, lumiere.Id,
                     BuildSegments(
-                        new[] { new Position(0, 4) },  // Segment 1: OK
-                        new[] { new Position(1, 5), new Position(2, 6), new Position(3, 7) }  // Segment 2: 3 (max is 2)
+                        [new Position(0, 4)],                                        // Segment 1: OK
+                        [new Position(1, 5), new Position(2, 6), new Position(3, 7)] // Segment 2: 3 (max is 2)
                     )),
                 CancellationToken.None));
 
@@ -521,8 +521,8 @@ public class MultiStepMovementIntegrationTests
         await handler.Handle(
             new MovePieceCommand(game.Id, token, cogsworth.Id,
                 BuildSegments(
-                    new[] { new Position(0, 4) },
-                    new[] { new Position(1, 4), new Position(2, 4) }
+                    [new Position(0, 4)],
+                    [new Position(1, 4), new Position(2, 4)]
                 )),
             CancellationToken.None);
 
@@ -555,25 +555,25 @@ public class MultiStepMovementIntegrationTests
         var segments = pieceName switch
         {
             "Cogsworth" => BuildSegments(
-                new[] { new Position(0, 4) },
-                new[] { new Position(1, 4), new Position(2, 4) }),
+                [new Position(0, 4)],
+                [new Position(1, 4), new Position(2, 4)]),
             "Lumiere" => BuildSegments(
-                new[] { new Position(0, 4) },
-                new[] { new Position(1, 5), new Position(2, 6) }),
+                [new Position(0, 4)],
+                [new Position(1, 5), new Position(2, 6)]),
             "Remy" => BuildSegments(
-                new[] { new Position(1, 4), new Position(2, 5) },
-                new[] { new Position(3, 4), new Position(4, 3) }),
+                [new Position(1, 4), new Position(2, 5)],
+                [new Position(3, 4), new Position(4, 3)]),
             "Anna" => BuildSegments(
-                new[] { new Position(0, 4) },
-                new[] { new Position(1, 4) },
-                new[] { new Position(1, 5) }),
+                [new Position(0, 4)],
+                [new Position(1, 4)],
+                [new Position(1, 5)]),
             "Olaf" => BuildSegments(
-                new[] { new Position(0, 4) },
-                new[] { new Position(1, 4) }),
+                [new Position(0, 4)],
+                [new Position(1, 4)]),
             "Kristoff" => BuildSegments(
-                new[] { new Position(1, 4) },
-                new[] { new Position(2, 5) },
-                new[] { new Position(3, 6) }),
+                [new Position(1, 4)],
+                [new Position(2, 5)],
+                [new Position(3, 6)]),
             _ => throw new ArgumentException($"Unknown piece: {pieceName}")
         };
 

--- a/tests/ScrambleCoin.Application.Tests/MultiStepMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/MultiStepMovementIntegrationTests.cs
@@ -109,6 +109,7 @@ public class MultiStepMovementIntegrationTests
         => new(gameRepo,
             botRepo,
             Substitute.For<IPublisher>(),
+            Substitute.For<ScrambleCoin.Application.Services.IVillainAutomationService>(),
             Substitute.For<ILogger<MovePieceCommandHandler>>());
 
     /// <summary>

--- a/tests/ScrambleCoin.Application.Tests/PieceTurnAvailabilityBoardStateTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/PieceTurnAvailabilityBoardStateTests.cs
@@ -16,13 +16,13 @@ namespace ScrambleCoin.Application.Tests;
 /// </summary>
 public class PieceTurnAvailabilityBoardStateTests
 {
-    private static (Game game, Guid p1, Guid p2) NewStartedGameWithRestrictedLineup()
+    private static (Game game, Guid p1) NewStartedGameWithRestrictedLineup()
     {
         var p1 = Guid.NewGuid();
         var p2 = Guid.NewGuid();
 
         // Mix unrestricted starter pieces with restricted ones so we can assert both branches.
-        // Lineup must contain exactly Lineup.RequiredPieceCount (= 5) pieces.
+        // Lineup must contain exact Lineup.RequiredPieceCount (= 5) pieces.
         string[] lineup1 = ["Mickey", "Elsa", "Scar", "Merlin", "Goofy"];
         string[] lineup2 = ["Mickey", "Minnie", "Donald", "Goofy", "Scrooge"];
 
@@ -34,7 +34,7 @@ public class PieceTurnAvailabilityBoardStateTests
         game.SetLineup(p2, new Lineup(pieces2));
         game.Start();
 
-        return (game, p1, p2);
+        return (game, p1);
     }
 
     private static GetBoardStateQueryHandler BuildHandlerFor(Game game, DomainBotReg reg)
@@ -51,7 +51,7 @@ public class PieceTurnAvailabilityBoardStateTests
     [Fact]
     public async Task Handle_YourPieces_IncludesAvailableFromTurnForRestrictedPiece()
     {
-        var (game, p1, _) = NewStartedGameWithRestrictedLineup();
+        var (game, p1) = NewStartedGameWithRestrictedLineup();
         var reg = new DomainBotReg(Guid.NewGuid(), p1, game.Id);
         var handler = BuildHandlerFor(game, reg);
 
@@ -64,7 +64,7 @@ public class PieceTurnAvailabilityBoardStateTests
     [Fact]
     public async Task Handle_YourPieces_NullAvailableFromTurnForUnrestrictedPiece()
     {
-        var (game, p1, _) = NewStartedGameWithRestrictedLineup();
+        var (game, p1) = NewStartedGameWithRestrictedLineup();
         var reg = new DomainBotReg(Guid.NewGuid(), p1, game.Id);
         var handler = BuildHandlerFor(game, reg);
 
@@ -79,7 +79,7 @@ public class PieceTurnAvailabilityBoardStateTests
     [InlineData("Merlin", 4)]
     public async Task Handle_YourPieces_ExposesEachRestrictedPieceCorrectly(string name, int expected)
     {
-        var (game, p1, _) = NewStartedGameWithRestrictedLineup();
+        var (game, p1) = NewStartedGameWithRestrictedLineup();
         var reg = new DomainBotReg(Guid.NewGuid(), p1, game.Id);
         var handler = BuildHandlerFor(game, reg);
 
@@ -92,7 +92,7 @@ public class PieceTurnAvailabilityBoardStateTests
     [Fact]
     public async Task Handle_OpponentPieces_AlsoExposesAvailableFromTurn()
     {
-        var (game, p1, _) = NewStartedGameWithRestrictedLineup();
+        var (game, p1) = NewStartedGameWithRestrictedLineup();
         var reg = new DomainBotReg(Guid.NewGuid(), p1, game.Id);
         var handler = BuildHandlerFor(game, reg);
 

--- a/tests/ScrambleCoin.Application.Tests/VillainActionDispatcherTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/VillainActionDispatcherTests.cs
@@ -1,0 +1,106 @@
+using MediatR;
+using NSubstitute;
+using ScrambleCoin.Application.Games.VillainActions.VillainMovePiece;
+using ScrambleCoin.Application.Games.VillainActions.VillainPlacePiece;
+using ScrambleCoin.Application.Games.VillainActions.VillainSkipMovement;
+using ScrambleCoin.Application.Games.VillainActions.VillainSkipPlacement;
+using ScrambleCoin.Application.Services;
+using ScrambleCoin.Domain.Exceptions;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="VillainActionDispatcher"/> (Issue #41).
+/// Verifies each <see cref="VillainAction"/> variant is mapped to the correct villain MediatR
+/// command with the correct parameters — villain actions use the same command pipeline as bots.
+/// </summary>
+public class VillainActionDispatcherTests
+{
+    private readonly IMediator _mediator = Substitute.For<IMediator>();
+    private readonly VillainActionDispatcher _dispatcher;
+
+    private readonly Guid _gameId = Guid.NewGuid();
+    private readonly Guid _villainPlayerId = Guid.NewGuid();
+
+    public VillainActionDispatcherTests()
+    {
+        _dispatcher = new VillainActionDispatcher(_mediator);
+    }
+
+    [Fact]
+    public async Task ExecuteVillainActionAsync_Placement_SendsVillainPlacePieceCommand()
+    {
+        var pieceId = Guid.NewGuid();
+        var position = new Position(2, 3);
+
+        await _dispatcher.ExecuteVillainActionAsync(
+            new PlacementAction(pieceId, position), _gameId, _villainPlayerId);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<VillainPlacePieceCommand>(c =>
+                c.GameId == _gameId &&
+                c.VillainPlayerId == _villainPlayerId &&
+                c.PieceId == pieceId &&
+                c.Position == position),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteVillainActionAsync_SkipPlacement_SendsVillainSkipPlacementCommand()
+    {
+        await _dispatcher.ExecuteVillainActionAsync(
+            new SkipPlacementAction(), _gameId, _villainPlayerId);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<VillainSkipPlacementCommand>(c =>
+                c.GameId == _gameId &&
+                c.VillainPlayerId == _villainPlayerId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteVillainActionAsync_Movement_SendsVillainMovePieceCommandWithSegments()
+    {
+        var pieceId = Guid.NewGuid();
+        var segments = new List<IReadOnlyList<Position>>
+        {
+            new List<Position> { new(1, 1) }
+        };
+
+        await _dispatcher.ExecuteVillainActionAsync(
+            new MovementAction(pieceId, segments), _gameId, _villainPlayerId);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<VillainMovePieceCommand>(c =>
+                c.GameId == _gameId &&
+                c.VillainPlayerId == _villainPlayerId &&
+                c.PieceId == pieceId &&
+                ReferenceEquals(c.Segments, segments)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteVillainActionAsync_SkipMovement_SendsVillainSkipMovementCommand()
+    {
+        await _dispatcher.ExecuteVillainActionAsync(
+            new SkipMovementAction(), _gameId, _villainPlayerId);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<VillainSkipMovementCommand>(c =>
+                c.GameId == _gameId &&
+                c.VillainPlayerId == _villainPlayerId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteVillainActionAsync_UnknownActionType_Throws()
+    {
+        var unknown = new UnknownVillainAction();
+
+        await Assert.ThrowsAsync<DomainException>(() =>
+            _dispatcher.ExecuteVillainActionAsync(unknown, _gameId, _villainPlayerId));
+    }
+
+    private sealed record UnknownVillainAction : VillainAction;
+}

--- a/tests/ScrambleCoin.Application.Tests/VillainAutomationServiceTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/VillainAutomationServiceTests.cs
@@ -23,7 +23,7 @@ public class VillainAutomationServiceTests
     /// Builds a real solo game (bot = PlayerOne, villain = PlayerTwo) advanced to the villain's
     /// MovePhase with one Mickey on the board and the bot holding no on-board pieces.
     /// </summary>
-    private static (Game game, Guid bot, Guid villain) SoloGameInVillainMovePhase()
+    private static (Game game, Guid villain) SoloGameInVillainMovePhase()
     {
         var bot = Guid.NewGuid();
         var villain = Guid.NewGuid();
@@ -43,7 +43,7 @@ public class VillainAutomationServiceTests
         game.PlacePiece(villain, villainLineup.Pieces[0].Id, new Position(0, 0));
         game.SkipPlacement(bot); // → MovePhase; bot has 0 pieces, so the villain becomes active
 
-        return (game, bot, villain);
+        return (game, villain);
     }
 
     private static VillainAutomationService BuildService(
@@ -84,7 +84,7 @@ public class VillainAutomationServiceTests
     public async Task EnsureVillainActsIfNeededAsync_VillainMovePhase_DispatchesActionAndReturnsControl()
     {
         // Arrange
-        var (game, _, villain) = SoloGameInVillainMovePhase();
+        var (game, villain) = SoloGameInVillainMovePhase();
         Assert.Equal(villain, game.MovePhaseActivePlayer); // sanity: it is the villain's turn
 
         var gameRepo = Substitute.For<IGameRepository>();
@@ -121,7 +121,7 @@ public class VillainAutomationServiceTests
     public async Task EnsureVillainActsIfNeededAsync_DispatchThrows_FallsBackToSkipAndDoesNotRethrow()
     {
         // Arrange
-        var (game, _, villain) = SoloGameInVillainMovePhase();
+        var (game, villain) = SoloGameInVillainMovePhase();
 
         var gameRepo = Substitute.For<IGameRepository>();
         gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);

--- a/tests/ScrambleCoin.Application.Tests/VillainAutomationServiceTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/VillainAutomationServiceTests.cs
@@ -1,0 +1,164 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Application.Services;
+using ScrambleCoin.Application.Services.Villains;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="VillainAutomationService"/> (Issue #41).
+/// Verifies: no-op for non-solo games, driving the villain's MovePhase until control returns, and
+/// failure isolation (a failed villain action falls back to a skip and never rethrows into the
+/// bot's shared request path).
+/// </summary>
+public class VillainAutomationServiceTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a real solo game (bot = PlayerOne, villain = PlayerTwo) advanced to the villain's
+    /// MovePhase with one Mickey on the board and the bot holding no on-board pieces.
+    /// </summary>
+    private static (Game game, Guid bot, Guid villain) SoloGameInVillainMovePhase()
+    {
+        var bot = Guid.NewGuid();
+        var villain = Guid.NewGuid();
+
+        var game = new Game(Guid.NewGuid(), bot, villain, new Board())
+        {
+            GameMode = GameMode.Solo,
+            VillainId = VillainRegistry.Elsa.Id
+        };
+
+        var villainLineup = VillainRegistry.Elsa.GetLineup(villain);
+        game.SetLineup(bot, VillainRegistry.GetDefaultLineup(bot));
+        game.SetLineup(villain, villainLineup);
+
+        game.Start();        // → CoinSpawn, turn 1
+        game.AdvancePhase(); // → PlacePhase
+        game.PlacePiece(villain, villainLineup.Pieces[0].Id, new Position(0, 0));
+        game.SkipPlacement(bot); // → MovePhase; bot has 0 pieces, so the villain becomes active
+
+        return (game, bot, villain);
+    }
+
+    private static VillainAutomationService BuildService(
+        IGameRepository gameRepo,
+        IVillainStrategyFactory factory,
+        IVillainActionDispatcher dispatcher) =>
+        new(gameRepo, factory, dispatcher, Substitute.For<ILogger<VillainAutomationService>>());
+
+    // ── No-op for non-solo games ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EnsureVillainActsIfNeededAsync_NonSoloGame_DispatchesNothing()
+    {
+        // Arrange: a standard game without a VillainId.
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var game = new Game(Guid.NewGuid(), p1, p2, new Board()); // VillainId is null
+
+        var gameRepo = Substitute.For<IGameRepository>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+        var factory = Substitute.For<IVillainStrategyFactory>();
+        var dispatcher = Substitute.For<IVillainActionDispatcher>();
+
+        var service = BuildService(gameRepo, factory, dispatcher);
+
+        // Act
+        await service.EnsureVillainActsIfNeededAsync(game.Id);
+
+        // Assert
+        factory.DidNotReceive().CreateStrategy(Arg.Any<string>());
+        await dispatcher.DidNotReceive().ExecuteVillainActionAsync(
+            Arg.Any<VillainAction>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Drives the villain's MovePhase until control returns ────────────────────
+
+    [Fact]
+    public async Task EnsureVillainActsIfNeededAsync_VillainMovePhase_DispatchesActionAndReturnsControl()
+    {
+        // Arrange
+        var (game, _, villain) = SoloGameInVillainMovePhase();
+        Assert.Equal(villain, game.MovePhaseActivePlayer); // sanity: it is the villain's turn
+
+        var gameRepo = Substitute.For<IGameRepository>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var strategy = Substitute.For<IVillainStrategy>();
+        strategy.DecideAction(Arg.Any<Game>(), Arg.Any<Guid>()).Returns(new SkipMovementAction());
+        var factory = Substitute.For<IVillainStrategyFactory>();
+        factory.CreateStrategy(VillainRegistry.Elsa.Id).Returns(strategy);
+
+        var dispatcher = Substitute.For<IVillainActionDispatcher>();
+        // The dispatched skip actually advances the domain so control leaves the villain.
+        dispatcher
+            .When(d => d.ExecuteVillainActionAsync(
+                Arg.Is<VillainAction>(a => a is SkipMovementAction),
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>()))
+            .Do(_ => game.SkipMovement(villain));
+
+        var service = BuildService(gameRepo, factory, dispatcher);
+
+        // Act
+        await service.EnsureVillainActsIfNeededAsync(game.Id);
+
+        // Assert: exactly one skip dispatched, and the villain is no longer the active mover.
+        await dispatcher.Received(1).ExecuteVillainActionAsync(
+            Arg.Is<VillainAction>(a => a is SkipMovementAction),
+            game.Id, villain, Arg.Any<CancellationToken>());
+        Assert.NotEqual(villain, game.MovePhaseActivePlayer);
+    }
+
+    // ── Failure isolation: failed action → skip fallback, no rethrow ────────────
+
+    [Fact]
+    public async Task EnsureVillainActsIfNeededAsync_DispatchThrows_FallsBackToSkipAndDoesNotRethrow()
+    {
+        // Arrange
+        var (game, _, villain) = SoloGameInVillainMovePhase();
+
+        var gameRepo = Substitute.For<IGameRepository>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var strategy = Substitute.For<IVillainStrategy>();
+        strategy.DecideAction(Arg.Any<Game>(), Arg.Any<Guid>())
+            .Returns(new MovementAction(Guid.NewGuid(), new List<IReadOnlyList<Position>>()));
+        var factory = Substitute.For<IVillainStrategyFactory>();
+        factory.CreateStrategy(VillainRegistry.Elsa.Id).Returns(strategy);
+
+        var dispatcher = Substitute.For<IVillainActionDispatcher>();
+        // The "real" villain action fails...
+        dispatcher
+            .When(d => d.ExecuteVillainActionAsync(
+                Arg.Is<VillainAction>(a => a is MovementAction),
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>()))
+            .Do(_ => throw new InvalidOperationException("simulated villain failure"));
+        // ...but the skip fallback succeeds and advances the domain.
+        dispatcher
+            .When(d => d.ExecuteVillainActionAsync(
+                Arg.Is<VillainAction>(a => a is SkipMovementAction),
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>()))
+            .Do(_ => game.SkipMovement(villain));
+
+        var service = BuildService(gameRepo, factory, dispatcher);
+
+        // Act: must NOT throw (the bot shares this call path).
+        var ex = await Record.ExceptionAsync(() => service.EnsureVillainActsIfNeededAsync(game.Id));
+
+        // Assert
+        Assert.Null(ex);
+        await dispatcher.Received(1).ExecuteVillainActionAsync(
+            Arg.Is<VillainAction>(a => a is MovementAction),
+            game.Id, villain, Arg.Any<CancellationToken>());
+        await dispatcher.Received(1).ExecuteVillainActionAsync(
+            Arg.Is<VillainAction>(a => a is SkipMovementAction),
+            game.Id, villain, Arg.Any<CancellationToken>());
+        Assert.NotEqual(villain, game.MovePhaseActivePlayer);
+    }
+}

--- a/tests/ScrambleCoin.Application.Tests/VillainRegistryTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/VillainRegistryTests.cs
@@ -1,0 +1,119 @@
+using ScrambleCoin.Application.Services.Villains;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="VillainRegistry"/> (Issue #41).
+/// Verifies the confirmed hardcoded lineups, slug tolerance, and the fallback behaviour for
+/// unknown villain IDs.
+/// </summary>
+public class VillainRegistryTests
+{
+    private static IReadOnlyList<string> PieceNames(Lineup lineup) =>
+        lineup.Pieces.Select(p => p.Name).ToList();
+
+    [Fact]
+    public void GetLineupForVillain_Elsa_ReturnsConfirmedFivePieceLineup()
+    {
+        var playerId = Guid.NewGuid();
+
+        var lineup = VillainRegistry.GetLineupForVillain(VillainRegistry.Elsa.Id, playerId);
+
+        Assert.Equal(
+            new[] { "Mickey", "Donald", "WALL•E", "Merlin", "Scrooge" },
+            PieceNames(lineup));
+        Assert.All(lineup.Pieces, p => Assert.Equal(playerId, p.PlayerId));
+    }
+
+    [Fact]
+    public void GetLineupForVillain_Ursula_ReturnsConfirmedFivePieceLineup()
+    {
+        var playerId = Guid.NewGuid();
+
+        var lineup = VillainRegistry.GetLineupForVillain(VillainRegistry.Ursula.Id, playerId);
+
+        Assert.Equal(
+            new[] { "Mickey", "Donald", "Anna", "Goofy", "Cinderella" },
+            PieceNames(lineup));
+    }
+
+    [Fact]
+    public void GetLineupForVillain_Gaston_ReturnsConfirmedFivePieceLineup()
+    {
+        var playerId = Guid.NewGuid();
+
+        var lineup = VillainRegistry.GetLineupForVillain(VillainRegistry.Gaston.Id, playerId);
+
+        Assert.Equal(
+            new[] { "Minnie", "Goofy", "Donald", "Scrooge", "Mickey" },
+            PieceNames(lineup));
+    }
+
+    [Theory]
+    [InlineData("Elsa")]
+    [InlineData("ELSA")]
+    [InlineData("  elsa  ")]
+    public void GetLineupForVillain_IsTolerantOfSlugFormat(string villainId)
+    {
+        var playerId = Guid.NewGuid();
+
+        var lineup = VillainRegistry.GetLineupForVillain(villainId, playerId);
+
+        Assert.Equal(
+            new[] { "Mickey", "Donald", "WALL•E", "Merlin", "Scrooge" },
+            PieceNames(lineup));
+    }
+
+    [Fact]
+    public void GetLineupForVillain_UnknownId_Throws()
+    {
+        var playerId = Guid.NewGuid();
+
+        Assert.Throws<ArgumentException>(() =>
+            VillainRegistry.GetLineupForVillain("not-a-villain", playerId));
+    }
+
+    [Fact]
+    public void GetLineupForVillainOrDefault_UnknownId_ReturnsDefaultLineup()
+    {
+        var playerId = Guid.NewGuid();
+
+        var lineup = VillainRegistry.GetLineupForVillainOrDefault("scar", playerId);
+
+        Assert.Equal(PieceNames(VillainRegistry.GetDefaultLineup(playerId)), PieceNames(lineup));
+        Assert.Equal(Lineup.RequiredPieceCount, lineup.Pieces.Count);
+    }
+
+    [Fact]
+    public void GetLineupForVillainOrDefault_KnownId_ReturnsBespokeLineup()
+    {
+        var playerId = Guid.NewGuid();
+
+        var lineup = VillainRegistry.GetLineupForVillainOrDefault(VillainRegistry.Gaston.Id, playerId);
+
+        Assert.Equal(
+            new[] { "Minnie", "Goofy", "Donald", "Scrooge", "Mickey" },
+            PieceNames(lineup));
+    }
+
+    [Theory]
+    [InlineData("elsa", true)]
+    [InlineData("Ursula", true)]
+    [InlineData("GASTON", true)]
+    [InlineData("scar", false)]
+    [InlineData("", false)]
+    public void IsKnown_ReflectsRegisteredVillains(string villainId, bool expected)
+    {
+        Assert.Equal(expected, VillainRegistry.IsKnown(villainId));
+    }
+
+    [Theory]
+    [InlineData("elsa", "Elsa")]
+    [InlineData("Ursula", "Ursula")]
+    [InlineData("GASTON", "Gaston")]
+    public void GetDisplayName_ReturnsExpectedName(string villainId, string expected)
+    {
+        Assert.Equal(expected, VillainRegistry.GetDisplayName(villainId));
+    }
+}

--- a/tests/ScrambleCoin.Application.Tests/VillainRegistryTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/VillainRegistryTests.cs
@@ -10,7 +10,7 @@ namespace ScrambleCoin.Application.Tests;
 /// </summary>
 public class VillainRegistryTests
 {
-    private static IReadOnlyList<string> PieceNames(Lineup lineup) =>
+    private static List<string> PieceNames(Lineup lineup) =>
         lineup.Pieces.Select(p => p.Name).ToList();
 
     [Fact]
@@ -21,7 +21,7 @@ public class VillainRegistryTests
         var lineup = VillainRegistry.GetLineupForVillain(VillainRegistry.Elsa.Id, playerId);
 
         Assert.Equal(
-            new[] { "Mickey", "Donald", "WALL•E", "Merlin", "Scrooge" },
+            ["Mickey", "Donald", "WALL•E", "Merlin", "Scrooge"],
             PieceNames(lineup));
         Assert.All(lineup.Pieces, p => Assert.Equal(playerId, p.PlayerId));
     }
@@ -34,7 +34,7 @@ public class VillainRegistryTests
         var lineup = VillainRegistry.GetLineupForVillain(VillainRegistry.Ursula.Id, playerId);
 
         Assert.Equal(
-            new[] { "Mickey", "Donald", "Anna", "Goofy", "Cinderella" },
+            ["Mickey", "Donald", "Anna", "Goofy", "Cinderella"],
             PieceNames(lineup));
     }
 
@@ -46,7 +46,7 @@ public class VillainRegistryTests
         var lineup = VillainRegistry.GetLineupForVillain(VillainRegistry.Gaston.Id, playerId);
 
         Assert.Equal(
-            new[] { "Minnie", "Goofy", "Donald", "Scrooge", "Mickey" },
+            ["Minnie", "Goofy", "Donald", "Scrooge", "Mickey"],
             PieceNames(lineup));
     }
 
@@ -61,7 +61,7 @@ public class VillainRegistryTests
         var lineup = VillainRegistry.GetLineupForVillain(villainId, playerId);
 
         Assert.Equal(
-            new[] { "Mickey", "Donald", "WALL•E", "Merlin", "Scrooge" },
+            ["Mickey", "Donald", "WALL•E", "Merlin", "Scrooge"],
             PieceNames(lineup));
     }
 
@@ -93,7 +93,7 @@ public class VillainRegistryTests
         var lineup = VillainRegistry.GetLineupForVillainOrDefault(VillainRegistry.Gaston.Id, playerId);
 
         Assert.Equal(
-            new[] { "Minnie", "Goofy", "Donald", "Scrooge", "Mickey" },
+            ["Minnie", "Goofy", "Donald", "Scrooge", "Mickey"],
             PieceNames(lineup));
     }
 

--- a/tests/ScrambleCoin.Application.Tests/VillainStrategyFactoryTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/VillainStrategyFactoryTests.cs
@@ -11,7 +11,8 @@ namespace ScrambleCoin.Application.Tests;
 /// </summary>
 public class VillainStrategyFactoryTests
 {
-    private readonly VillainStrategyFactory _factory = new();
+    private readonly IVillainStrategyFactory _factory = new VillainStrategyFactory();
+    private static readonly string[] expected = ["Mickey", "Donald", "WALL•E", "Merlin", "Scrooge"];
 
     [Fact]
     public void CreateStrategy_Elsa_ReturnsElsaStrategy()
@@ -44,9 +45,9 @@ public class VillainStrategyFactoryTests
     [InlineData("elsa", "Elsa")]
     [InlineData("ursula", "Ursula")]
     [InlineData("gaston", "Gaston")]
-    public void GetDisplayName_ReturnsExpectedName(string villainId, string expected)
+    public void GetDisplayName_ReturnsExpectedName(string villainId, string expectedVillain)
     {
-        Assert.Equal(expected, _factory.GetDisplayName(villainId));
+        Assert.Equal(expectedVillain, _factory.GetDisplayName(villainId));
     }
 
     [Fact]
@@ -57,7 +58,7 @@ public class VillainStrategyFactoryTests
         var lineup = _factory.GetVillainLineup("elsa", playerId);
 
         Assert.Equal(
-            new[] { "Mickey", "Donald", "WALL•E", "Merlin", "Scrooge" },
+            expected,
             lineup.Pieces.Select(p => p.Name).ToList());
         Assert.All(lineup.Pieces, p => Assert.Equal(playerId, p.PlayerId));
     }

--- a/tests/ScrambleCoin.Application.Tests/VillainStrategyFactoryTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/VillainStrategyFactoryTests.cs
@@ -1,0 +1,64 @@
+using ScrambleCoin.Application.Services;
+using ScrambleCoin.Application.Services.Villains;
+using ScrambleCoin.Application.Services.Villains.Implementations;
+using ScrambleCoin.Domain.Exceptions;
+
+namespace ScrambleCoin.Application.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="VillainStrategyFactory"/> (Issue #41).
+/// Verifies the correct strategy type, lineup, and display name are resolved per villain ID.
+/// </summary>
+public class VillainStrategyFactoryTests
+{
+    private readonly VillainStrategyFactory _factory = new();
+
+    [Fact]
+    public void CreateStrategy_Elsa_ReturnsElsaStrategy()
+    {
+        var strategy = _factory.CreateStrategy("elsa");
+
+        Assert.IsType<ElsaStrategy>(strategy);
+        Assert.IsAssignableFrom<IVillainStrategy>(strategy);
+    }
+
+    [Fact]
+    public void CreateStrategy_Ursula_ReturnsUrsulaStrategy()
+    {
+        Assert.IsType<UrsulaStrategy>(_factory.CreateStrategy("Ursula"));
+    }
+
+    [Fact]
+    public void CreateStrategy_Gaston_ReturnsGastonStrategy()
+    {
+        Assert.IsType<GastonStrategy>(_factory.CreateStrategy("GASTON"));
+    }
+
+    [Fact]
+    public void CreateStrategy_UnknownVillain_Throws()
+    {
+        Assert.Throws<DomainException>(() => _factory.CreateStrategy("scar"));
+    }
+
+    [Theory]
+    [InlineData("elsa", "Elsa")]
+    [InlineData("ursula", "Ursula")]
+    [InlineData("gaston", "Gaston")]
+    public void GetDisplayName_ReturnsExpectedName(string villainId, string expected)
+    {
+        Assert.Equal(expected, _factory.GetDisplayName(villainId));
+    }
+
+    [Fact]
+    public void GetVillainLineup_Elsa_ReturnsBespokeLineupOwnedByPlayer()
+    {
+        var playerId = Guid.NewGuid();
+
+        var lineup = _factory.GetVillainLineup("elsa", playerId);
+
+        Assert.Equal(
+            new[] { "Mickey", "Donald", "WALL•E", "Merlin", "Scrooge" },
+            lineup.Pieces.Select(p => p.Name).ToList());
+        Assert.All(lineup.Pieces, p => Assert.Equal(playerId, p.PlayerId));
+    }
+}

--- a/tests/ScrambleCoin.Domain.Tests/HasPieceMovedThisTurnTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/HasPieceMovedThisTurnTests.cs
@@ -1,0 +1,98 @@
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Domain.Tests;
+
+/// <summary>
+/// Unit tests for the <see cref="Game.HasPieceMovedThisTurn"/> accessor (Issue #41).
+/// The villain strategy uses this to find the next unmoved on-board piece, so it must reflect
+/// the move/skip state accurately and reset between turns.
+/// </summary>
+public class HasPieceMovedThisTurnTests
+{
+    private static (Game game, Guid p1, Guid p2, Piece p1Piece, Piece p2Piece) GameInMovePhase(
+        Position? p1Pos = null,
+        Position? p2Pos = null)
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        var p1Piece = new Piece(Guid.NewGuid(), "P1Mover", p1,
+            EntryPointType.Borders, MovementType.Orthogonal, 3, 1);
+        var p1Fill = Enumerable.Range(0, 4)
+            .Select(i => new Piece(Guid.NewGuid(), $"P1Fill{i}", p1, EntryPointType.Borders, MovementType.Orthogonal, 1, 1));
+
+        var p2Piece = new Piece(Guid.NewGuid(), "P2Mover", p2,
+            EntryPointType.Borders, MovementType.Orthogonal, 1, 1);
+        var p2Fill = Enumerable.Range(0, 4)
+            .Select(i => new Piece(Guid.NewGuid(), $"P2Fill{i}", p2, EntryPointType.Borders, MovementType.Orthogonal, 1, 1));
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(new[] { p1Piece }.Concat(p1Fill)));
+        game.SetLineup(p2, new Lineup(new[] { p2Piece }.Concat(p2Fill)));
+        game.Start();
+        game.AdvancePhase(); // CoinSpawn → PlacePhase
+        game.PlacePiece(p1, p1Piece.Id, p1Pos ?? new Position(0, 3));
+        game.PlacePiece(p2, p2Piece.Id, p2Pos ?? new Position(7, 3)); // → MovePhase
+
+        return (game, p1, p2, p1Piece, p2Piece);
+    }
+
+    [Fact]
+    public void HasPieceMovedThisTurn_BeforeAnyMove_ReturnsFalse()
+    {
+        var (game, _, _, p1Piece, _) = GameInMovePhase();
+
+        Assert.False(game.HasPieceMovedThisTurn(p1Piece.Id));
+    }
+
+    [Fact]
+    public void HasPieceMovedThisTurn_AfterMovingPiece_ReturnsTrue()
+    {
+        var (game, p1, _, p1Piece, _) = GameInMovePhase();
+
+        game.MovePiece(p1, p1Piece.Id, new List<IReadOnlyList<Position>>
+        {
+            new List<Position> { new(0, 4) }
+        });
+
+        Assert.True(game.HasPieceMovedThisTurn(p1Piece.Id));
+    }
+
+    [Fact]
+    public void HasPieceMovedThisTurn_AfterSkipMovement_ReturnsTrueForAllOnBoardPieces()
+    {
+        var (game, p1, _, p1Piece, _) = GameInMovePhase();
+
+        game.SkipMovement(p1);
+
+        Assert.True(game.HasPieceMovedThisTurn(p1Piece.Id));
+    }
+
+    [Fact]
+    public void HasPieceMovedThisTurn_ResetsAtStartOfNextMovePhase()
+    {
+        var (game, p1, p2, p1Piece, _) = GameInMovePhase();
+
+        // Complete the move phase for both players to advance to the next turn.
+        game.SkipMovement(p1);
+        game.SkipMovement(p2);
+
+        // Advance through turn 2's CoinSpawn and PlacePhase into its MovePhase, where the
+        // moved-piece markers are cleared.
+        game.AdvancePhase();      // CoinSpawn → PlacePhase
+        game.SkipPlacement(p1);
+        game.SkipPlacement(p2);   // → MovePhase (markers cleared)
+
+        Assert.False(game.HasPieceMovedThisTurn(p1Piece.Id));
+    }
+
+    [Fact]
+    public void HasPieceMovedThisTurn_UnknownPieceId_ReturnsFalse()
+    {
+        var (game, _, _, _, _) = GameInMovePhase();
+
+        Assert.False(game.HasPieceMovedThisTurn(Guid.NewGuid()));
+    }
+}

--- a/tests/ScrambleCoin.Domain.Tests/PassiveAbilitiesTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/PassiveAbilitiesTests.cs
@@ -362,7 +362,7 @@ public class PassiveAbilitiesTests
         // Turn flow: PlacePhase → MovePhase → (turn ends, next turn starts)
         // We're currently in turn 1 MovePhase
         // Need to advance to turn 5 MovePhase start
-        for (int turn = 2; turn <= 5; turn++)
+        for (var turn = 2; turn <= 5; turn++)
         {
             game.AdvancePhase();  // → CoinSpawn
             game.AdvancePhase();  // → PlacePhase  

--- a/tests/ScrambleCoin.Domain.Tests/PieceFactoryTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/PieceFactoryTests.cs
@@ -106,15 +106,8 @@ public class PieceFactoryTests
 
     // ── Parameterized: all starter pieces return a non-null Piece ────────────
 
-    public static IEnumerable<object[]> StarterPieceNames =>
-        new List<object[]>
-        {
-            new object[] { "Mickey"  },
-            new object[] { "Minnie"  },
-            new object[] { "Donald"  },
-            new object[] { "Goofy"   },
-            new object[] { "Scrooge" }
-        };
+    public static TheoryData<string> StarterPieceNames =>
+    ["Mickey", "Minnie", "Donald", "Goofy", "Scrooge"];
 
     [Theory]
     [MemberData(nameof(StarterPieceNames))]

--- a/tests/ScrambleCoin.Domain.Tests/PieceTests.cs
+++ b/tests/ScrambleCoin.Domain.Tests/PieceTests.cs
@@ -332,7 +332,7 @@ public class PieceTests
         var piece = PieceFactory.Any();
 
         // should be a no-op without throwing
-        var ex = Record.Exception(() => piece.RemoveFromBoard());
+        var ex = Record.Exception(piece.RemoveFromBoard);
         Assert.Null(ex);
     }
 }


### PR DESCRIPTION
## Summary
Adds a server-controlled CPU **villain** opponent for **solo mode** games. The bot plays as PlayerOne (moves first); the villain plays as PlayerTwo and is fully driven by the server — no human/bot input. The villain uses a simple greedy strategy and acts automatically after the bot, dispatching its decisions through the **same** MediatR commands bots use (no special domain path).

Closes #41.

> **Base branch:** this PR targets `milestone/event-ready` (the branch it was built on), not `main`.

## Changes
- `Services/IVillainStrategy.cs`: `IVillainStrategy` + `VillainAction` union (Placement/SkipPlacement/Movement/SkipMovement).
- `Services/Villains/GreedyVillainStrategy.cs`: greedy AI — place on nearest free legal entry tile (respects EntryPointType, AvailableFromTurn, 3-piece cap); move each piece toward the nearest coin with a Domain-legal move (Orthogonal/Diagonal/AnyDirection/Jump/Charge/Ethereal + multi-segment); simulates Elsa ice-patch slides between segments; skips when capped/blocked.
- `Services/Villains/Implementations/{Elsa,Ursula,Gaston}Strategy.cs` + `VillainRegistry.cs`: 3 villains with hardcoded 5-piece lineups (Elsa: Mickey, Donald, WALL•E, Merlin, Scrooge · Ursula: Mickey, Donald, Anna, Goofy, Cinderella · Gaston: Minnie, Goofy, Donald, Scrooge, Mickey).
- `Services/Villains/IVillainStrategyFactory.cs`: factory + slug-tolerant lookup, default-lineup fallback.
- `Services/VillainActionDispatcher.cs`: maps a `VillainAction` to existing `Games/VillainActions/*` MediatR commands.
- `Services/VillainAutomationService.cs`: `EnsureVillainActsIfNeededAsync` — no-op for non-solo; drives villain turns with a safety cap; isolates villain-side failures (logs Error + dispatches a skip so the bot request can't 500 and the game can't deadlock).
- `Games/SoloMode/CreateSoloGame/CreateSoloGameCommandHandler.cs`: registers the villain lineup via `SetLineup` at creation.
- `Games/MovePiece/MovePieceCommandHandler.cs` & `Games/SubmitPlacement/SubmitPlacementCommandHandler.cs`: hook to trigger villain automation after the bot acts (no-op for non-solo).
- `Domain/Entities/Game.Movement.cs`: pure read accessor `HasPieceMovedThisTurn(Guid)`.
- DI registration in `ScrambleCoin.Api/Program.cs` and `ScrambleCoin.Web/Program.cs`.

## Assumptions made
- Villain lineups were **confirmed with the requester** (the issue asked to confirm before assuming): the three lineups listed above.
- The 12 other catalogue villains (no dedicated strategy/lineup yet) fall back to a generic default lineup and the shared greedy strategy so solo-game creation never fails.

## Testing
- Unit/integration tests added: villain strategy (place / skip-at-cap / move-toward-coin / skip-when-blocked / no-coins), **multi-segment move over an ice patch applied to the real Domain** (regression guard for the ice-slide simulation), registry lineups + slug tolerance + fallback, factory resolution, dispatcher command mapping, automation no-op/drive-loop/failure-isolation, solo-create lineup registration, and the `HasPieceMovedThisTurn` accessor.
- `dotnet test`: Domain **678 passed**, Application **312 passed**. Build clean (0 errors). E2E not run (needs a running app).

## Manual test plan
- [ ] Manual test plan posted on the issue (incl. ice-patch scenario: bot fields an Elsa piece, villain = Ursula, force Anna/Cinderella across ice — verify no 500, no deadlock)
- [ ] Manual tests executed and passed

---
- [ ] Domain (read accessor only)
- [x] Application
- [ ] Infrastructure
- [x] Web / REST API (DI + handler hook)
- [ ] SignalR
- [ ] Tournament / Leaderboard
- [ ] UI (Blazor)

---

## Bot API contract
- [x] No API endpoints were added or changed

---

## Review cycles
- Implementation reviews: 1 (CHANGES REQUIRED → APPROVED)
- Test reviews: 1 (CHANGES REQUIRED → APPROVED)

## Version bump
`minor` (issue label: `feature`).