### PR TITLE
Spectator page: distinguish player vs villain piece colours

### DIFF
--- a/src/ScrambleCoin.Application/Games/GetBoardState/BoardStateDto.cs
+++ b/src/ScrambleCoin.Application/Games/GetBoardState/BoardStateDto.cs
@@ -13,6 +13,15 @@ namespace ScrambleCoin.Application.Games.GetBoardState;
 /// <param name="OpponentPieces">All pieces belonging to the opponent.</param>
 /// <param name="AvailableCoins">All coin tiles currently on the board.</param>
 /// <param name="ActivePlayer">The playerId of the player whose turn it is, or null outside MovePhase.</param>
+/// <param name="IsSoloMode">
+/// True when the game is a solo-mode game (bot vs. villain/CPU). In solo mode PlayerTwo is the villain,
+/// which spectator UIs use to render PlayerTwo's pieces in the distinct villain colour. Bot-facing callers
+/// can ignore this field.
+/// </param>
+/// <param name="VillainId">
+/// In solo mode, the slug/id of the villain controlling PlayerTwo (e.g. "elsa"); null otherwise.
+/// Useful for spectator tooltips. Bot-facing callers can ignore this field.
+/// </param>
 public sealed record BoardStateDto(
     int Turn,
     string? Phase,
@@ -22,7 +31,9 @@ public sealed record BoardStateDto(
     IReadOnlyList<PieceDto> YourPieces,
     IReadOnlyList<PieceDto> OpponentPieces,
     IReadOnlyList<CoinDto> AvailableCoins,
-    string? ActivePlayer);
+    string? ActivePlayer,
+    bool IsSoloMode = false,
+    string? VillainId = null);
 
 /// <summary>The board container: holds the flat list of all 64 tiles.</summary>
 /// <param name="Tiles">All tiles on the 8×8 board, in row-major order.</param>

--- a/src/ScrambleCoin.Application/Games/GetBoardState/GetSpectatorBoardStateQueryHandler.cs
+++ b/src/ScrambleCoin.Application/Games/GetBoardState/GetSpectatorBoardStateQueryHandler.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using MediatR;
 using ScrambleCoin.Application.Interfaces;
 using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
 using ScrambleCoin.Domain.Obstacles;
 using ScrambleCoin.Domain.ValueObjects;
 
@@ -52,7 +53,9 @@ public sealed class GetSpectatorBoardStateQueryHandler : IRequestHandler<GetSpec
             YourPieces: playerOnePieces,
             OpponentPieces: playerTwoPieces,
             AvailableCoins: availableCoins,
-            ActivePlayer: activePlayer);
+            ActivePlayer: activePlayer,
+            IsSoloMode: game.GameMode == GameMode.Solo,
+            VillainId: game.GameMode == GameMode.Solo ? game.VillainId : null);
     }
 
     // ── Private mapping helpers ───────────────────────────────────────────────

--- a/src/ScrambleCoin.Web/Pages/Spectate.razor
+++ b/src/ScrambleCoin.Web/Pages/Spectate.razor
@@ -231,7 +231,8 @@
                        PlayerOneId="_playerOneId"
                        GameEnded="_gameEnded"
                        WinnerId="_winnerId"
-                       IsDraw="_isDraw" />
+                       IsDraw="_isDraw"
+                       IsSoloMode="_boardState?.IsSoloMode ?? false" />
         </div>
 
         <!-- Legend -->
@@ -242,7 +243,14 @@
             <span class="legend-item"><span class="legend-swatch" style="background:#e65100;"></span> Gold Coin</span>
             <span class="legend-item"><span class="legend-swatch" style="background:#37474f;"></span> Silver Coin</span>
             <span class="legend-item"><span class="legend-swatch" style="background:#0d47a1; border-radius: 50%;"></span> P1 Piece</span>
