### PR TITLE
Loki + Promtail: structured log aggregation in Grafana

### DIFF
--- a/.github/workflows/infra-validate.yml
+++ b/.github/workflows/infra-validate.yml
@@ -9,6 +9,7 @@ on:
       - .env.example
       - infra/grafana/**
       - infra/prometheus.yml
+      - infra/promtail/**
       - .github/workflows/infra-validate.yml
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -436,6 +436,10 @@ FodyWeavers.xsd
 # Logs
 logs/
 
+# Keep the Web logs dir placeholder so the Promtail bind-mount source exists
+!src/ScrambleCoin.Web/logs/
+!src/ScrambleCoin.Web/logs/.gitkeep
+
 .idea/.idea.ScrambleCoin/.idea/
 
 # Local development secrets — never commit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
     depends_on:
       sqlserver:
         condition: service_healthy
+      loki:
+        condition: service_started
 
   scramblecoin-api:
     build:
@@ -54,9 +56,29 @@ services:
       ASPNETCORE_ENVIRONMENT: "Docker"
       ASPNETCORE_URLS: "http://+:5001"
       ConnectionStrings__DefaultConnection: "Server=scramblecoin-sqlserver,1433;Database=ScrambleCoin;User Id=sa;Password=${MSSQL_SA_PASSWORD};TrustServerCertificate=True;"
+    volumes:
+      - api-logs:/app/logs
     depends_on:
       sqlserver:
         condition: service_healthy
+
+  loki:
+    image: grafana/loki:latest
+    container_name: scramblecoin-loki
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+
+  promtail:
+    image: grafana/promtail:latest
+    container_name: scramblecoin-promtail
+    command: -config.file=/etc/promtail/config.yml
+    volumes:
+      - ./infra/promtail/config.yml:/etc/promtail/config.yml:ro
+      - api-logs:/var/log/scramblecoin/api:ro
+      - ./src/ScrambleCoin.Web/logs:/var/log/scramblecoin/web:ro
+    depends_on:
+      - loki
 
   prometheus:
     image: prom/prometheus:latest
@@ -74,3 +96,4 @@ services:
 volumes:
   grafana-data:
   prometheus-data:
+  api-logs:

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,68 @@
+# ScrambleCoin — Infrastructure & Observability
+
+This directory contains the local observability stack used during the event:
+Grafana dashboards, a Prometheus scrape config, and the Loki + Promtail log
+aggregation pipeline. Everything is wired together via the repo-root
+`docker-compose.yml`.
+
+| Service     | Purpose                                   | URL                     |
+|-------------|-------------------------------------------|-------------------------|
+| Grafana     | Dashboards + Explore (metrics & logs)     | http://localhost:3000   |
+| Prometheus  | API metrics store (issue #80)             | http://localhost:9090   |
+| Loki        | Log storage (LogQL)                       | http://localhost:3100   |
+| Promtail    | Scrapes Serilog log files → Loki          | (no UI)                 |
+| SQL Server  | Game database                             | localhost:1433          |
+
+Grafana provisioning lives under `infra/grafana/provisioning/` (datasources +
+dashboards are auto-loaded on container start).
+
+## Bring it up
+
+```bash
+cp .env.example .env          # one-time: provides MSSQL_SA_PASSWORD etc.
+docker compose up -d
+```
+
+## Logs (Loki + Promtail)
+
+`ScrambleCoin.Api` and `ScrambleCoin.Web` write structured logs via Serilog's
+`JsonFormatter` to rolling daily files under `logs/`. Promtail tails those files
+and ships them to Loki:
+
+- The **API** runs in a container, so its `logs/` are exposed through the shared
+  named volume `api-logs` (mounted into both the API and Promtail containers).
+- The **Web** still runs on the host, so its
+  `src/ScrambleCoin.Web/logs/` directory is bind-mounted (read-only) into the
+  Promtail container.
+
+Because Serilog emits JSON, Promtail's `json` pipeline stage extracts structured
+fields. `level` (e.g. `Information`, `Warning`, `Error`) is promoted to a Loki
+**label** (low cardinality) for fast filtering; high-cardinality fields such as
+`GameId` are extracted for matching but **not** promoted to labels.
+
+### Verify it's working
+
+1. `docker compose up -d` — confirm `scramblecoin-loki` and `scramblecoin-promtail` start.
+2. Open http://localhost:3100/ready — should return `ready`.
+3. Open Grafana → **Explore** → select the **ScrambleCoin Loki** data source.
+4. Or open the provisioned dashboard **ScrambleCoin — Logs**.
+
+### Useful LogQL queries
+
+Find all events for a specific GameId:
+
+```logql
+{job="scramblecoin-api"} |= "<GameId>"
+```
+
+All warnings and errors from the API (quick bot-error triage):
+
+```logql
+{job="scramblecoin-api", level=~"Warning|Error"}
+```
+
+All Web logs:
+
+```logql
+{job="scramblecoin-web"}
+```

--- a/infra/grafana/provisioning/dashboards/logs.json
+++ b/infra/grafana/provisioning/dashboards/logs.json
@@ -1,0 +1,178 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "scramblecoin-loki"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "scramblecoin-loki"
+          },
+          "editorMode": "code",
+          "expr": "{job=~\"$job\", level=~\"Warning|Error\"} |= \"$search\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Live Warnings & Errors",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "scramblecoin-loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 50,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "scramblecoin-loki"
+          },
+          "editorMode": "code",
+          "expr": "sum by (level) (count_over_time({job=~\"$job\"}[$__interval]))",
+          "legendFormat": "{{level}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Log volume by level",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "scramblecoin",
+    "logs"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "multi": true,
+        "name": "job",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "scramblecoin-api",
+            "value": "scramblecoin-api"
+          },
+          {
+            "selected": false,
+            "text": "scramblecoin-web",
+            "value": "scramblecoin-web"
+          }
+        ],
+        "query": "scramblecoin-api,scramblecoin-web",
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "name": "search",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ScrambleCoin — Logs",
+  "uid": "scramblecoin-logs",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/grafana/provisioning/datasources/loki.yaml
+++ b/infra/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: ScrambleCoin Loki
+    type: loki
+    access: proxy
+    uid: scramblecoin-loki
+    url: http://loki:3100
+    isDefault: false
+    editable: false

--- a/infra/grafana/validate_provisioning.py
+++ b/infra/grafana/validate_provisioning.py
@@ -56,6 +56,18 @@ EXPECTED_PANEL_TITLES = [
 ]
 PLAINTEXT_SA_PASSWORD = "ScrambleCoin_Dev!2024"
 
+# ---- Issue #81 (Loki + Promtail log aggregation) artifacts -------------------
+LOKI_DATASOURCE = os.path.join(ROOT, "infra", "grafana", "provisioning", "datasources", "loki.yaml")
+LOGS_DASHBOARD = os.path.join(ROOT, "infra", "grafana", "provisioning", "dashboards", "logs.json")
+PROMTAIL_CONFIG = os.path.join(ROOT, "infra", "promtail", "config.yml")
+INFRA_README = os.path.join(ROOT, "infra", "README.md")
+CI_WORKFLOW = os.path.join(ROOT, ".github", "workflows", "infra-validate.yml")
+
+LOKI_DATASOURCE_UID = "scramblecoin-loki"
+LOKI_DATASOURCE_URL = "http://loki:3100"
+PROMTAIL_PUSH_URL = "http://loki:3100/loki/api/v1/push"
+README_GAMEID_QUERY = '{job="scramblecoin-api"} |= "<GameId>"'
+
 _failures = []
 _checks = 0
 
@@ -223,6 +235,227 @@ def validate_issue_80():
               "declares a 'scramblecoin-api' service (text check)")
 
 
+def validate_issue_81():
+    """Assert the Loki + Promtail log-aggregation artifacts (issue #81)."""
+    print("\n== Loki + Promtail log aggregation validation (issue #81) ==")
+
+    # ---- Loki datasource ----------------------------------------------------
+    print("\ndatasources/loki.yaml:")
+    loki_ds_uid = None
+    loki_ds0 = None
+    if check(os.path.isfile(LOKI_DATASOURCE), "loki.yaml exists"):
+        ds_doc = load_yaml(LOKI_DATASOURCE)
+        if ds_doc is not None:
+            check(isinstance(ds_doc, dict) and "datasources" in ds_doc,
+                  "loki.yaml parses as YAML with a 'datasources' list")
+            try:
+                loki_ds0 = ds_doc["datasources"][0]
+                loki_ds_uid = loki_ds0.get("uid")
+                check(loki_ds0.get("type") == "loki",
+                      f"datasource type is 'loki' (got {loki_ds0.get('type')!r})")
+                check(loki_ds0.get("url") == LOKI_DATASOURCE_URL,
+                      f"datasource url is {LOKI_DATASOURCE_URL!r} (got {loki_ds0.get('url')!r})")
+            except (KeyError, IndexError, TypeError):
+                loki_ds_uid = None
+        else:
+            loki_ds_uid = datasource_uid_via_regex(LOKI_DATASOURCE)
+            check(loki_ds_uid is not None, "loki.yaml uid readable (regex fallback)")
+            loki_text = open(LOKI_DATASOURCE, "r", encoding="utf-8").read()
+            check("type: loki" in loki_text, "datasource type is 'loki' (text check)")
+            check(LOKI_DATASOURCE_URL in loki_text,
+                  f"datasource url is {LOKI_DATASOURCE_URL!r} (text check)")
+    check(loki_ds_uid == LOKI_DATASOURCE_UID,
+          f"datasource uid is {LOKI_DATASOURCE_UID!r} (got {loki_ds_uid!r})")
+
+    # ---- logs.json dashboard ------------------------------------------------
+    print("\ndashboards/logs.json:")
+    dash = None
+    if check(os.path.isfile(LOGS_DASHBOARD), "logs.json exists"):
+        try:
+            dash = json.load(open(LOGS_DASHBOARD, "r", encoding="utf-8"))
+            check(True, "logs.json is valid JSON")
+        except json.JSONDecodeError as exc:
+            check(False, f"logs.json is valid JSON ({exc})")
+
+    if dash is not None:
+        check(bool(dash.get("uid")),
+              f"dashboard has a fixed top-level uid (got {dash.get('uid')!r})")
+
+        panels = dash.get("panels", []) or []
+        check(len(panels) >= 2,
+              f"dashboard has at least 2 panels (got {len(panels)})")
+
+        panel_types = [p.get("type") for p in panels]
+        check("logs" in panel_types,
+              f"dashboard has a 'logs'-type panel (got types {panel_types})")
+        check(any(t in ("barchart", "timeseries") for t in panel_types),
+              f"dashboard has a bar/timeseries volume panel (got types {panel_types})")
+
+        # Every panel/target datasource uid must equal the Loki datasource uid
+        # (a uid mismatch yields a blank panel).
+        uids = _all_datasource_uids(dash)
+        check(len(uids) > 0, "logs.json declares datasource references")
+        mismatches = [u for u in uids if u != LOKI_DATASOURCE_UID]
+        check(not mismatches,
+              f"all datasource uids match {LOKI_DATASOURCE_UID!r} "
+              f"({'OK' if not mismatches else 'mismatches: ' + repr(mismatches)})")
+
+        # Templating: a 'job' variable and a free-text 'search' variable.
+        tmpl = ((dash.get("templating") or {}).get("list")) or []
+        tmpl_names = [v.get("name") for v in tmpl]
+        check("job" in tmpl_names,
+              f"templating contains a 'job' variable (got {tmpl_names})")
+        search_var = next((v for v in tmpl if v.get("name") == "search"), None)
+        check(search_var is not None,
+              f"templating contains a 'search' variable (got {tmpl_names})")
+        if search_var is not None:
+            check(search_var.get("type") == "textbox",
+                  f"'search' variable is free-text (type 'textbox', got {search_var.get('type')!r})")
+
+    # ---- promtail config ----------------------------------------------------
+    print("\ninfra/promtail/config.yml:")
+    pt_doc = None
+    pt_text = ""
+    if check(os.path.isfile(PROMTAIL_CONFIG), "promtail config.yml exists"):
+        pt_text = open(PROMTAIL_CONFIG, "r", encoding="utf-8").read()
+        pt_doc = load_yaml(PROMTAIL_CONFIG)
+    if pt_doc is not None:
+        clients = pt_doc.get("clients") or []
+        client_url = clients[0].get("url") if clients else None
+        check(client_url == PROMTAIL_PUSH_URL,
+              f"clients[0].url is {PROMTAIL_PUSH_URL!r} (got {client_url!r})")
+
+        scrape_configs = pt_doc.get("scrape_configs") or []
+        check(len(scrape_configs) == 2,
+              f"exactly two scrape_configs (got {len(scrape_configs)})")
+
+        # Index scrape configs by job label.
+        jobs = {}
+        for sc in scrape_configs:
+            for static in (sc.get("static_configs") or []):
+                labels = static.get("labels") or {}
+                job = labels.get("job")
+                if job:
+                    jobs[job] = (sc, labels)
+        check("scramblecoin-api" in jobs,
+              f"has a scrape job labelled 'scramblecoin-api' (got {sorted(jobs)})")
+        check("scramblecoin-web" in jobs,
+              f"has a scrape job labelled 'scramblecoin-web' (got {sorted(jobs)})")
+
+        expected_paths = {
+            "scramblecoin-api": "scramblecoin-api-*.log",
+            "scramblecoin-web": "scramblecoin-web-*.log",
+        }
+        for job, suffix in expected_paths.items():
+            if job in jobs:
+                sc, labels = jobs[job]
+                path = labels.get("__path__", "")
+                check(path.endswith(suffix),
+                      f"{job} __path__ ends with {suffix!r} (got {path!r})")
+
+                stages = sc.get("pipeline_stages") or []
+                stage_keys = [k for st in stages if isinstance(st, dict) for k in st.keys()]
+                check("json" in stage_keys,
+                      f"{job} has a 'json' pipeline stage (got {stage_keys})")
+
+                labels_stage = next((st.get("labels") for st in stages
+                                     if isinstance(st, dict) and "labels" in st), None) or {}
+                check("level" in labels_stage,
+                      f"{job} labels stage promotes 'level' (got {list(labels_stage)})")
+                # High-cardinality fields must NOT be promoted to labels.
+                check("game_id" not in labels_stage and "GameId" not in labels_stage,
+                      f"{job} labels stage does NOT promote high-cardinality game_id "
+                      f"(got {list(labels_stage)})")
+    else:
+        # PyYAML unavailable — fall back to textual checks.
+        check(PROMTAIL_PUSH_URL in pt_text,
+              f"clients url contains {PROMTAIL_PUSH_URL!r} (text check)")
+        check("job: scramblecoin-api" in pt_text,
+              "has a scrape job labelled 'scramblecoin-api' (text check)")
+        check("job: scramblecoin-web" in pt_text,
+              "has a scrape job labelled 'scramblecoin-web' (text check)")
+        check("scramblecoin-api-*.log" in pt_text,
+              "api __path__ ends with 'scramblecoin-api-*.log' (text check)")
+        check("scramblecoin-web-*.log" in pt_text,
+              "web __path__ ends with 'scramblecoin-web-*.log' (text check)")
+
+    # ---- docker-compose.yml: loki + promtail services -----------------------
+    print("\ndocker-compose.yml (issue #81 services):")
+    if os.path.isfile(COMPOSE):
+        compose_text = open(COMPOSE, "r", encoding="utf-8").read()
+        compose_doc = load_yaml(COMPOSE)
+    else:
+        compose_text, compose_doc = "", None
+    if compose_doc is not None:
+        services = (compose_doc.get("services") or {})
+        volumes = (compose_doc.get("volumes") or {})
+
+        check("loki" in services, "declares a 'loki' service")
+        loki_svc = services.get("loki") or {}
+        check("grafana/loki" in str(loki_svc.get("image", "")),
+              f"loki service uses 'grafana/loki' image (got {loki_svc.get('image')!r})")
+
+        check("promtail" in services, "declares a 'promtail' service")
+        promtail_svc = services.get("promtail") or {}
+        check("grafana/promtail" in str(promtail_svc.get("image", "")),
+              f"promtail service uses 'grafana/promtail' image (got {promtail_svc.get('image')!r})")
+
+        check("api-logs" in volumes, "declares the top-level 'api-logs' volume")
+
+        # scramblecoin-api mounts the api-logs volume at /app/logs
+        api_svc = services.get("scramblecoin-api") or {}
+        api_mounts = [str(m) for m in (api_svc.get("volumes") or [])]
+        check(any("api-logs:/app/logs" in m for m in api_mounts),
+              f"scramblecoin-api mounts 'api-logs:/app/logs' (got {api_mounts})")
+
+        # promtail mounts: same api-logs volume (read-only), web bind, and config
+        pt_mounts = [str(m) for m in (promtail_svc.get("volumes") or [])]
+        check(any(m.startswith("api-logs:") and m.endswith(":ro") for m in pt_mounts),
+              f"promtail mounts the 'api-logs' volume read-only (got {pt_mounts})")
+        check(any("./src/ScrambleCoin.Web/logs" in m for m in pt_mounts),
+              f"promtail binds './src/ScrambleCoin.Web/logs' (got {pt_mounts})")
+        check(any("infra/promtail/config.yml" in m for m in pt_mounts),
+              f"promtail mounts its config file (got {pt_mounts})")
+
+        # depends_on relationships
+        def _depends(svc):
+            dep = svc.get("depends_on")
+            if isinstance(dep, dict):
+                return list(dep.keys())
+            if isinstance(dep, list):
+                return dep
+            return []
+        check("loki" in _depends(promtail_svc),
+              f"promtail depends_on 'loki' (got {_depends(promtail_svc)})")
+        grafana_svc = services.get("grafana") or {}
+        check("loki" in _depends(grafana_svc),
+              f"grafana depends_on includes 'loki' (got {_depends(grafana_svc)})")
+    else:
+        check(re.search(r"^\s{2}loki:", compose_text, re.MULTILINE) is not None,
+              "declares a 'loki' service (text check)")
+        check("grafana/loki" in compose_text,
+              "loki service uses 'grafana/loki' image (text check)")
+        check(re.search(r"^\s{2}promtail:", compose_text, re.MULTILINE) is not None,
+              "declares a 'promtail' service (text check)")
+        check("grafana/promtail" in compose_text,
+              "promtail service uses 'grafana/promtail' image (text check)")
+        check("api-logs" in compose_text, "declares the 'api-logs' volume (text check)")
+
+    # ---- infra/README.md documents the GameId LogQL query -------------------
+    print("\ninfra/README.md:")
+    if check(os.path.isfile(INFRA_README), "infra/README.md exists"):
+        readme_text = open(INFRA_README, "r", encoding="utf-8").read()
+        check(README_GAMEID_QUERY in readme_text,
+              f"documents the GameId LogQL query {README_GAMEID_QUERY!r}")
+
+    # ---- CI workflow includes infra/promtail in its paths filter ------------
+    print("\n.github/workflows/infra-validate.yml:")
+    if check(os.path.isfile(CI_WORKFLOW), "infra-validate.yml exists"):
+        ci_text = open(CI_WORKFLOW, "r", encoding="utf-8").read()
+        check("infra/promtail/**" in ci_text,
+              "paths filter includes 'infra/promtail/**'")
+
+
 def main():
     print("== tournament dashboard provisioning validation (issue #79) ==\n")
 
@@ -336,6 +569,9 @@ def main():
 
     # ---- Issue #80: Prometheus API observability -----------------------------
     validate_issue_80()
+
+    # ---- Issue #81: Loki + Promtail log aggregation --------------------------
+    validate_issue_81()
 
     # ---- Summary -------------------------------------------------------------
     print("\n" + "=" * 60)

--- a/infra/promtail/config.yml
+++ b/infra/promtail/config.yml
@@ -1,0 +1,46 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: scramblecoin-api
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: scramblecoin-api
+          __path__: /var/log/scramblecoin/api/scramblecoin-api-*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: Level
+            timestamp: Timestamp
+            game_id: 'Properties.GameId'
+            bot_id: 'Properties.BotId'
+      - labels:
+          level:
+      - timestamp:
+          source: timestamp
+          format: RFC3339
+
+  - job_name: scramblecoin-web
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: scramblecoin-web
+          __path__: /var/log/scramblecoin/web/scramblecoin-web-*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: Level
+            timestamp: Timestamp
+      - labels:
+          level:
+      - timestamp:
+          source: timestamp
+          format: RFC3339

--- a/src/ScrambleCoin.Api/Program.cs
+++ b/src/ScrambleCoin.Api/Program.cs
@@ -24,6 +24,7 @@ builder.Host.UseSerilog((context, services, configuration) =>
         .Enrich.WithEnvironmentName()
         .WriteTo.Console()
         .WriteTo.File(
+            formatter: new Serilog.Formatting.Json.JsonFormatter(),
             path: "logs/scramblecoin-api-.log",
             rollingInterval: RollingInterval.Day,
             retainedFileCountLimit: 7);

--- a/src/ScrambleCoin.Web/Program.cs
+++ b/src/ScrambleCoin.Web/Program.cs
@@ -33,6 +33,7 @@ try
             .Enrich.WithEnvironmentName()
             .WriteTo.Console()
             .WriteTo.File(
+                formatter: new Serilog.Formatting.Json.JsonFormatter(),
                 path: "logs/scramblecoin-web-.log",
                 rollingInterval: RollingInterval.Day,
                 retainedFileCountLimit: 7);


### PR DESCRIPTION
## Summary
Closes #81.

Adds **Loki** (log storage, :3100) + **Promtail** (file scraper) to the compose stack so Serilog logs from `ScrambleCoin.Api` and `ScrambleCoin.Web` are ingested into Loki and queryable from Grafana via LogQL. Loki = logs; Prometheus (#80) = metrics.

## Changes
- `docker-compose.yml`: add `loki` + `promtail` services and `api-logs` named volume; mount `api-logs:/app/logs` on the API container and (read-only) on Promtail; bind-mount `./src/ScrambleCoin.Web/logs` for the host-run Web; `grafana`/`promtail` depend_on `loki`.
- `infra/promtail/config.yml`: two scrape jobs (`scramblecoin-api`/`scramblecoin-web`); JSON pipeline extracts `Level`/`Timestamp`/`Properties.GameId`/`BotId`; `level` promoted to a label (game_id NOT, to avoid high cardinality).
- `infra/grafana/provisioning/datasources/loki.yaml`: Loki datasource (uid `scramblecoin-loki`).
- `infra/grafana/provisioning/dashboards/logs.json`: "ScrambleCoin — Logs" dashboard (live Warning/Error stream, log-volume-by-level chart, `job` + free-text `search` variables).
- `src/ScrambleCoin.Api/Program.cs` + `src/ScrambleCoin.Web/Program.cs`: add Serilog `JsonFormatter` to the file sink (Option A) for structured Loki fields.
- `infra/README.md`: LogQL docs incl. `{job="scramblecoin-api"} |= "<GameId>"`.
- `.github/workflows/infra-validate.yml`: add `infra/promtail/**` to the path filter.
- `infra/grafana/validate_provisioning.py`: extended with a #81 section (47 → 91 structural checks).
- `src/ScrambleCoin.Web/logs/.gitkeep` + `.gitignore` negation so the bind-mount source is tracked.

## Mixed host/container log access
The API runs in a container, so its logs flow through the shared named volume `api-logs`; the Web runs on the host, so its logs are bind-mounted. Both intentional and confirmed up front.

## Testing
- Unit tests: 0 (infra-only; no new C# business logic — JsonFormatter is config-only).
- Structural validation: infra validator extended 47 → **91 checks**, all green; `docker compose config -q` resolves.
- E2E tests: 0 added.

All automated checks pass. A manual test plan was posted on the issue; status is 🧪 Needs Manual Test.

## Review cycles
- Implementation: 0 cycle(s)
- Tests: 0 cycle(s)

## Version bump
minor (labels: feature, infra)