### PR TITLE
Prometheus metrics endpoint for real-time API observability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Build context is the repo root; keep the image small and the context clean.
+**/bin/
+**/obj/
+.git/
+.gitignore
+.github/
+.vs/
+.vscode/
+.idea/
+**/appsettings.Development.json
+**/*.user
+node_modules/
+**/logs/
+*.md
+.env
+.env.*
+!.env.example
+docker-compose.yml

--- a/.github/workflows/infra-validate.yml
+++ b/.github/workflows/infra-validate.yml
@@ -8,6 +8,7 @@ on:
       - docker-compose.yml
       - .env.example
       - infra/grafana/**
+      - infra/prometheus.yml
       - .github/workflows/infra-validate.yml
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -112,6 +112,46 @@ panel's datasource `uid` matches the provisioned datasource, and that
 
 ---
 
+## 📈 Prometheus Metrics / API Observability
+
+The `ScrambleCoin.Api` exposes a Prometheus `/metrics` endpoint
+([`prometheus-net.AspNetCore`](https://github.com/prometheus-net/prometheus-net))
+with default HTTP metrics (`http_requests_received_total`,
+`http_request_duration_seconds`) plus a custom `scramblecoin_moves_total`
+counter (labelled by `game_id` / `player_id`) that increments on every committed
+move. A `prometheus` container scrapes the API every **5 s** and Grafana renders
+an **"API Health"** dashboard.
+
+### Bring up the stack
+
+```bash
+docker compose up -d
+```
+
+In addition to SQL Server and Grafana, this now also starts:
+
+- **`scramblecoin-api`** — the API, containerized and listening on
+  <http://localhost:5001> (env `Docker`, a non-Production value, so `/metrics`
+  stays exposed).
+- **`prometheus`** — Prometheus, UI at <http://localhost:9090>.
+
+### Endpoints
+
+- **Metrics**: <http://localhost:5001/metrics> (Prometheus exposition format).
+  It is **disabled in Production** (guarded by `!IsProduction()`).
+- **Prometheus targets**: <http://localhost:9090/targets>. Two scrape targets are
+  configured in [`infra/prometheus.yml`](infra/prometheus.yml):
+  `scramblecoin-api:5001` (the container, `source=container`) and
+  `host.docker.internal:5001` (a host fallback for `dotnet run`,
+  `source=host`). Whichever API instance is running shows **UP**; the other shows
+  **DOWN** — that is expected.
+- **Grafana**: the **"API Health"** dashboard appears automatically under
+  **Dashboards** alongside the Tournament dashboard. Panels: HTTP requests/sec by
+  endpoint, move-submission latency (p50/p95/p99), error rate (4xx+5xx), and moves
+  per second.
+
+---
+
 ## 🚀 Getting Started
 
 ### 1. Restore & Build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,5 +42,35 @@ services:
       sqlserver:
         condition: service_healthy
 
+  scramblecoin-api:
+    build:
+      context: .
+      dockerfile: src/ScrambleCoin.Api/Dockerfile
+    container_name: scramblecoin-api
+    ports:
+      - "5001:5001"
+    environment:
+      # Non-Production value so the /metrics endpoint stays exposed for scraping.
+      ASPNETCORE_ENVIRONMENT: "Docker"
+      ASPNETCORE_URLS: "http://+:5001"
+      ConnectionStrings__DefaultConnection: "Server=scramblecoin-sqlserver,1433;Database=ScrambleCoin;User Id=sa;Password=${MSSQL_SA_PASSWORD};TrustServerCertificate=True;"
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: scramblecoin-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./infra/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      - scramblecoin-api
+
 volumes:
   grafana-data:
+  prometheus-data:

--- a/infra/grafana/provisioning/dashboards/api-health.json
+++ b/infra/grafana/provisioning/dashboards/api-health.json
@@ -1,0 +1,291 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "scramblecoin-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "scramblecoin-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (endpoint) (rate(http_requests_received_total[1m]))",
+          "legendFormat": "{{endpoint}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Requests/sec by Endpoint",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "scramblecoin-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "scramblecoin-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket[1m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "scramblecoin-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[1m])))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "scramblecoin-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket[1m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Move Submission Latency (p50/p95/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "scramblecoin-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "scramblecoin-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_requests_received_total{code=~\"4..|5..\"}[5m])) / clamp_min(sum(rate(http_requests_received_total[5m])), 1)",
+          "legendFormat": "error rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate (4xx+5xx)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "scramblecoin-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "scramblecoin-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(scramblecoin_moves_total[1m]))",
+          "legendFormat": "moves/sec",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Moves per Second",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [
+    "scramblecoin",
+    "api"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "API Health",
+  "uid": "scramblecoin-api-health",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/grafana/provisioning/datasources/prometheus.yaml
+++ b/infra/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: ScrambleCoin Prometheus
+    type: prometheus
+    access: proxy
+    uid: scramblecoin-prometheus
+    url: http://prometheus:9090
+    isDefault: false
+    editable: false

--- a/infra/grafana/validate_provisioning.py
+++ b/infra/grafana/validate_provisioning.py
@@ -34,6 +34,20 @@ DATASOURCE = os.path.join(ROOT, "infra", "grafana", "provisioning", "datasources
 COMPOSE = os.path.join(ROOT, "docker-compose.yml")
 ENV_EXAMPLE = os.path.join(ROOT, ".env.example")
 
+# ---- Issue #80 (Prometheus API observability) artifacts ----------------------
+PROM_DATASOURCE = os.path.join(ROOT, "infra", "grafana", "provisioning", "datasources", "prometheus.yaml")
+API_DASHBOARD = os.path.join(ROOT, "infra", "grafana", "provisioning", "dashboards", "api-health.json")
+PROMETHEUS_CONFIG = os.path.join(ROOT, "infra", "prometheus.yml")
+
+PROM_DATASOURCE_UID = "scramblecoin-prometheus"
+API_DASHBOARD_UID = "scramblecoin-api-health"
+API_EXPECTED_PANEL_TITLES = [
+    "HTTP Requests",
+    "Latency",
+    "Error Rate",
+    "Moves per Second",
+]
+
 EXPECTED_PANEL_TITLES = [
     "Active Games",
     "Games by Status",
@@ -72,6 +86,141 @@ def datasource_uid_via_regex(path):
         text = fh.read()
     m = re.search(r"^\s*uid:\s*([A-Za-z0-9_\-]+)\s*$", text, re.MULTILINE)
     return m.group(1) if m else None
+
+
+def _all_datasource_uids(obj):
+    """Recursively yield every datasource uid found under panels/targets."""
+    uids = []
+
+    def _uid_of(ds):
+        if isinstance(ds, dict):
+            return ds.get("uid")
+        return ds
+
+    def walk(panels):
+        for p in panels or []:
+            ds = p.get("datasource")
+            if ds is not None:
+                uids.append(_uid_of(ds))
+            for t in (p.get("targets") or []):
+                tds = t.get("datasource")
+                if tds is not None:
+                    uids.append(_uid_of(tds))
+            # nested panels (rows)
+            if p.get("panels"):
+                walk(p.get("panels"))
+
+    walk(obj.get("panels", []))
+    return uids
+
+
+def validate_issue_80():
+    """Assert the Prometheus API-observability artifacts (issue #80)."""
+    print("\n== prometheus API observability validation (issue #80) ==")
+
+    # ---- Prometheus datasource ----------------------------------------------
+    print("\ndatasources/prometheus.yaml:")
+    prom_ds_uid = None
+    if check(os.path.isfile(PROM_DATASOURCE), "prometheus.yaml exists"):
+        ds_doc = load_yaml(PROM_DATASOURCE)
+        if ds_doc is not None:
+            check(isinstance(ds_doc, dict) and "datasources" in ds_doc,
+                  "prometheus.yaml parses as YAML with a 'datasources' list")
+            try:
+                ds0 = ds_doc["datasources"][0]
+                prom_ds_uid = ds0.get("uid")
+                check(ds0.get("type") == "prometheus",
+                      f"datasource type is 'prometheus' (got {ds0.get('type')!r})")
+            except (KeyError, IndexError, TypeError):
+                prom_ds_uid = None
+        else:
+            prom_ds_uid = datasource_uid_via_regex(PROM_DATASOURCE)
+            check(prom_ds_uid is not None, "prometheus.yaml uid readable (regex fallback)")
+    check(prom_ds_uid == PROM_DATASOURCE_UID,
+          f"datasource uid is {PROM_DATASOURCE_UID!r} (got {prom_ds_uid!r})")
+
+    # ---- api-health.json dashboard ------------------------------------------
+    print("\ndashboards/api-health.json:")
+    dash = None
+    if check(os.path.isfile(API_DASHBOARD), "api-health.json exists"):
+        try:
+            dash = json.load(open(API_DASHBOARD, "r", encoding="utf-8"))
+            check(True, "api-health.json is valid JSON")
+        except json.JSONDecodeError as exc:
+            check(False, f"api-health.json is valid JSON ({exc})")
+
+    if dash is not None:
+        check(dash.get("refresh") == "5s",
+              f"dashboard refresh is '5s' (got {dash.get('refresh')!r})")
+        check(dash.get("uid") == API_DASHBOARD_UID,
+              f"dashboard uid is {API_DASHBOARD_UID!r} (got {dash.get('uid')!r})")
+
+        panels = dash.get("panels", []) or []
+        titles = [p.get("title", "") for p in panels]
+        check(len(panels) == 4,
+              f"dashboard has exactly 4 panels (got {len(panels)}: {titles})")
+        for expected in API_EXPECTED_PANEL_TITLES:
+            check(any(expected.lower() in (t or "").lower() for t in titles),
+                  f"panel present with title containing {expected!r}")
+
+        # Every panel/target datasource uid must equal the prometheus datasource uid.
+        uids = _all_datasource_uids(dash)
+        check(len(uids) > 0, "api-health.json declares datasource references")
+        mismatches = [u for u in uids if u != PROM_DATASOURCE_UID]
+        check(not mismatches,
+              f"all datasource uids match {PROM_DATASOURCE_UID!r} "
+              f"({'OK' if not mismatches else 'mismatches: ' + repr(mismatches)})")
+
+    # ---- prometheus.yml scrape config ---------------------------------------
+    print("\ninfra/prometheus.yml:")
+    prom_doc = None
+    prom_text = ""
+    if check(os.path.isfile(PROMETHEUS_CONFIG), "prometheus.yml exists"):
+        prom_text = open(PROMETHEUS_CONFIG, "r", encoding="utf-8").read()
+        prom_doc = load_yaml(PROMETHEUS_CONFIG)
+    if prom_doc is not None:
+        scrape_interval = (prom_doc.get("global") or {}).get("scrape_interval")
+        check(scrape_interval == "5s",
+              f"global.scrape_interval is '5s' (got {scrape_interval!r})")
+        # Collect all target strings across scrape_configs.
+        all_targets = []
+        for sc in (prom_doc.get("scrape_configs") or []):
+            for static in (sc.get("static_configs") or []):
+                all_targets.extend(static.get("targets") or [])
+        check(any("scramblecoin-api:5001" in t for t in all_targets),
+              f"has a scrape target containing 'scramblecoin-api:5001' (got {all_targets})")
+        check(any("host.docker.internal:5001" in t for t in all_targets),
+              f"has a scrape target containing 'host.docker.internal:5001' (got {all_targets})")
+    else:
+        # PyYAML unavailable — fall back to textual checks.
+        check(re.search(r"scrape_interval:\s*5s", prom_text) is not None,
+              "global.scrape_interval is '5s' (text check)")
+        check("scramblecoin-api:5001" in prom_text,
+              "has a scrape target containing 'scramblecoin-api:5001' (text check)")
+        check("host.docker.internal:5001" in prom_text,
+              "has a scrape target containing 'host.docker.internal:5001' (text check)")
+
+    # ---- docker-compose.yml: prometheus + scramblecoin-api services ----------
+    print("\ndocker-compose.yml (issue #80 services):")
+    if os.path.isfile(COMPOSE):
+        compose_text = open(COMPOSE, "r", encoding="utf-8").read()
+        compose_doc = load_yaml(COMPOSE)
+    else:
+        compose_text, compose_doc = "", None
+    if compose_doc is not None:
+        services = (compose_doc.get("services") or {})
+        check("prometheus" in services, "declares a 'prometheus' service")
+        prom_svc = services.get("prometheus") or {}
+        check("prom/prometheus" in str(prom_svc.get("image", "")),
+              f"prometheus service uses 'prom/prometheus' image (got {prom_svc.get('image')!r})")
+        check("scramblecoin-api" in services, "declares a 'scramblecoin-api' service")
+    else:
+        check(re.search(r"^\s{2}prometheus:", compose_text, re.MULTILINE) is not None,
+              "declares a 'prometheus' service (text check)")
+        check("prom/prometheus" in compose_text,
+              "prometheus service uses 'prom/prometheus' image (text check)")
+        check(re.search(r"^\s{2}scramblecoin-api:", compose_text, re.MULTILINE) is not None,
+              "declares a 'scramblecoin-api' service (text check)")
 
 
 def main():
@@ -184,6 +333,9 @@ def main():
         check(not mismatches,
               f"all datasource uids match {ds_uid!r} "
               f"({'OK' if not mismatches else 'mismatches: ' + '; '.join(mismatches)})")
+
+    # ---- Issue #80: Prometheus API observability -----------------------------
+    validate_issue_80()
 
     # ---- Summary -------------------------------------------------------------
     print("\n" + "=" * 60)

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: scramblecoin-api
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['scramblecoin-api:5001']
+        labels: { source: 'container' }
+      - targets: ['host.docker.internal:5001']
+        labels: { source: 'host' }

--- a/src/ScrambleCoin.Api/Dockerfile
+++ b/src/ScrambleCoin.Api/Dockerfile
@@ -1,0 +1,26 @@
+# Multi-stage build for ScrambleCoin.Api.
+# Build context MUST be the repository root (it needs sibling projects).
+#   docker build -f src/ScrambleCoin.Api/Dockerfile -t scramblecoin-api .
+
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+# Restore first (better layer caching): copy the solution + all csproj files.
+COPY ScrambleCoin.sln ./
+COPY global.json ./
+COPY src/ScrambleCoin.Domain/ScrambleCoin.Domain.csproj src/ScrambleCoin.Domain/
+COPY src/ScrambleCoin.Application/ScrambleCoin.Application.csproj src/ScrambleCoin.Application/
+COPY src/ScrambleCoin.Infrastructure/ScrambleCoin.Infrastructure.csproj src/ScrambleCoin.Infrastructure/
+COPY src/ScrambleCoin.Api/ScrambleCoin.Api.csproj src/ScrambleCoin.Api/
+RUN dotnet restore src/ScrambleCoin.Api/ScrambleCoin.Api.csproj
+
+# Copy the rest of the source and publish.
+COPY . .
+RUN dotnet publish src/ScrambleCoin.Api/ScrambleCoin.Api.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish ./
+EXPOSE 5001
+ENV ASPNETCORE_URLS=http://+:5001
+ENTRYPOINT ["dotnet", "ScrambleCoin.Api.dll"]

--- a/src/ScrambleCoin.Api/Observability/PrometheusMoveMetrics.cs
+++ b/src/ScrambleCoin.Api/Observability/PrometheusMoveMetrics.cs
@@ -1,0 +1,20 @@
+using Prometheus;
+using ScrambleCoin.Application.Abstractions;
+
+namespace ScrambleCoin.Api.Observability;
+
+/// <summary>
+/// <c>prometheus-net</c> implementation of <see cref="IMoveMetrics"/>. Lives in the Api layer so the
+/// Application layer stays free of the metrics dependency. Increments the process-wide
+/// <c>scramblecoin_moves_total</c> counter, labelled by <c>game_id</c> and <c>player_id</c>.
+/// </summary>
+public sealed class PrometheusMoveMetrics : IMoveMetrics
+{
+    private static readonly Counter MoveCounter = Metrics.CreateCounter(
+        "scramblecoin_moves_total",
+        "Total moves submitted",
+        new CounterConfiguration { LabelNames = new[] { "game_id", "player_id" } });
+
+    public void RecordMove(Guid gameId, Guid playerId)
+        => MoveCounter.WithLabels(gameId.ToString(), playerId.ToString()).Inc();
+}

--- a/src/ScrambleCoin.Api/Observability/PrometheusMoveMetrics.cs
+++ b/src/ScrambleCoin.Api/Observability/PrometheusMoveMetrics.cs
@@ -13,7 +13,8 @@ public sealed class PrometheusMoveMetrics : IMoveMetrics
     private static readonly Counter MoveCounter = Metrics.CreateCounter(
         "scramblecoin_moves_total",
         "Total moves submitted",
-        new CounterConfiguration { LabelNames = new[] { "game_id", "player_id" } });
+        new CounterConfiguration { LabelNames = ["game_id", "player_id"]
+        });
 
     public void RecordMove(Guid gameId, Guid playerId)
         => MoveCounter.WithLabels(gameId.ToString(), playerId.ToString()).Inc();

--- a/src/ScrambleCoin.Api/Program.cs
+++ b/src/ScrambleCoin.Api/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
+using Prometheus;
 using Serilog;
 using Serilog.Events;
 using ScrambleCoin.Application.BotRegistration;
@@ -69,6 +70,11 @@ builder.Services.AddScoped<IUnitOfWork>(sp => sp.GetRequiredService<ScrambleCoin
 builder.Services.Configure<QueueOptions>(builder.Configuration.GetSection("Queue"));
 builder.Services.AddSingleton<IQueueService, QueueService>();
 
+// ── Prometheus metrics ────────────────────────────────────────────────────────
+// Singleton: the underlying scramblecoin_moves_total counter is static/process-wide.
+builder.Services.AddSingleton<ScrambleCoin.Application.Abstractions.IMoveMetrics,
+    ScrambleCoin.Api.Observability.PrometheusMoveMetrics>();
+
 // ── EF Core (SQL Server) ──────────────────────────────────────────────────────
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
     ?? "Server=(localdb)\\mssqllocaldb;Database=ScrambleCoin;Trusted_Connection=True;";
@@ -131,6 +137,10 @@ if (!app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 app.UseRouting();
+
+// Collect default HTTP metrics (http_requests_received_total, http_request_duration_seconds).
+app.UseHttpMetrics();
+
 app.UseSerilogRequestLogging();
 
 // ── Swagger UI (all environments for the event) ───────────────────────────────
@@ -165,6 +175,12 @@ app.MapGameEndpoints();
 app.MapSoloModeEndpoints();
 app.MapTournamentEndpoints();
 app.MapHub<ScrambleCoin.Api.Hubs.GameHub>("/hubs/game");
+
+// Prometheus scrape endpoint (GET /metrics) — exposed in all non-Production environments.
+if (!app.Environment.IsProduction())
+{
+    app.MapMetrics();
+}
 
 app.Run();
 

--- a/src/ScrambleCoin.Api/ScrambleCoin.Api.csproj
+++ b/src/ScrambleCoin.Api/ScrambleCoin.Api.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/ScrambleCoin.Application/Abstractions/IMoveMetrics.cs
+++ b/src/ScrambleCoin.Application/Abstractions/IMoveMetrics.cs
@@ -1,0 +1,15 @@
+namespace ScrambleCoin.Application.Abstractions;
+
+/// <summary>
+/// Abstraction for recording move-submission metrics. Implemented in the Api layer with
+/// <c>prometheus-net</c> so the Application layer stays free of any metrics-library dependency
+/// (it keeps referencing only Domain + MediatR).
+/// </summary>
+public interface IMoveMetrics
+{
+    /// <summary>
+    /// Records a single successfully-committed move for the given game and player.
+    /// Surfaces as the <c>scramblecoin_moves_total</c> counter (labelled by game/player).
+    /// </summary>
+    void RecordMove(Guid gameId, Guid playerId);
+}

--- a/src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommandHandler.cs
+++ b/src/ScrambleCoin.Application/Games/MovePiece/MovePieceCommandHandler.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
+using ScrambleCoin.Application.Abstractions;
 using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Interfaces;
 using ScrambleCoin.Application.Notifications;
@@ -28,19 +29,22 @@ public sealed class MovePieceCommandHandler : IRequestHandler<MovePieceCommand, 
     private readonly IPublisher _publisher;
     private readonly IVillainAutomationService _villainAutomationService;
     private readonly ILogger<MovePieceCommandHandler> _logger;
+    private readonly IMoveMetrics _moveMetrics;
 
     public MovePieceCommandHandler(
         IGameRepository gameRepository,
         IBotRegistrationRepository botRegistrationRepository,
         IPublisher publisher,
         IVillainAutomationService villainAutomationService,
-        ILogger<MovePieceCommandHandler> logger)
+        ILogger<MovePieceCommandHandler> logger,
+        IMoveMetrics moveMetrics)
     {
         _gameRepository = gameRepository;
         _botRegistrationRepository = botRegistrationRepository;
         _publisher = publisher;
         _villainAutomationService = villainAutomationService;
         _logger = logger;
+        _moveMetrics = moveMetrics;
     }
 
     public async Task<MoveResult> Handle(MovePieceCommand request, CancellationToken cancellationToken)
@@ -77,6 +81,9 @@ public sealed class MovePieceCommandHandler : IRequestHandler<MovePieceCommand, 
         _logger.LogInformation(
             "Piece {PieceId} moved by bot {BotId} in game {GameId} on turn {Turn}.",
             request.PieceId, playerId, request.GameId, turnNumber);
+
+        // Record the successful move for Prometheus (scramblecoin_moves_total).
+        _moveMetrics.RecordMove(request.GameId, playerId);
 
         foreach (var phaseEvent in phaseAdvancedEvents)
             await _publisher.Publish(

--- a/tests/ScrambleCoin.Application.Tests/EtherealMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/EtherealMovementIntegrationTests.cs
@@ -96,7 +96,7 @@ public class EtherealMovementIntegrationTests
             publisher ?? Substitute.For<IPublisher>(),
             Substitute.For<Services.IVillainAutomationService>(),
             Substitute.For<ILogger<MovePieceCommandHandler>>(),
-            Substitute.For<ScrambleCoin.Application.Abstractions.IMoveMetrics>());
+            Substitute.For<Abstractions.IMoveMetrics>());
 
     /// <summary>
     /// Builds a multi-step segment for Ethereal movement.

--- a/tests/ScrambleCoin.Application.Tests/EtherealMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/EtherealMovementIntegrationTests.cs
@@ -95,7 +95,8 @@ public class EtherealMovementIntegrationTests
             botRepo,
             publisher ?? Substitute.For<IPublisher>(),
             Substitute.For<Services.IVillainAutomationService>(),
-            Substitute.For<ILogger<MovePieceCommandHandler>>());
+            Substitute.For<ILogger<MovePieceCommandHandler>>(),
+            Substitute.For<ScrambleCoin.Application.Abstractions.IMoveMetrics>());
 
     /// <summary>
     /// Builds a multi-step segment for Ethereal movement.

--- a/tests/ScrambleCoin.Application.Tests/IcePatchMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/IcePatchMovementIntegrationTests.cs
@@ -252,7 +252,8 @@ public class IcePatchMovementIntegrationTests
             botRepo,
             Substitute.For<IPublisher>(),
             Substitute.For<Services.IVillainAutomationService>(),
-            Substitute.For<ILogger<MovePieceCommandHandler>>());
+            Substitute.For<ILogger<MovePieceCommandHandler>>(),
+            Substitute.For<ScrambleCoin.Application.Abstractions.IMoveMetrics>());
 
     /// <summary>
     /// Builds a segment list for orthogonal movement (one step).

--- a/tests/ScrambleCoin.Application.Tests/IcePatchMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/IcePatchMovementIntegrationTests.cs
@@ -253,7 +253,7 @@ public class IcePatchMovementIntegrationTests
             Substitute.For<IPublisher>(),
             Substitute.For<Services.IVillainAutomationService>(),
             Substitute.For<ILogger<MovePieceCommandHandler>>(),
-            Substitute.For<ScrambleCoin.Application.Abstractions.IMoveMetrics>());
+            Substitute.For<Abstractions.IMoveMetrics>());
 
     /// <summary>
     /// Builds a segment list for orthogonal movement (one step).

--- a/tests/ScrambleCoin.Application.Tests/MovePieceCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/MovePieceCommandHandlerTests.cs
@@ -91,13 +91,14 @@ public class MovePieceCommandHandlerTests
     private static MovePieceCommandHandler BuildHandler(
         IGameRepository repo,
         IBotRegistrationRepository? botRepo = null,
-        IPublisher? publisher = null)
+        IPublisher? publisher = null,
+        IMoveMetrics? moveMetrics = null)
         => new(repo,
                botRepo ?? Substitute.For<IBotRegistrationRepository>(),
                publisher ?? Substitute.For<IPublisher>(),
                Substitute.For<IVillainAutomationService>(),
                Substitute.For<ILogger<MovePieceCommandHandler>>(),
-               Substitute.For<IMoveMetrics>());
+               moveMetrics ?? Substitute.For<IMoveMetrics>());
 
     // ── Test 1: Handler delegates to domain and saves ──────────────────────────
 
@@ -149,7 +150,85 @@ public class MovePieceCommandHandlerTests
         Assert.Null(ex);
     }
 
-    // ── Test 2: Handler propagates domain exceptions ───────────────────────────
+    // ── Move metrics: scramblecoin_moves_total (Issue #80) ─────────────────────
+
+    [Fact]
+    public async Task Handle_OnSuccessfulMove_RecordsMoveMetricWithGameAndPlayerId()
+    {
+        // Arrange
+        var (game, p1, _, p1Piece, _) = GameInMovePhaseWithPieces();
+        var token = Guid.NewGuid();
+
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var moveMetrics = Substitute.For<IMoveMetrics>();
+        var handler = BuildHandler(repo, BotRepo(token, p1, game.Id), moveMetrics: moveMetrics);
+
+        IReadOnlyList<IReadOnlyList<Position>> segments = new List<IReadOnlyList<Position>>
+        {
+            new List<Position> { new(0, 4) }.AsReadOnly()
+        }.AsReadOnly();
+
+        // Act
+        await handler.Handle(new MovePieceCommand(game.Id, token, p1Piece.Id, segments), CancellationToken.None);
+
+        // Assert: the move was recorded exactly once for the correct game + player.
+        moveMetrics.Received(1).RecordMove(game.Id, p1);
+    }
+
+    [Fact]
+    public async Task Handle_WhenTokenUnauthorized_DoesNotRecordMoveMetric()
+    {
+        // Arrange: bot-registration repo returns null → UnauthorizedGameAccessException
+        // is thrown before any move is committed.
+        var (game, _, _, p1Piece, _) = GameInMovePhaseWithPieces();
+        var token = Guid.NewGuid();
+
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var botRepo = Substitute.For<IBotRegistrationRepository>();
+        botRepo.GetByTokenAsync(token, Arg.Any<CancellationToken>())
+            .Returns((DomainBotReg?)null);
+
+        var moveMetrics = Substitute.For<IMoveMetrics>();
+        var handler = BuildHandler(repo, botRepo, moveMetrics: moveMetrics);
+
+        IReadOnlyList<IReadOnlyList<Position>> segments = new List<IReadOnlyList<Position>>
+        {
+            new List<Position> { new(0, 4) }.AsReadOnly()
+        }.AsReadOnly();
+
+        // Act / Assert
+        await Assert.ThrowsAsync<UnauthorizedGameAccessException>(() =>
+            handler.Handle(new MovePieceCommand(game.Id, token, p1Piece.Id, segments), CancellationToken.None));
+
+        moveMetrics.DidNotReceive().RecordMove(Arg.Any<Guid>(), Arg.Any<Guid>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenDomainThrows_DoesNotRecordMoveMetric()
+    {
+        // Arrange: a move attempted in CoinSpawn phase makes the domain throw
+        // before the metric is recorded.
+        var (game, p1) = GameInCoinSpawnPhase();
+        var token = Guid.NewGuid();
+
+        var repo = Substitute.For<IGameRepository>();
+        repo.GetByIdAsync(game.Id, Arg.Any<CancellationToken>()).Returns(game);
+
+        var moveMetrics = Substitute.For<IMoveMetrics>();
+        var handler = BuildHandler(repo, BotRepo(token, p1, game.Id), moveMetrics: moveMetrics);
+
+        var command = new MovePieceCommand(game.Id, token, Guid.NewGuid(), new List<IReadOnlyList<Position>>());
+
+        // Act / Assert
+        await Assert.ThrowsAsync<DomainException>(() =>
+            handler.Handle(command, CancellationToken.None));
+
+        moveMetrics.DidNotReceive().RecordMove(Arg.Any<Guid>(), Arg.Any<Guid>());
+    }
 
     [Fact]
     public async Task Handle_WhenDomainThrows_ExceptionPropagates()

--- a/tests/ScrambleCoin.Application.Tests/MovePieceCommandHandlerTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/MovePieceCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using ScrambleCoin.Application.Abstractions;
 using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Games.MovePiece;
 using ScrambleCoin.Application.Interfaces;
@@ -95,7 +96,8 @@ public class MovePieceCommandHandlerTests
                botRepo ?? Substitute.For<IBotRegistrationRepository>(),
                publisher ?? Substitute.For<IPublisher>(),
                Substitute.For<IVillainAutomationService>(),
-               Substitute.For<ILogger<MovePieceCommandHandler>>());
+               Substitute.For<ILogger<MovePieceCommandHandler>>(),
+               Substitute.For<IMoveMetrics>());
 
     // ── Test 1: Handler delegates to domain and saves ──────────────────────────
 

--- a/tests/ScrambleCoin.Application.Tests/MultiStepMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/MultiStepMovementIntegrationTests.cs
@@ -110,7 +110,8 @@ public class MultiStepMovementIntegrationTests
             botRepo,
             Substitute.For<IPublisher>(),
             Substitute.For<Services.IVillainAutomationService>(),
-            Substitute.For<ILogger<MovePieceCommandHandler>>());
+            Substitute.For<ILogger<MovePieceCommandHandler>>(),
+            Substitute.For<ScrambleCoin.Application.Abstractions.IMoveMetrics>());
 
     /// <summary>
     /// Builds a multi-segment move list from individual segment paths.

--- a/tests/ScrambleCoin.Application.Tests/MultiStepMovementIntegrationTests.cs
+++ b/tests/ScrambleCoin.Application.Tests/MultiStepMovementIntegrationTests.cs
@@ -111,7 +111,7 @@ public class MultiStepMovementIntegrationTests
             Substitute.For<IPublisher>(),
             Substitute.For<Services.IVillainAutomationService>(),
             Substitute.For<ILogger<MovePieceCommandHandler>>(),
-            Substitute.For<ScrambleCoin.Application.Abstractions.IMoveMetrics>());
+            Substitute.For<Abstractions.IMoveMetrics>());
 
     /// <summary>
     /// Builds a multi-segment move list from individual segment paths.


### PR DESCRIPTION
## Summary
Closes #80.

Adds Prometheus-based real-time API observability. `ScrambleCoin.Api` exposes a `/metrics` endpoint (default HTTP metrics + a custom move counter), a `prometheus` container scrapes it, and a Grafana "API Health" dashboard (building on #79) visualises throughput, latency, error rate, and moves/sec.

## Changes
- **Application**: new `IMoveMetrics` abstraction (Abstractions/); `MovePieceCommandHandler` injects it and records a move on the committed-success path only. No prometheus-net dependency in Application (Clean Architecture preserved).
- **Api**: `PrometheusMoveMetrics` (prometheus-net impl of `IMoveMetrics`); `Program.cs` adds `UseHttpMetrics()` + `MapMetrics()` guarded by `!IsProduction()`; `prometheus-net.AspNetCore` 8.2.1. New `Dockerfile` + root `.dockerignore`.
- **Infra**: `docker-compose.yml` gains `scramblecoin-api` (containerised API) and `prometheus` (port 9090) services + `prometheus-data` volume. `infra/prometheus.yml` (5s scrape) targets both the API container and a host fallback.
- **Grafana**: `datasources/prometheus.yaml` (uid `scramblecoin-prometheus`) + `dashboards/api-health.json` (4 panels, refresh 5s).
- **Validation/CI**: extended `infra/grafana/validate_provisioning.py` (now 47 checks) + widened the infra-validate workflow path filter.
- **README**: Prometheus/observability section.

### Metrics
- `http_requests_received_total`, `http_request_duration_seconds` (default, via `UseHttpMetrics`)
- `scramblecoin_moves_total{game_id, player_id}` (custom, on successful moves)

## Design decisions (confirmed with maintainer)
1. **Both scrape targets**: the API is containerised (`scramblecoin-api`) AND a host fallback `host.docker.internal:5001` is kept in prometheus.yml. One target is UP and the other DOWN depending on whether the API runs in Docker or via `dotnet run` — by design.
2. **Custom counter via abstraction** (`IMoveMetrics` in Application, prometheus-net impl in Api) to keep Application dependency-free.

## Production guard
`/metrics` is only mapped when `!IsProduction()` (returns 404 in Production). The API container sets `ASPNETCORE_ENVIRONMENT=Docker` so it stays exposed for scraping during the event.

## Testing
- Unit tests: 3 added — records metric on success; does NOT record on unauthorized token; does NOT record on domain throw. `dotnet test` → 319 passed.
- Infra validation: validator extended (47 checks, mutation-tested) + CI.
- No E2E (excluded).

Manual test plan posted on issue #80.

## Review cycles
- Implementation: 0 cycle(s)
- Tests: 0 cycle(s)

## Version bump
<!-- version label minor applied automatically based on issue labels api/feature/infra -->