-            <span class="legend-item"><span class="legend-swatch" style="background:#b71c1c; border-radius: 50%;"></span> P2 Piece</span>
+            @if (_boardState?.IsSoloMode == true)
+            {
+                <span class="legend-item"><span class="legend-swatch" style="background:#4527a0; border-radius: 50%;"></span> Villain (CPU)</span>
+            }
+            else
+            {
+                <span class="legend-item"><span class="legend-swatch" style="background:#b71c1c; border-radius: 50%;"></span> P2 Piece</span>
+            }
             <span class="legend-item"><span class="legend-swatch" style="background: rgba(179,229,252,0.5);"></span> Ice Patch</span>
             <span class="legend-item"><span class="legend-swatch" style="background:#ff9800;"></span> Fence</span>
         </div>

--- a/src/ScrambleCoin.Web/Shared/GameBoard.razor
+++ b/src/ScrambleCoin.Web/Shared/GameBoard.razor
@@ -114,6 +114,7 @@
 
     .piece-p1 { background: radial-gradient(circle at 35% 35%, #1e88e5, #0d47a1); }
     .piece-p2 { background: radial-gradient(circle at 35% 35%, #e53935, #b71c1c); }
+    .piece-villain { background: radial-gradient(circle at 35% 35%, #7e57c2, #4527a0); }
 
     .piece-name {
         font-size: 0.48rem;
@@ -188,6 +189,7 @@
     [Parameter] public bool GameEnded { get; set; }
     [Parameter] public Guid? WinnerId { get; set; }
     [Parameter] public bool IsDraw { get; set; }
+    [Parameter] public bool IsSoloMode { get; set; }
 
     private string? _previousPhase;
     private bool _showBanner;
@@ -331,12 +333,13 @@
                 @foreach (var piece in AllPlacedPieces())
                 {
                     var isP1 = IsPlayerOnePiece(piece);
+                    var pieceClass = isP1 ? "piece-p1" : (IsSoloMode ? "piece-villain" : "piece-p2");
                     var top  = piece.Position!.Row * 68;
                     var left = piece.Position!.Col * 68;
                     <div class="piece-token"
                          @key="piece.PieceId"
                          style="top: @(top)px; left: @(left)px;">
-                        <div class="piece-bubble @(isP1 ? "piece-p1" : "piece-p2")">
+                        <div class="piece-bubble @pieceClass">
                             @PieceEmoji(piece.Name)
                         </div>
                         <div class="piece-name">@piece.Name</div>

--- a/src/ScrambleCoin.Web/Shared/GameBoard.razor
+++ b/src/ScrambleCoin.Web/Shared/GameBoard.razor
@@ -333,7 +333,7 @@
                 @foreach (var piece in AllPlacedPieces())
                 {
                     var isP1 = IsPlayerOnePiece(piece);
-                    var pieceClass = isP1 ? "piece-p1" : (IsSoloMode ? "piece-villain" : "piece-p2");
+                    var pieceClass = isP1 ? "piece-p1" : IsSoloMode ? "piece-villain" : "piece-p2";
                     var top  = piece.Position!.Row * 68;
                     var left = piece.Position!.Col * 68;
                     <div class="piece-token"

--- a/tests/ScrambleCoin.Application.Tests/GetSpectatorBoardStateQueryHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/GetSpectatorBoardStateQueryHandlerTests.cs
@@ -22,7 +22,7 @@ public class GetSpectatorBoardStateQueryHandlerTests
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     /// <summary>Creates a started game (CoinSpawn phase) with both lineups set.</summary>
-    private static (Game game, Guid p1, Guid p2) NewStartedGame()
+    private static Game NewStartedGame()
     {
         var p1 = Guid.NewGuid();
         var p2 = Guid.NewGuid();
@@ -39,7 +39,7 @@ public class GetSpectatorBoardStateQueryHandlerTests
         game.SetLineup(p2, new Lineup(pieces2));
         game.Start(); // → TurnNumber = 1, Phase = CoinSpawn
 
-        return (game, p1, p2);
+        return game;
     }
 
     private static GetSpectatorBoardStateQueryHandler BuildHandler(IGameRepository gameRepo)
@@ -51,7 +51,7 @@ public class GetSpectatorBoardStateQueryHandlerTests
     public async Task Handle_SoloGame_SetsIsSoloModeTrue()
     {
         // Arrange
-        var (game, _, _) = NewStartedGame();
+        var game = NewStartedGame();
         game.GameMode = GameMode.Solo;
         game.VillainId = "elsa";
 
@@ -71,7 +71,7 @@ public class GetSpectatorBoardStateQueryHandlerTests
     public async Task Handle_SoloGame_MapsVillainId()
     {
         // Arrange
-        var (game, _, _) = NewStartedGame();
+        var game = NewStartedGame();
         game.GameMode = GameMode.Solo;
         game.VillainId = "elsa";
 
@@ -93,7 +93,7 @@ public class GetSpectatorBoardStateQueryHandlerTests
     public async Task Handle_StandardGame_SetsIsSoloModeFalse()
     {
         // Arrange — default GameMode is Standard (bot vs bot)
-        var (game, _, _) = NewStartedGame();
+        var game = NewStartedGame();
 
         var gameRepo = Substitute.For<IGameRepository>();
         gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
@@ -111,7 +111,7 @@ public class GetSpectatorBoardStateQueryHandlerTests
     public async Task Handle_StandardGame_LeavesVillainIdNull()
     {
         // Arrange — a stray VillainId must NOT leak through when the game is not solo
-        var (game, _, _) = NewStartedGame();
+        var game = NewStartedGame();
         game.GameMode = GameMode.Standard;
         game.VillainId = "elsa";
 

--- a/tests/ScrambleCoin.Application.Tests/GetSpectatorBoardStateQueryHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/GetSpectatorBoardStateQueryHandlerTests.cs
@@ -1,0 +1,129 @@
+using NSubstitute;
+using ScrambleCoin.Application.Games.GetBoardState;
+using ScrambleCoin.Application.Interfaces;
+using ScrambleCoin.Domain.Entities;
+using ScrambleCoin.Domain.Enums;
+using ScrambleCoin.Domain.ValueObjects;
+
+namespace ScrambleCoin.Application.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="GetSpectatorBoardStateQueryHandler"/> — Issue #107.
+/// Focuses on the mapping of the spectator-only <see cref="BoardStateDto.IsSoloMode"/>
+/// and <see cref="BoardStateDto.VillainId"/> fields used to colour villain pieces.
+/// </summary>
+public class GetSpectatorBoardStateQueryHandlerTests
+{
+    // ── Constants ─────────────────────────────────────────────────────────────
+
+    private static readonly IReadOnlyList<string> DefaultLineup =
+        ["Mickey", "Minnie", "Donald", "Goofy", "Scrooge"];
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>Creates a started game (CoinSpawn phase) with both lineups set.</summary>
+    private static (Game game, Guid p1, Guid p2) NewStartedGame()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        var pieces1 = DefaultLineup
+            .Select(n => new Piece(Guid.NewGuid(), n, p1, EntryPointType.Borders, MovementType.Orthogonal, 3, 1))
+            .ToList();
+        var pieces2 = DefaultLineup
+            .Select(n => new Piece(Guid.NewGuid(), n, p2, EntryPointType.Borders, MovementType.Orthogonal, 3, 1))
+            .ToList();
+
+        var game = new Game(p1, p2, new Board());
+        game.SetLineup(p1, new Lineup(pieces1));
+        game.SetLineup(p2, new Lineup(pieces2));
+        game.Start(); // → TurnNumber = 1, Phase = CoinSpawn
+
+        return (game, p1, p2);
+    }
+
+    private static GetSpectatorBoardStateQueryHandler BuildHandler(IGameRepository gameRepo)
+        => new(gameRepo);
+
+    // ── Solo mode ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_SoloGame_SetsIsSoloModeTrue()
+    {
+        // Arrange
+        var (game, _, _) = NewStartedGame();
+        game.GameMode = GameMode.Solo;
+        game.VillainId = "elsa";
+
+        var gameRepo = Substitute.For<IGameRepository>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var handler = BuildHandler(gameRepo);
+
+        // Act
+        var dto = await handler.Handle(new GetSpectatorBoardStateQuery(game.Id), CancellationToken.None);
+
+        // Assert
+        Assert.True(dto.IsSoloMode);
+    }
+
+    [Fact]
+    public async Task Handle_SoloGame_MapsVillainId()
+    {
+        // Arrange
+        var (game, _, _) = NewStartedGame();
+        game.GameMode = GameMode.Solo;
+        game.VillainId = "elsa";
+
+        var gameRepo = Substitute.For<IGameRepository>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var handler = BuildHandler(gameRepo);
+
+        // Act
+        var dto = await handler.Handle(new GetSpectatorBoardStateQuery(game.Id), CancellationToken.None);
+
+        // Assert
+        Assert.Equal("elsa", dto.VillainId);
+    }
+
+    // ── Bot-vs-bot / standard mode ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_StandardGame_SetsIsSoloModeFalse()
+    {
+        // Arrange — default GameMode is Standard (bot vs bot)
+        var (game, _, _) = NewStartedGame();
+
+        var gameRepo = Substitute.For<IGameRepository>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var handler = BuildHandler(gameRepo);
+
+        // Act
+        var dto = await handler.Handle(new GetSpectatorBoardStateQuery(game.Id), CancellationToken.None);
+
+        // Assert
+        Assert.False(dto.IsSoloMode);
+    }
+
+    [Fact]
+    public async Task Handle_StandardGame_LeavesVillainIdNull()
+    {
+        // Arrange — a stray VillainId must NOT leak through when the game is not solo
+        var (game, _, _) = NewStartedGame();
+        game.GameMode = GameMode.Standard;
+        game.VillainId = "elsa";
+
+        var gameRepo = Substitute.For<IGameRepository>();
+        gameRepo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var handler = BuildHandler(gameRepo);
+
+        // Act
+        var dto = await handler.Handle(new GetSpectatorBoardStateQuery(game.Id), CancellationToken.None);
+
+        // Assert
+        Assert.Null(dto.VillainId);
+    }
+}

--- a/tests/ScrambleCoin.Web.Tests/GameBoardComponentTests.cs
+++ b/tests/ScrambleCoin.Web.Tests/GameBoardComponentTests.cs
@@ -1,0 +1,93 @@
+using Bunit;
+using ScrambleCoin.Application.Games.GetBoardState;
+using ScrambleCoin.Web.Shared;
+
+namespace ScrambleCoin.Web.Tests;
+
+/// <summary>
+/// bUnit component tests for <c>GameBoard.razor</c> — Issue #107.
+///
+/// Verifies that PlayerOne pieces always render with the blue <c>piece-p1</c> class,
+/// while PlayerTwo pieces render as the purple <c>piece-villain</c> in solo mode and
+/// the red <c>piece-p2</c> in bot-vs-bot mode.
+///
+/// In <c>GameBoard</c>, <c>YourPieces</c> are PlayerOne and <c>OpponentPieces</c> are PlayerTwo.
+/// </summary>
+public sealed class GameBoardComponentTests
+{
+    private static PieceDto PlacedPiece(string name, int row, int col) =>
+        new(
+            PieceId: Guid.NewGuid(),
+            Name: name,
+            Position: new PositionDto(row, col),
+            MovementType: "Orthogonal",
+            MaxDistance: 3,
+            MovesPerTurn: 1,
+            IsOnBoard: true,
+            AvailableFromTurn: null);
+
+    /// <summary>Builds a board state with one placed PlayerOne piece and one placed PlayerTwo piece.</summary>
+    private static BoardStateDto BuildBoardState(bool isSoloMode) =>
+        new(
+            Turn: 1,
+            Phase: "MovePhase",
+            YourScore: 0,
+            OpponentScore: 0,
+            Board: new BoardDto([]),
+            YourPieces: [PlacedPiece("Mickey", 0, 0)],
+            OpponentPieces: [PlacedPiece("Maleficent", 7, 7)],
+            AvailableCoins: [],
+            ActivePlayer: null,
+            IsSoloMode: isSoloMode,
+            VillainId: isSoloMode ? "elsa" : null);
+
+    [Fact]
+    public void GameBoard_SoloMode_RendersPlayerOnePieceAsBlue()
+    {
+        using var ctx = new BunitContext();
+
+        var cut = ctx.Render<GameBoard>(parameters => parameters
+            .Add(p => p.BoardState, BuildBoardState(isSoloMode: true))
+            .Add(p => p.IsSoloMode, true));
+
+        Assert.Contains("piece-bubble piece-p1", cut.Markup);
+    }
+
+    [Fact]
+    public void GameBoard_SoloMode_RendersPlayerTwoPieceAsVillain()
+    {
+        using var ctx = new BunitContext();
+
+        var cut = ctx.Render<GameBoard>(parameters => parameters
+            .Add(p => p.BoardState, BuildBoardState(isSoloMode: true))
+            .Add(p => p.IsSoloMode, true));
+
+        Assert.Contains("piece-bubble piece-villain", cut.Markup);
+        Assert.DoesNotContain("piece-bubble piece-p2", cut.Markup);
+    }
+
+    [Fact]
+    public void GameBoard_BotVsBot_RendersPlayerTwoPieceAsRed()
+    {
+        using var ctx = new BunitContext();
+
+        var cut = ctx.Render<GameBoard>(parameters => parameters
+            .Add(p => p.BoardState, BuildBoardState(isSoloMode: false))
+            .Add(p => p.IsSoloMode, false));
+
+        Assert.Contains("piece-bubble piece-p2", cut.Markup);
+        Assert.DoesNotContain("piece-bubble piece-villain", cut.Markup);
+    }
+
+    [Fact]
+    public void GameBoard_BotVsBot_RendersPlayerOnePieceAsBlue()
+    {
+        using var ctx = new BunitContext();
+
+        var cut = ctx.Render<GameBoard>(parameters => parameters
+            .Add(p => p.BoardState, BuildBoardState(isSoloMode: false))
+            .Add(p => p.IsSoloMode, false));
+
+        Assert.Contains("piece-bubble piece-p1", cut.Markup);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #107.

Pieces on the `/spectate/{gameId}` board now render in distinct colours so spectators can tell players apart, including CPU villains in solo mode.

## Changes
- `src/ScrambleCoin.Application/Games/GetBoardState/BoardStateDto.cs`: appended `IsSoloMode` (bool) and `VillainId` (string?) with defaults — bot-facing `/api/games/{id}/state` contract unchanged.
- `src/ScrambleCoin.Application/Games/GetBoardState/GetSpectatorBoardStateQueryHandler.cs`: populate `IsSoloMode = game.GameMode == GameMode.Solo` and `VillainId` (villain slug when solo, else null).
- `src/ScrambleCoin.Web/Shared/GameBoard.razor`: new `IsSoloMode` parameter + `.piece-villain` purple class; piece class = `isP1 ? "piece-p1" : (IsSoloMode ? "piece-villain" : "piece-p2")`. P1 always blue.
- `src/ScrambleCoin.Web/Pages/Spectate.razor`: pass `IsSoloMode` to GameBoard; mode-aware legend ("P2 Piece" <-> "Villain (CPU)").

### Colours
- P1 = blue (`#0d47a1`), P2 = orange/red (`#b71c1c`), Villain/CPU (solo) = purple (`#4527a0`). Saturated gradients with white text -> legible on the dark board in light & dark MudBlazor themes.

## Testing
- Unit tests: 4 added (`GetSpectatorBoardStateQueryHandlerTests`)
- Component (bUnit) tests: 4 added (`GameBoardComponentTests`)
- E2E tests: 0

All tests pass (Application 316, Web 277). E2E excluded (needs running app + Playwright).
Manual test plan posted on issue #107 (legend + light/dark theme contrast verified manually, since the legend needs a live SignalR connection).

## Review cycles
- Implementation: 0 cycle(s)
- Tests: 0 cycle(s)

## Version bump
<!-- version label `minor` applied automatically based on issue label `ui` -->