### PR TITLE
Grafana + SQL Server: live tournament dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env before running `docker compose up -d`:
+#   cp .env.example .env
+# Then optionally edit the passwords below. The .env file is gitignored.
+MSSQL_SA_PASSWORD=ScrambleCoin_Dev!2024
+GRAFANA_ADMIN_PASSWORD=admin

--- a/.github/workflows/infra-validate.yml
+++ b/.github/workflows/infra-validate.yml
@@ -1,0 +1,37 @@
+name: Infra — Validate Grafana Provisioning
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - docker-compose.yml
+      - .env.example
+      - infra/grafana/**
+      - .github/workflows/infra-validate.yml
+
+jobs:
+  validate:
+    name: validate-grafana-provisioning
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Validate Grafana provisioning artifacts (issue #79 invariants)
+        run: python3 infra/grafana/validate_provisioning.py
+
+      - name: Validate docker-compose.yml resolves
+        run: |
+          cp .env.example .env
+          docker compose config -q
+          rm -f .env

--- a/README.md
+++ b/README.md
@@ -60,6 +60,43 @@ dotnet ef database update \
 
 ---
 
+## 📊 Live Tournament Dashboard (Grafana)
+
+A pre-provisioned [Grafana](https://grafana.com/) dashboard reads live tournament
+stats directly from the SQL Server container. No manual import or configuration is
+required — the datasource and dashboard are provisioned from `infra/grafana/`.
+
+### 1. Create your local `.env`
+
+Docker Compose auto-loads a `.env` file from the project root for the SQL Server
+and Grafana passwords. Copy the committed example and optionally edit the passwords:
+
+```bash
+cp .env.example .env
+```
+
+> `.env` is gitignored — it stays on your machine only. The defaults keep the
+> existing dev setup working (`MSSQL_SA_PASSWORD=ScrambleCoin_Dev!2024`).
+
+### 2. Start the stack
+
+```bash
+docker compose up -d
+```
+
+This starts SQL Server **and** Grafana. Grafana waits for the SQL Server health
+check to pass before starting.
+
+### 3. Open the dashboard
+
+- Browse to <http://localhost:3000>
+- Log in as `admin` / value of `GRAFANA_ADMIN_PASSWORD` (default `admin`)
+- The dashboard appears automatically under **Dashboards → "Tournament Dashboard"**
+- It refreshes every **5 s** and shows: Active Games, Games by Status, the Bot
+  Leaderboard, and Games Completed per Minute.
+
+---
+
 ## 🚀 Getting Started
 
 ### 1. Restore & Build

--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ check to pass before starting.
 - It refreshes every **5 s** and shows: Active Games, Games by Status, the Bot
   Leaderboard, and Games Completed per Minute.
 
+### 4. Validate the provisioning (optional)
+
+The Grafana provisioning artifacts (datasource, dashboard provider and the
+`tournament.json` dashboard) are checked in CI by
+[`.github/workflows/infra-validate.yml`](.github/workflows/infra-validate.yml).
+You can run the same structural validation locally:
+
+```bash
+python3 infra/grafana/validate_provisioning.py
+```
+
+It asserts the dashboard's `uid`/`refresh`, the 4 expected panels, that every
+panel's datasource `uid` matches the provisioned datasource, and that
+`docker-compose.yml` / `.env.example` keep the SA password out of source control.
+
 ---
 
 ## 🚀 Getting Started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "1433:1433"
     environment:
       ACCEPT_EULA: "Y"
-      MSSQL_SA_PASSWORD: "ScrambleCoin_Dev!2024"
+      MSSQL_SA_PASSWORD: "${MSSQL_SA_PASSWORD}"
     healthcheck:
       test:
         - CMD
@@ -16,7 +16,7 @@ services:
         - -U
         - sa
         - -P
-        - ScrambleCoin_Dev!2024
+        - ${MSSQL_SA_PASSWORD}
         - -Q
         - SELECT 1
         - -No
@@ -24,3 +24,23 @@ services:
       timeout: 5s
       retries: 10
       start_period: 30s
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: scramblecoin-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD}"
+      GF_INSTALL_PLUGINS: ""
+      MSSQL_SA_PASSWORD: "${MSSQL_SA_PASSWORD}"
+    volumes:
+      - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+
+volumes:
+  grafana-data:

--- a/infra/grafana/provisioning/dashboards/dashboards.yaml
+++ b/infra/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+providers:
+  - name: ScrambleCoin
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 10
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/infra/grafana/provisioning/dashboards/tournament.json
+++ b/infra/grafana/provisioning/dashboards/tournament.json
@@ -1,0 +1,314 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "mssql",
+        "uid": "scramblecoin-mssql"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "mssql",
+            "uid": "scramblecoin-mssql"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT COUNT(*) AS value FROM Games WHERE Status = 1;",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Games",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "mssql",
+        "uid": "scramblecoin-mssql"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "mssql",
+            "uid": "scramblecoin-mssql"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT CASE Status WHEN 0 THEN 'WaitingForBots' WHEN 1 THEN 'InProgress' WHEN 2 THEN 'Finished' WHEN 3 THEN 'Cancelled' ELSE 'Unknown' END AS metric, COUNT(*) AS value FROM Games GROUP BY Status;",
+          "refId": "A"
+        }
+      ],
+      "title": "Games by Status",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "mssql",
+        "uid": "scramblecoin-mssql"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "mssql",
+            "uid": "scramblecoin-mssql"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT BotName AS Bot, Wins, Losses, Draws, Points FROM RankingTracks ORDER BY Points DESC, Wins DESC, BotName ASC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Bot Leaderboard",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "mssql",
+        "uid": "scramblecoin-mssql"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "mssql",
+            "uid": "scramblecoin-mssql"
+          },
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT DATEADD(MINUTE, DATEDIFF(MINUTE, 0, CAST(LastMoveAt AS datetime2)), 0) AS time, COUNT(*) AS \"Games completed\" FROM Games WHERE Status = 2 AND $__timeFilter(CAST(LastMoveAt AS datetime2)) GROUP BY DATEADD(MINUTE, DATEDIFF(MINUTE, 0, CAST(LastMoveAt AS datetime2)), 0) ORDER BY 1;",
+          "refId": "A"
+        }
+      ],
+      "title": "Games Completed per Minute",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [
+    "scramblecoin",
+    "tournament"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Tournament Dashboard",
+  "uid": "scramblecoin-tournament",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/grafana/provisioning/datasources/mssql.yaml
+++ b/infra/grafana/provisioning/datasources/mssql.yaml
@@ -1,0 +1,17 @@
+apiVersion: 1
+datasources:
+  - name: ScrambleCoin SQL Server
+    uid: scramblecoin-mssql
+    type: mssql
+    access: proxy
+    url: scramblecoin-sqlserver:1433
+    user: sa
+    jsonData:
+      database: ScrambleCoin
+      encrypt: 'false'
+      maxOpenConns: 5
+      maxIdleConns: 2
+    secureJsonData:
+      password: ${MSSQL_SA_PASSWORD}
+    isDefault: true
+    editable: false

--- a/infra/grafana/validate_provisioning.py
+++ b/infra/grafana/validate_provisioning.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Structural validation for the Grafana + SQL Server tournament dashboard (issue #79).
+
+This is an infrastructure-only change, so there is no C# code to unit-test.
+Instead we assert the issue-specific invariants of the infra artifacts that are
+most likely to silently break the live dashboard:
+
+  1. tournament.json is valid JSON with refresh "5s", a fixed top-level uid, and
+     exactly the 4 expected panels.
+  2. Every panel/target datasource uid in tournament.json matches the datasource
+     uid declared in mssql.yaml (uid mismatch -> blank dashboard).
+  3. docker-compose.yml uses ${MSSQL_SA_PASSWORD} (no hard-coded plaintext SA
+     password) and declares a grafana service + grafana-data volume.
+  4. .env.example exists and defines MSSQL_SA_PASSWORD and GRAFANA_ADMIN_PASSWORD.
+
+Dependency-light: uses stdlib json; uses PyYAML if available, otherwise a tiny
+regex fallback to read the datasource uid. Exits non-zero on any failure.
+
+Run from the repo root (or anywhere — paths are resolved relative to this file):
+    python3 infra/grafana/validate_provisioning.py
+"""
+
+import json
+import os
+import re
+import sys
+
+# Repo root is two levels up from infra/grafana/
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+
+DASHBOARD = os.path.join(ROOT, "infra", "grafana", "provisioning", "dashboards", "tournament.json")
+DASHBOARD_PROVIDER = os.path.join(ROOT, "infra", "grafana", "provisioning", "dashboards", "dashboards.yaml")
+DATASOURCE = os.path.join(ROOT, "infra", "grafana", "provisioning", "datasources", "mssql.yaml")
+COMPOSE = os.path.join(ROOT, "docker-compose.yml")
+ENV_EXAMPLE = os.path.join(ROOT, ".env.example")
+
+EXPECTED_PANEL_TITLES = [
+    "Active Games",
+    "Games by Status",
+    "Bot Leaderboard",
+    "Games Completed per Minute",
+]
+PLAINTEXT_SA_PASSWORD = "ScrambleCoin_Dev!2024"
+
+_failures = []
+_checks = 0
+
+
+def check(condition, message):
+    global _checks
+    _checks += 1
+    if condition:
+        print(f"  PASS: {message}")
+    else:
+        print(f"  FAIL: {message}")
+        _failures.append(message)
+    return bool(condition)
+
+
+def load_yaml(path):
+    """Parse a YAML file. Prefer PyYAML; fall back to None (caller handles)."""
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        return None
+    with open(path, "r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def datasource_uid_via_regex(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    m = re.search(r"^\s*uid:\s*([A-Za-z0-9_\-]+)\s*$", text, re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def main():
+    print("== tournament dashboard provisioning validation (issue #79) ==\n")
+
+    # ---- Invariant 4: .env.example -------------------------------------------
+    print(".env.example:")
+    if check(os.path.isfile(ENV_EXAMPLE), ".env.example exists"):
+        env_text = open(ENV_EXAMPLE, "r", encoding="utf-8").read()
+    else:
+        env_text = ""
+    check(re.search(r"^\s*MSSQL_SA_PASSWORD\s*=", env_text, re.MULTILINE) is not None,
+          ".env.example defines MSSQL_SA_PASSWORD")
+    check(re.search(r"^\s*GRAFANA_ADMIN_PASSWORD\s*=", env_text, re.MULTILINE) is not None,
+          ".env.example defines GRAFANA_ADMIN_PASSWORD")
+
+    # ---- Invariant 3: docker-compose.yml -------------------------------------
+    print("\ndocker-compose.yml:")
+    if check(os.path.isfile(COMPOSE), "docker-compose.yml exists"):
+        compose_text = open(COMPOSE, "r", encoding="utf-8").read()
+        compose_doc = load_yaml(COMPOSE)
+    else:
+        compose_text, compose_doc = "", None
+    check(PLAINTEXT_SA_PASSWORD not in compose_text,
+          f"no hard-coded plaintext SA password ({PLAINTEXT_SA_PASSWORD!r})")
+    check("${MSSQL_SA_PASSWORD}" in compose_text,
+          "SA password is injected via ${MSSQL_SA_PASSWORD}")
+    if compose_doc is not None:
+        services = (compose_doc.get("services") or {})
+        volumes = (compose_doc.get("volumes") or {})
+        check("grafana" in services, "declares a 'grafana' service")
+        check("sqlserver" in services, "declares a 'sqlserver' service")
+        check("grafana-data" in volumes, "declares the 'grafana-data' volume")
+    else:
+        # PyYAML unavailable — fall back to textual checks.
+        check(re.search(r"^\s{2}grafana:", compose_text, re.MULTILINE) is not None,
+              "declares a 'grafana' service (text check)")
+        check("grafana-data" in compose_text, "declares the 'grafana-data' volume (text check)")
+
+    # ---- Datasource uid (needed for invariant 2) -----------------------------
+    print("\ndatasources/mssql.yaml:")
+    ds_uid = None
+    if check(os.path.isfile(DATASOURCE), "mssql.yaml exists"):
+        ds_doc = load_yaml(DATASOURCE)
+        if ds_doc is not None:
+            check(isinstance(ds_doc, dict) and "datasources" in ds_doc,
+                  "mssql.yaml parses as YAML with a 'datasources' list")
+            try:
+                ds_uid = ds_doc["datasources"][0]["uid"]
+            except (KeyError, IndexError, TypeError):
+                ds_uid = None
+        else:
+            ds_uid = datasource_uid_via_regex(DATASOURCE)
+            check(ds_uid is not None, "mssql.yaml uid readable (regex fallback)")
+    check(bool(ds_uid), f"datasource declares a uid (got {ds_uid!r})")
+
+    # ---- dashboards.yaml provider parses -------------------------------------
+    print("\ndashboards/dashboards.yaml:")
+    if check(os.path.isfile(DASHBOARD_PROVIDER), "dashboards.yaml exists"):
+        prov_doc = load_yaml(DASHBOARD_PROVIDER)
+        if prov_doc is not None:
+            check(isinstance(prov_doc, dict) and "providers" in prov_doc,
+                  "dashboards.yaml parses as YAML with a 'providers' list")
+        else:
+            print("  SKIP: PyYAML unavailable — provider YAML parse not strictly checked")
+
+    # ---- Invariants 1 & 2: tournament.json -----------------------------------
+    print("\ndashboards/tournament.json:")
+    dash = None
+    if check(os.path.isfile(DASHBOARD), "tournament.json exists"):
+        try:
+            dash = json.load(open(DASHBOARD, "r", encoding="utf-8"))
+            check(True, "tournament.json is valid JSON")
+        except json.JSONDecodeError as exc:
+            check(False, f"tournament.json is valid JSON ({exc})")
+
+    if dash is not None:
+        check(dash.get("refresh") == "5s",
+              f"dashboard refresh is '5s' (got {dash.get('refresh')!r})")
+        check(bool(dash.get("uid")),
+              f"dashboard has a fixed top-level uid (got {dash.get('uid')!r})")
+
+        panels = dash.get("panels", []) or []
+        titles = [p.get("title", "") for p in panels]
+        check(len(panels) == 4,
+              f"dashboard has exactly 4 panels (got {len(panels)}: {titles})")
+        for expected in EXPECTED_PANEL_TITLES:
+            check(any(expected.lower() in (t or "").lower() for t in titles),
+                  f"panel present with title containing {expected!r}")
+
+        # Invariant 2: every panel/target datasource uid matches the datasource uid.
+        mismatches = []
+        checked_refs = 0
+
+        def _uid_of(ds):
+            if isinstance(ds, dict):
+                return ds.get("uid")
+            return ds  # may be a string or template var
+
+        for p in panels:
+            for ref_label, ds in [("panel", p.get("datasource"))] + \
+                    [("target", t.get("datasource")) for t in (p.get("targets") or [])]:
+                if ds is None:
+                    continue
+                uid = _uid_of(ds)
+                checked_refs += 1
+                if uid != ds_uid:
+                    mismatches.append(f"{p.get('title')!r}/{ref_label}: {uid!r}")
+        check(checked_refs > 0, "tournament.json declares datasource references")
+        check(not mismatches,
+              f"all datasource uids match {ds_uid!r} "
+              f"({'OK' if not mismatches else 'mismatches: ' + '; '.join(mismatches)})")
+
+    # ---- Summary -------------------------------------------------------------
+    print("\n" + "=" * 60)
+    if _failures:
+        print(f"RESULT: FAILED — {len(_failures)} of {_checks} checks failed:")
+        for f in _failures:
+            print(f"  - {f}")
+        return 1
+    print(f"RESULT: OK — all {_checks} checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Closes #79.

Adds a **Grafana** service to `docker-compose.yml` with an auto-provisioned MSSQL datasource and a live **Tournament Dashboard** (checked into `infra/grafana/`). Zero application/C# code changes. Gives the event a live shared-screen scoreboard.

## Changes
- `docker-compose.yml`: added `grafana` service (`grafana/grafana:latest`, port 3000, `depends_on` sqlserver healthy, `grafana-data` volume). Externalised the SA password from plaintext to `${MSSQL_SA_PASSWORD}`.
- `.env.example`: committed template (`MSSQL_SA_PASSWORD`, `GRAFANA_ADMIN_PASSWORD`); real `.env` is gitignored.
- `infra/grafana/provisioning/datasources/mssql.yaml`: MSSQL datasource (uid `scramblecoin-mssql`) to `scramblecoin-sqlserver:1433`, db `ScrambleCoin`, password from env.
- `infra/grafana/provisioning/dashboards/dashboards.yaml` + `tournament.json`: file-provisioned dashboard, auto-refresh 5s, 4 panels.
- `infra/grafana/validate_provisioning.py` + `.github/workflows/infra-validate.yml`: CI validation of the provisioning artifacts.
- `README.md`: documents `cp .env.example .env` then `docker compose up -d` then open http://localhost:3000.

### Panels
1. Active Games (stat) — Games WHERE Status = 1
2. Games by Status (pie) — Games.Status INT mapped to WaitingForBots/InProgress/Finished/Cancelled
3. Bot Leaderboard (table) — RankingTracks (BotName, Wins, Losses, Draws, Points)
4. Games Completed per Minute (time series) — Games.LastMoveAt where Status = 2

## Deviations from the issue technical notes (schema reality, confirmed with maintainer)
- Leaderboard sources from **RankingTracks** (has BotName + W/L/D), not BotRegistrations (GUID-only, no names).
- Time-series uses **LastMoveAt** — the only timestamp on Games (no CreatedAt/FinishedAt).
- Status is an **INT enum** (0..3), mapped to labels in the pie query.

## Testing
- Infra validation: `validate_provisioning.py` (25 checks incl. datasource-uid consistency, no plaintext password) — passes; wired into CI. Mutation-tested (breaking a uid / injecting the password makes it fail).
- `docker compose config -q` validates with a `.env`.
- No unit/bUnit tests (infra-only, no C# code).

A manual test plan is posted on issue #79.

## Review cycles
- Implementation: 0 cycle(s)
- Tests: 0 cycle(s)

## Version bump
<!-- version label minor applied automatically based on issue labels feature/infra/ui -->
