### PR TITLE
Deploy full stack (app + observability) to Azure Container Apps

### DIFF
--- a/.github/workflows/aca-validate.yml
+++ b/.github/workflows/aca-validate.yml
@@ -1,0 +1,58 @@
+name: Infra — Validate ACA Deploy Artifacts
+
+# Statically validates the Azure Container Apps deploy artifacts (issue #132)
+# on PRs. No Azure subscription or Docker daemon is required: we only compile
+# the bicep template and build the app projects whose Loki sink wiring must
+# keep compiling. The actual deploy is the manual workflow_dispatch
+# deploy-aca.yml workflow.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - infra/aca.bicep
+      - infra/aca.parameters.json
+      - infra/grafana/**
+      - infra/loki/**
+      - infra/prometheus/**
+      - src/ScrambleCoin.Web/Dockerfile
+      - .github/workflows/aca-validate.yml
+
+jobs:
+  validate-aca:
+    name: validate-aca
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ── Bicep compile (az is preinstalled on ubuntu-latest runners) ─────────
+      # Fails on bicep errors. The two known `use-secure-value-for-secure-inputs`
+      # warnings are tolerated because `az bicep build` returns exit 0 on
+      # warnings (we deliberately do NOT pass --error-on-warnings).
+      - name: Install Bicep
+        run: az bicep install
+
+      - name: Compile aca.bicep
+        run: az bicep build --file infra/aca.bicep
+
+      # ── App build: keep the conditional Loki sink wiring compiling ──────────
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Build API project
+        run: dotnet build src/ScrambleCoin.Api/ScrambleCoin.Api.csproj --nologo
+
+      - name: Build Web project
+        run: dotnet build src/ScrambleCoin.Web/ScrambleCoin.Web.csproj --nologo
+
+      # ── Optional, non-blocking Dockerfile lint (hadolint not yet adopted) ───
+      - name: Lint Web Dockerfile (non-blocking)
+        continue-on-error: true
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: src/ScrambleCoin.Web/Dockerfile

--- a/.github/workflows/deploy-aca.yml
+++ b/.github/workflows/deploy-aca.yml
@@ -1,0 +1,119 @@
+name: Deploy to Azure Container Apps
+
+# Manual-only deploy so it never conflicts with the App Service
+# release-and-deploy.yml workflow (which runs on push to main).
+on:
+  workflow_dispatch:
+    inputs:
+      resourceGroup:
+        description: 'Azure resource group (must already contain the Azure SQL from main.bicep)'
+        required: true
+        default: 'rg-scramblecoin'
+      acrName:
+        description: 'Azure Container Registry name (globally unique, alphanumeric, 5-50 chars)'
+        required: true
+        default: 'acrscramblecoin'
+      location:
+        description: 'Azure region'
+        required: true
+        default: 'swedencentral'
+      sqlServerFqdn:
+        description: 'Azure SQL Server FQDN (from main.bicep output sqlServerFqdn)'
+        required: true
+        default: 'sql-scramblecoin.database.windows.net'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-aca:
+    name: deploy-aca
+    runs-on: ubuntu-latest
+
+    env:
+      DOTNET_NOLOGO: true
+      RESOURCE_GROUP: ${{ github.event.inputs.resourceGroup }}
+      ACR_NAME: ${{ github.event.inputs.acrName }}
+      LOCATION: ${{ github.event.inputs.location }}
+      IMAGE_TAG: ${{ github.sha }}
+
+    steps:
+      # ── 1. Checkout ───────────────────────────────────────────────────────────
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ── 2. Azure login ────────────────────────────────────────────────────────
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      # ── 3. Ensure the ACR exists (idempotent) before pushing images ───────────
+      - name: Ensure ACR exists
+        run: |
+          az acr create \
+            --resource-group "$RESOURCE_GROUP" \
+            --name "$ACR_NAME" \
+            --sku Basic \
+            --admin-enabled true \
+            --location "$LOCATION" \
+            --only-show-errors \
+            --output none || \
+          az acr update --name "$ACR_NAME" --admin-enabled true --only-show-errors --output none
+
+      # ── 4. Build + push all images server-side (no local Docker needed) ───────
+      - name: Build API image
+        run: az acr build --registry "$ACR_NAME" --image "scramblecoin-api:$IMAGE_TAG" --file src/ScrambleCoin.Api/Dockerfile .
+
+      - name: Build Web image
+        run: az acr build --registry "$ACR_NAME" --image "scramblecoin-web:$IMAGE_TAG" --file src/ScrambleCoin.Web/Dockerfile .
+
+      - name: Build Loki image
+        run: az acr build --registry "$ACR_NAME" --image "loki:$IMAGE_TAG" --file infra/loki/Dockerfile infra/loki
+
+      - name: Build Prometheus image
+        run: az acr build --registry "$ACR_NAME" --image "prometheus:$IMAGE_TAG" --file infra/prometheus/Dockerfile infra/prometheus
+
+      - name: Build Grafana image
+        run: az acr build --registry "$ACR_NAME" --image "grafana:$IMAGE_TAG" --file infra/grafana/Dockerfile infra/grafana
+
+      # ── 5. Deploy the ACA stack ───────────────────────────────────────────────
+      - name: Deploy aca.bicep
+        run: |
+          az deployment group create \
+            --resource-group "$RESOURCE_GROUP" \
+            --template-file infra/aca.bicep \
+            --parameters infra/aca.parameters.json \
+            --parameters \
+              acrName="$ACR_NAME" \
+              location="$LOCATION" \
+              imageTag="$IMAGE_TAG" \
+              sqlServerFqdn="${{ github.event.inputs.sqlServerFqdn }}" \
+              sqlAdminPassword="${{ secrets.SQL_ADMIN_PASSWORD }}" \
+              grafanaAdminPassword="${{ secrets.GRAFANA_ADMIN_PASSWORD }}" \
+            --output json > deployment.json
+
+      # ── 6. EF Core migrations against Azure SQL ───────────────────────────────
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Install EF Core CLI tools
+        run: dotnet tool install --global dotnet-ef --version 9.*
+
+      - name: Run EF Core migrations
+        env:
+          ConnectionStrings__DefaultConnection: ${{ secrets.AZURE_SQL_CONNECTION_STRING }}
+        run: >
+          dotnet ef database update
+          --project src/ScrambleCoin.Infrastructure
+          --startup-project src/ScrambleCoin.Api
+
+      # ── 7. Echo the resulting URLs ────────────────────────────────────────────
+      - name: Show deployment URLs
+        run: |
+          echo "ACR login server : $(jq -r '.properties.outputs.acrLoginServer.value' deployment.json)"
+          echo "Web URL          : $(jq -r '.properties.outputs.webUrl.value' deployment.json)"
+          echo "API URL          : $(jq -r '.properties.outputs.apiUrl.value' deployment.json)"
+          echo "Grafana URL      : $(jq -r '.properties.outputs.grafanaUrl.value' deployment.json)"

--- a/infra/README.md
+++ b/infra/README.md
@@ -66,3 +66,114 @@ All Web logs:
 ```logql
 {job="scramblecoin-web"}
 ```
+
+---
+
+## Deploy to Azure Container Apps (ACA)
+
+The **entire stack** — Blazor Web, bot API, Grafana, Loki, Prometheus — can be
+deployed to **Azure Container Apps** for the event. This is separate from the
+App Service deploy (`release-and-deploy.yml`) and is triggered **manually**.
+
+> **Local dev is unchanged.** `docker compose` + Promtail (the "Logs (Loki +
+> Promtail)" section above) still works exactly as before. In the cloud, ACA
+> cannot bind-mount host files and cannot tail container log files across apps,
+> so logging is re-architected: the API and Web push logs **directly** to Loki
+> via the `Serilog.Sinks.Grafana.Loki` sink. That sink is **conditional** — it
+> only activates when the `Loki__Url` environment variable is set (which ACA
+> sets, and local compose does not). Prometheus/Grafana ship as **custom images**
+> that bake their config/provisioning in (since ACA can't mount the host files).
+
+### What gets provisioned
+
+`infra/aca.bicep` creates:
+
+- **Azure Container Registry** (`acr<appName>`, Basic, admin-enabled) — holds the
+  web/api images plus custom loki/prometheus/grafana images.
+- **Log Analytics workspace** (`log-<appName>-aca`) for the ACA environment.
+- **Container Apps environment** (`cae-<appName>`).
+- **Five Container Apps**:
+  - `scramblecoin-web` — external HTTPS, port 8080.
+  - `scramblecoin-api` — external HTTPS, port 5001 (keeps `/metrics` exposed —
+    see note below).
+  - `grafana` — external HTTPS, port 3000.
+  - `loki` — internal, port 3100 (ephemeral storage).
+  - `prometheus` — internal, port 9090 (ephemeral storage).
+
+**Azure SQL is reused**, not recreated — provision it once via `main.bicep`.
+
+> **Note — API `ASPNETCORE_ENVIRONMENT=Docker`:** `Program.cs` only maps the
+> Prometheus `/metrics` endpoint when the environment is **not** `Production`.
+> The `scramblecoin-api` Container App therefore runs with
+> `ASPNETCORE_ENVIRONMENT=Docker` (matching `docker-compose.yml`) so Prometheus
+> can scrape it. The Web app runs as `Production`.
+
+### Prerequisites
+
+1. An Azure subscription and the Azure CLI (`az login`).
+2. A resource group, e.g. `az group create -n rg-scramblecoin -l swedencentral`.
+3. **Azure SQL provisioned first** via `main.bicep`:
+   ```bash
+   az deployment group create \
+     -g rg-scramblecoin \
+     --template-file infra/main.bicep \
+     --parameters infra/main.parameters.json \
+     --parameters sqlAdminPassword='<your-strong-password>'
+   ```
+   Note the `sqlServerFqdn` output (e.g. `sql-scramblecoin.database.windows.net`).
+
+### GitHub secrets to set
+
+| Secret | Purpose |
+| --- | --- |
+| `AZURE_CREDENTIALS` | Service principal JSON for `azure/login` (`az ad sp create-for-rbac --sdk-auth`). |
+| `AZURE_SQL_CONNECTION_STRING` | Full Azure SQL connection string — used by the EF migration step. |
+| `SQL_ADMIN_PASSWORD` | Azure SQL admin password — injected into the API/Web connection strings and the Grafana SQL datasource. |
+| `GRAFANA_ADMIN_PASSWORD` | Grafana admin password — set as an ACA secret (never baked into the image). |
+
+### Run the deploy
+
+GitHub → **Actions** → **Deploy to Azure Container Apps** → **Run workflow**, and
+fill in the inputs (`resourceGroup`, `acrName`, `location`, `sqlServerFqdn`). The
+workflow will:
+
+1. `azure/login` with `AZURE_CREDENTIALS`.
+2. Ensure the ACR exists (idempotent).
+3. `az acr build` (server-side, no local Docker) all five images, tagged with the
+   git SHA.
+4. `az deployment group create` for `infra/aca.bicep` with `imageTag=<sha>`.
+5. Run EF Core migrations against Azure SQL.
+6. Echo the resulting **Web / API / Grafana** URLs.
+
+### Find the URLs
+
+The final **Show deployment URLs** step prints the public endpoints. You can also
+read them any time with:
+
+```bash
+az containerapp show -g rg-scramblecoin -n scramblecoin-web    --query properties.configuration.ingress.fqdn -o tsv
+az containerapp show -g rg-scramblecoin -n scramblecoin-api    --query properties.configuration.ingress.fqdn -o tsv
+az containerapp show -g rg-scramblecoin -n grafana             --query properties.configuration.ingress.fqdn -o tsv
+```
+
+> **Internal DNS note:** within the ACA environment, apps reach each other by
+> name (`http://loki:3100`, `http://prometheus:9090`, `scramblecoin-api:5001`).
+> The Grafana datasources and the API's `Loki__Url` are wired to these names.
+
+### Manual deploy without GitHub Actions
+
+You can run the same steps locally:
+
+```bash
+az acr build --registry acrscramblecoin --image scramblecoin-api:latest --file src/ScrambleCoin.Api/Dockerfile .
+az acr build --registry acrscramblecoin --image scramblecoin-web:latest --file src/ScrambleCoin.Web/Dockerfile .
+az acr build --registry acrscramblecoin --image loki:latest       --file infra/loki/Dockerfile infra/loki
+az acr build --registry acrscramblecoin --image prometheus:latest --file infra/prometheus/Dockerfile infra/prometheus
+az acr build --registry acrscramblecoin --image grafana:latest    --file infra/grafana/Dockerfile infra/grafana
+
+az deployment group create \
+  -g rg-scramblecoin \
+  --template-file infra/aca.bicep \
+  --parameters infra/aca.parameters.json \
+  --parameters sqlAdminPassword='<pwd>' grafanaAdminPassword='<pwd>' imageTag=latest
+```

--- a/infra/aca.bicep
+++ b/infra/aca.bicep
@@ -226,11 +226,11 @@ resource grafana 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'LOKI_URL'
-              value: 'http://loki:3100'
+              value: 'http://loki'
             }
             {
               name: 'PROMETHEUS_URL'
-              value: 'http://prometheus:9090'
+              value: 'http://prometheus'
             }
             {
               name: 'AZURE_SQL_HOST'
@@ -312,7 +312,7 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'Loki__Url'
-              value: 'http://loki:3100'
+              value: 'http://loki'
             }
             {
               name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
@@ -377,7 +377,7 @@ resource web 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'Loki__Url'
-              value: 'http://loki:3100'
+              value: 'http://loki'
             }
           ]
         }

--- a/infra/aca.bicep
+++ b/infra/aca.bicep
@@ -1,0 +1,406 @@
+// ---------------------------------------------------------------------------
+// ScrambleCoin — Azure Container Apps (ACA) stack (issue #132)
+//
+// Provisions: Azure Container Registry, a Log Analytics workspace, a Container
+// Apps managed environment, and five Container Apps (web, api, grafana, loki,
+// prometheus). Azure SQL is provisioned separately by infra/main.bicep and is
+// reused here via the sqlServerFqdn parameter.
+//
+// This file is intentionally separate from main.bicep (App Service stack) and
+// does NOT modify it. Validate with:  az bicep build --file infra/aca.bicep
+// ---------------------------------------------------------------------------
+
+@description('Base name for all resources.')
+param appName string = 'scramblecoin'
+
+@description('Azure region for all resources.')
+param location string = resourceGroup().location
+
+@description('Azure SQL administrator login (matches main.bicep).')
+param sqlAdminLogin string
+
+@description('Azure SQL administrator password (matches main.bicep).')
+@secure()
+param sqlAdminPassword string
+
+@description('Fully qualified domain name of the Azure SQL Server provisioned by main.bicep, e.g. sql-scramblecoin.database.windows.net')
+param sqlServerFqdn string
+
+@description('Grafana admin password (set via ACA secret, never baked into the image).')
+@secure()
+param grafanaAdminPassword string
+
+@description('Container image tag to deploy (typically the git SHA). Defaults to latest.')
+param imageTag string = 'latest'
+
+@description('Azure Container Registry name. ACR names are globally unique, alphanumeric only, 5-50 chars. Override if the derived default is taken.')
+param acrName string = 'acr${appName}'
+
+@description('Optional Application Insights connection string for the API (leave empty to disable).')
+param appInsightsConnectionString string = ''
+
+// ---------------------------------------------------------------------------
+// Derived values
+// ---------------------------------------------------------------------------
+var sqlDbName = 'sqldb-${appName}'
+var sqlConnectionString = 'Server=tcp:${sqlServerFqdn},1433;Initial Catalog=${sqlDbName};Persist Security Info=False;User ID=${sqlAdminLogin};Password=${sqlAdminPassword};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;'
+var acrLoginServer = acr.properties.loginServer
+
+// Shared registry block (ACR admin credentials) for image pull.
+var registries = [
+  {
+    server: acrLoginServer
+    username: acr.listCredentials().username
+    passwordSecretRef: 'acr-password'
+  }
+]
+var acrPasswordSecret = {
+  name: 'acr-password'
+  value: acr.listCredentials().passwords[0].value
+}
+
+// ---------------------------------------------------------------------------
+// Azure Container Registry (admin-enabled — simplest auth for the event)
+// ---------------------------------------------------------------------------
+resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: acrName
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    adminUserEnabled: true
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Log Analytics workspace for the Container Apps environment
+// ---------------------------------------------------------------------------
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: 'log-${appName}-aca'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Container Apps managed environment
+// ---------------------------------------------------------------------------
+resource managedEnvironment 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: 'cae-${appName}'
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Loki — internal ingress (observability log store, ephemeral, single replica)
+// ---------------------------------------------------------------------------
+resource loki 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'loki'
+  location: location
+  properties: {
+    managedEnvironmentId: managedEnvironment.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: false
+        targetPort: 3100
+        transport: 'http'
+      }
+      registries: registries
+      secrets: [
+        acrPasswordSecret
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'loki'
+          image: '${acrLoginServer}/loki:${imageTag}'
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prometheus — internal ingress (metrics store, ephemeral, single replica)
+// ---------------------------------------------------------------------------
+resource prometheus 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'prometheus'
+  location: location
+  properties: {
+    managedEnvironmentId: managedEnvironment.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: false
+        targetPort: 9090
+        transport: 'http'
+      }
+      registries: registries
+      secrets: [
+        acrPasswordSecret
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'prometheus'
+          image: '${acrLoginServer}/prometheus:${imageTag}'
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Grafana — external ingress (dashboards)
+// ---------------------------------------------------------------------------
+resource grafana 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'grafana'
+  location: location
+  properties: {
+    managedEnvironmentId: managedEnvironment.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: true
+        targetPort: 3000
+        transport: 'http'
+      }
+      registries: registries
+      secrets: [
+        acrPasswordSecret
+        {
+          name: 'grafana-admin-password'
+          value: grafanaAdminPassword
+        }
+        {
+          name: 'azure-sql-password'
+          value: sqlAdminPassword
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'grafana'
+          image: '${acrLoginServer}/grafana:${imageTag}'
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            {
+              name: 'GF_SECURITY_ADMIN_PASSWORD'
+              secretRef: 'grafana-admin-password'
+            }
+            {
+              name: 'LOKI_URL'
+              value: 'http://loki:3100'
+            }
+            {
+              name: 'PROMETHEUS_URL'
+              value: 'http://prometheus:9090'
+            }
+            {
+              name: 'AZURE_SQL_HOST'
+              value: '${sqlServerFqdn}:1433'
+            }
+            {
+              name: 'AZURE_SQL_DB'
+              value: sqlDbName
+            }
+            {
+              name: 'AZURE_SQL_USER'
+              value: sqlAdminLogin
+            }
+            {
+              name: 'AZURE_SQL_PASSWORD'
+              secretRef: 'azure-sql-password'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ScrambleCoin API — external ingress (bot REST API + Prometheus /metrics)
+//
+// ASPNETCORE_ENVIRONMENT is set to 'Docker' (not 'Production') because
+// Program.cs only maps the Prometheus /metrics endpoint when NOT Production.
+// Using 'Docker' keeps /metrics exposed so Prometheus can scrape it (matching
+// docker-compose.yml's api service).
+// ---------------------------------------------------------------------------
+resource api 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'scramblecoin-api'
+  location: location
+  properties: {
+    managedEnvironmentId: managedEnvironment.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: true
+        targetPort: 5001
+        transport: 'http'
+      }
+      registries: registries
+      secrets: [
+        acrPasswordSecret
+        {
+          name: 'sql-connection-string'
+          value: sqlConnectionString
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'scramblecoin-api'
+          image: '${acrLoginServer}/scramblecoin-api:${imageTag}'
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            {
+              name: 'ASPNETCORE_URLS'
+              value: 'http://+:5001'
+            }
+            {
+              name: 'ASPNETCORE_ENVIRONMENT'
+              value: 'Docker'
+            }
+            {
+              name: 'ConnectionStrings__DefaultConnection'
+              secretRef: 'sql-connection-string'
+            }
+            {
+              name: 'Loki__Url'
+              value: 'http://loki:3100'
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              value: appInsightsConnectionString
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 3
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ScrambleCoin Web — external ingress (Blazor Server)
+// ---------------------------------------------------------------------------
+resource web 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'scramblecoin-web'
+  location: location
+  properties: {
+    managedEnvironmentId: managedEnvironment.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: true
+        targetPort: 8080
+        transport: 'http'
+      }
+      registries: registries
+      secrets: [
+        acrPasswordSecret
+        {
+          name: 'sql-connection-string'
+          value: sqlConnectionString
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'scramblecoin-web'
+          image: '${acrLoginServer}/scramblecoin-web:${imageTag}'
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            {
+              name: 'ASPNETCORE_URLS'
+              value: 'http://+:8080'
+            }
+            {
+              name: 'ASPNETCORE_ENVIRONMENT'
+              value: 'Production'
+            }
+            {
+              name: 'ConnectionStrings__DefaultConnection'
+              secretRef: 'sql-connection-string'
+            }
+            {
+              name: 'Loki__Url'
+              value: 'http://loki:3100'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 3
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Outputs
+// ---------------------------------------------------------------------------
+@description('ACR login server (e.g. acrscramblecoin.azurecr.io).')
+output acrLoginServer string = acrLoginServer
+
+@description('Public HTTPS URL of the Blazor Web app.')
+output webUrl string = 'https://${web.properties.configuration.ingress.fqdn}'
+
+@description('Public HTTPS URL of the bot REST API.')
+output apiUrl string = 'https://${api.properties.configuration.ingress.fqdn}'
+
+@description('Public HTTPS URL of Grafana.')
+output grafanaUrl string = 'https://${grafana.properties.configuration.ingress.fqdn}'

--- a/infra/aca.json
+++ b/infra/aca.json
@@ -1,0 +1,486 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.40.2.10011",
+      "templateHash": "5075175339163909713"
+    }
+  },
+  "parameters": {
+    "appName": {
+      "type": "string",
+      "defaultValue": "scramblecoin",
+      "metadata": {
+        "description": "Base name for all resources."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for all resources."
+      }
+    },
+    "sqlAdminLogin": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure SQL administrator login (matches main.bicep)."
+      }
+    },
+    "sqlAdminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Azure SQL administrator password (matches main.bicep)."
+      }
+    },
+    "sqlServerFqdn": {
+      "type": "string",
+      "metadata": {
+        "description": "Fully qualified domain name of the Azure SQL Server provisioned by main.bicep, e.g. sql-scramblecoin.database.windows.net"
+      }
+    },
+    "grafanaAdminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Grafana admin password (set via ACA secret, never baked into the image)."
+      }
+    },
+    "imageTag": {
+      "type": "string",
+      "defaultValue": "latest",
+      "metadata": {
+        "description": "Container image tag to deploy (typically the git SHA). Defaults to latest."
+      }
+    },
+    "acrName": {
+      "type": "string",
+      "defaultValue": "[format('acr{0}', parameters('appName'))]",
+      "metadata": {
+        "description": "Azure Container Registry name. ACR names are globally unique, alphanumeric only, 5-50 chars. Override if the derived default is taken."
+      }
+    },
+    "appInsightsConnectionString": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional Application Insights connection string for the API (leave empty to disable)."
+      }
+    }
+  },
+  "variables": {
+    "sqlDbName": "[format('sqldb-{0}', parameters('appName'))]",
+    "sqlConnectionString": "[format('Server=tcp:{0},1433;Initial Catalog={1};Persist Security Info=False;User ID={2};Password={3};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;', parameters('sqlServerFqdn'), variables('sqlDbName'), parameters('sqlAdminLogin'), parameters('sqlAdminPassword'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ContainerRegistry/registries",
+      "apiVersion": "2023-07-01",
+      "name": "[parameters('acrName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Basic"
+      },
+      "properties": {
+        "adminUserEnabled": true
+      }
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2022-10-01",
+      "name": "[format('log-{0}-aca', parameters('appName'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "name": "PerGB2018"
+        },
+        "retentionInDays": 30
+      }
+    },
+    {
+      "type": "Microsoft.App/managedEnvironments",
+      "apiVersion": "2024-03-01",
+      "name": "[format('cae-{0}', parameters('appName'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "appLogsConfiguration": {
+          "destination": "log-analytics",
+          "logAnalyticsConfiguration": {
+            "customerId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', format('log-{0}-aca', parameters('appName'))), '2022-10-01').customerId]",
+            "sharedKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', format('log-{0}-aca', parameters('appName'))), '2022-10-01').primarySharedKey]"
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', format('log-{0}-aca', parameters('appName')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.App/containerApps",
+      "apiVersion": "2024-03-01",
+      "name": "loki",
+      "location": "[parameters('location')]",
+      "properties": {
+        "managedEnvironmentId": "[resourceId('Microsoft.App/managedEnvironments', format('cae-{0}', parameters('appName')))]",
+        "configuration": {
+          "activeRevisionsMode": "Single",
+          "ingress": {
+            "external": false,
+            "targetPort": 3100,
+            "transport": "http"
+          },
+          "registries": [
+            {
+              "server": "[reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer]",
+              "username": "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').username]",
+              "passwordSecretRef": "acr-password"
+            }
+          ],
+          "secrets": [
+            {
+              "name": "acr-password",
+              "value": "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').passwords[0].value]"
+            }
+          ]
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "loki",
+              "image": "[format('{0}/loki:{1}', reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer, parameters('imageTag'))]",
+              "resources": {
+                "cpu": "[json('0.5')]",
+                "memory": "1Gi"
+              }
+            }
+          ],
+          "scale": {
+            "minReplicas": 1,
+            "maxReplicas": 1
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName'))]",
+        "[resourceId('Microsoft.App/managedEnvironments', format('cae-{0}', parameters('appName')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.App/containerApps",
+      "apiVersion": "2024-03-01",
+      "name": "prometheus",
+      "location": "[parameters('location')]",
+      "properties": {
+        "managedEnvironmentId": "[resourceId('Microsoft.App/managedEnvironments', format('cae-{0}', parameters('appName')))]",
+        "configuration": {
+          "activeRevisionsMode": "Single",
+          "ingress": {
+            "external": false,
+            "targetPort": 9090,
+            "transport": "http"
+          },
+          "registries": [
+            {
+              "server": "[reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer]",
+              "username": "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').username]",
+              "passwordSecretRef": "acr-password"
+            }
+          ],
+          "secrets": [
+            {
+              "name": "acr-password",
+              "value": "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').passwords[0].value]"
+            }
+          ]
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "prometheus",
+              "image": "[format('{0}/prometheus:{1}', reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer, parameters('imageTag'))]",
+              "resources": {
+                "cpu": "[json('0.5')]",
+                "memory": "1Gi"
+              }
+            }
+          ],
+          "scale": {
+            "minReplicas": 1,
+            "maxReplicas": 1
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName'))]",
+        "[resourceId('Microsoft.App/managedEnvironments', format('cae-{0}', parameters('appName')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.App/containerApps",
+      "apiVersion": "2024-03-01",
+      "name": "grafana",
+      "location": "[parameters('location')]",
+      "properties": {
+        "managedEnvironmentId": "[resourceId('Microsoft.App/managedEnvironments', format('cae-{0}', parameters('appName')))]",
+        "configuration": {
+          "activeRevisionsMode": "Single",
+          "ingress": {
+            "external": true,
+            "targetPort": 3000,
+            "transport": "http"
+          },
+          "registries": [
+            {
+              "server": "[reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer]",
+              "username": "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').username]",
+              "passwordSecretRef": "acr-password"
+            }
+          ],
+          "secrets": [
+            {
+              "name": "acr-password",
+              "value": "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').passwords[0].value]"
+            },
+            {
+              "name": "grafana-admin-password",
+              "value": "[parameters('grafanaAdminPassword')]"
+            },
+            {
+              "name": "azure-sql-password",
+              "value": "[parameters('sqlAdminPassword')]"
+            }
+          ]
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "grafana",
+              "image": "[format('{0}/grafana:{1}', reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer, parameters('imageTag'))]",
+              "resources": {
+                "cpu": "[json('0.5')]",
+                "memory": "1Gi"
+              },
+              "env": [
+                {
+                  "name": "GF_SECURITY_ADMIN_PASSWORD",
+                  "secretRef": "grafana-admin-password"
+                },
+                {
+                  "name": "LOKI_URL",
+                  "value": "http://loki:3100"
+                },
+                {
+                  "name": "PROMETHEUS_URL",
+                  "value": "http://prometheus:9090"
+                },
+                {
+                  "name": "AZURE_SQL_HOST",
+                  "value": "[format('{0}:1433', parameters('sqlServerFqdn'))]"
+                },
+                {
+                  "name": "AZURE_SQL_DB",
+                  "value": "[variables('sqlDbName')]"
+                },
+                {
+                  "name": "AZURE_SQL_USER",
+                  "value": "[parameters('sqlAdminLogin')]"
+                },
+                {
+                  "name": "AZURE_SQL_PASSWORD",
+                  "secretRef": "azure-sql-password"
+                }
+              ]
+            }
+          ],
+          "scale": {
+            "minReplicas": 1,
+            "maxReplicas": 1
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName'))]",
+        "[resourceId('Microsoft.App/managedEnvironments', format('cae-{0}', parameters('appName')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.App/containerApps",
+      "apiVersion": "2024-03-01",
+      "name": "scramblecoin-api",
+      "location": "[parameters('location')]",
+      "properties": {
+        "managedEnvironmentId": "[resourceId('Microsoft.App/managedEnvironments', format('cae-{0}', parameters('appName')))]",
+        "configuration": {
+          "activeRevisionsMode": "Single",
+          "ingress": {
+            "external": true,
+            "targetPort": 5001,
+            "transport": "http"
+          },
+          "registries": [
+            {
+              "server": "[reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer]",
+              "username": "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').username]",
+              "passwordSecretRef": "acr-password"
+            }
+          ],
+          "secrets": [
+            {
+              "name": "acr-password",
+              "value": "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').passwords[0].value]"
+            },
+            {
+              "name": "sql-connection-string",
+              "value": "[variables('sqlConnectionString')]"
+            }
+          ]
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "scramblecoin-api",
+              "image": "[format('{0}/scramblecoin-api:{1}', reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer, parameters('imageTag'))]",
+              "resources": {
+                "cpu": "[json('0.5')]",
+                "memory": "1Gi"
+              },
+              "env": [
+                {
+                  "name": "ASPNETCORE_URLS",
+                  "value": "http://+:5001"
+                },
+                {
+                  "name": "ASPNETCORE_ENVIRONMENT",
+                  "value": "Docker"
+                },
+                {
+                  "name": "ConnectionStrings__DefaultConnection",
+                  "secretRef": "sql-connection-string"
+                },
+                {
+                  "name": "Loki__Url",
+                  "value": "http://loki:3100"
+                },
+                {
+                  "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                  "value": "[parameters('appInsightsConnectionString')]"
+                }
+              ]
+            }
+          ],
+          "scale": {
+            "minReplicas": 1,
+            "maxReplicas": 3
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName'))]",
+        "[resourceId('Microsoft.App/managedEnvironments', format('cae-{0}', parameters('appName')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.App/containerApps",
+      "apiVersion": "2024-03-01",
+      "name": "scramblecoin-web",
+      "location": "[parameters('location')]",
+      "properties": {
+        "managedEnvironmentId": "[resourceId('Microsoft.App/managedEnvironments', format('cae-{0}', parameters('appName')))]",
+        "configuration": {
+          "activeRevisionsMode": "Single",
+          "ingress": {
+            "external": true,
+            "targetPort": 8080,
+            "transport": "http"
+          },
+          "registries": [
+            {
+              "server": "[reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer]",
+              "username": "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').username]",
+              "passwordSecretRef": "acr-password"
+            }
+          ],
+          "secrets": [
+            {
+              "name": "acr-password",
+              "value": "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').passwords[0].value]"
+            },
+            {
+              "name": "sql-connection-string",
+              "value": "[variables('sqlConnectionString')]"
+            }
+          ]
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "scramblecoin-web",
+              "image": "[format('{0}/scramblecoin-web:{1}', reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer, parameters('imageTag'))]",
+              "resources": {
+                "cpu": "[json('0.5')]",
+                "memory": "1Gi"
+              },
+              "env": [
+                {
+                  "name": "ASPNETCORE_URLS",
+                  "value": "http://+:8080"
+                },
+                {
+                  "name": "ASPNETCORE_ENVIRONMENT",
+                  "value": "Production"
+                },
+                {
+                  "name": "ConnectionStrings__DefaultConnection",
+                  "secretRef": "sql-connection-string"
+                },
+                {
+                  "name": "Loki__Url",
+                  "value": "http://loki:3100"
+                }
+              ]
+            }
+          ],
+          "scale": {
+            "minReplicas": 1,
+            "maxReplicas": 3
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName'))]",
+        "[resourceId('Microsoft.App/managedEnvironments', format('cae-{0}', parameters('appName')))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "acrLoginServer": {
+      "type": "string",
+      "metadata": {
+        "description": "ACR login server (e.g. acrscramblecoin.azurecr.io)."
+      },
+      "value": "[reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer]"
+    },
+    "webUrl": {
+      "type": "string",
+      "metadata": {
+        "description": "Public HTTPS URL of the Blazor Web app."
+      },
+      "value": "[format('https://{0}', reference(resourceId('Microsoft.App/containerApps', 'scramblecoin-web'), '2024-03-01').configuration.ingress.fqdn)]"
+    },
+    "apiUrl": {
+      "type": "string",
+      "metadata": {
+        "description": "Public HTTPS URL of the bot REST API."
+      },
+      "value": "[format('https://{0}', reference(resourceId('Microsoft.App/containerApps', 'scramblecoin-api'), '2024-03-01').configuration.ingress.fqdn)]"
+    },
+    "grafanaUrl": {
+      "type": "string",
+      "metadata": {
+        "description": "Public HTTPS URL of Grafana."
+      },
+      "value": "[format('https://{0}', reference(resourceId('Microsoft.App/containerApps', 'grafana'), '2024-03-01').configuration.ingress.fqdn)]"
+    }
+  }
+}

--- a/infra/aca.parameters.json
+++ b/infra/aca.parameters.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appName": {
+      "value": "scramblecoin"
+    },
+    "location": {
+      "value": "swedencentral"
+    },
+    "sqlAdminLogin": {
+      "value": "scrambleadmin"
+    },
+    "sqlAdminPassword": {
+      "value": "REPLACE_WITH_SQL_ADMIN_PASSWORD"
+    },
+    "sqlServerFqdn": {
+      "value": "sql-scramblecoin.database.windows.net"
+    },
+    "grafanaAdminPassword": {
+      "value": "REPLACE_WITH_GRAFANA_ADMIN_PASSWORD"
+    },
+    "imageTag": {
+      "value": "latest"
+    },
+    "acrName": {
+      "value": "acrscramblecoin"
+    },
+    "appInsightsConnectionString": {
+      "value": ""
+    }
+  }
+}

--- a/infra/grafana/Dockerfile
+++ b/infra/grafana/Dockerfile
@@ -1,0 +1,23 @@
+# Custom Grafana image for Azure Container Apps.
+#
+# ACA cannot bind-mount host files, so the datasource + dashboard provisioning
+# is baked into the image. The cloud datasources (provisioning-cloud/) use
+# env-var-driven URLs/secrets (LOKI_URL, PROMETHEUS_URL, AZURE_SQL_*) instead of
+# the docker-compose hostnames used by the local provisioning/ tree (left
+# untouched for local dev). The dashboard JSONs are reused as-is from the local
+# provisioning tree so there is a single source of truth.
+#
+# Build context: infra/grafana
+#   docker build -f infra/grafana/Dockerfile -t grafana infra/grafana
+FROM grafana/grafana:latest
+
+# Cloud datasources + dashboard provider (env-substituted at startup).
+COPY provisioning-cloud/datasources/ /etc/grafana/provisioning/datasources/
+COPY provisioning-cloud/dashboards/dashboards.yaml /etc/grafana/provisioning/dashboards/dashboards.yaml
+
+# Reuse the same dashboard JSONs as local dev (single source of truth).
+COPY provisioning/dashboards/tournament.json /etc/grafana/provisioning/dashboards/tournament.json
+COPY provisioning/dashboards/api-health.json /etc/grafana/provisioning/dashboards/api-health.json
+COPY provisioning/dashboards/logs.json /etc/grafana/provisioning/dashboards/logs.json
+
+EXPOSE 3000

--- a/infra/grafana/provisioning-cloud/dashboards/dashboards.yaml
+++ b/infra/grafana/provisioning-cloud/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+providers:
+  - name: ScrambleCoin
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: false
+    updateIntervalSeconds: 10
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/infra/grafana/provisioning-cloud/datasources/loki.yaml
+++ b/infra/grafana/provisioning-cloud/datasources/loki.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+datasources:
+  - name: ScrambleCoin Loki
+    type: loki
+    access: proxy
+    uid: scramblecoin-loki
+    # Grafana expands ${ENV} in provisioning files at startup. Defaults to the
+    # ACA internal hostname; overridable via the LOKI_URL env on the container.
+    url: ${LOKI_URL:-http://loki:3100}
+    isDefault: false
+    editable: false

--- a/infra/grafana/provisioning-cloud/datasources/loki.yaml
+++ b/infra/grafana/provisioning-cloud/datasources/loki.yaml
@@ -6,6 +6,6 @@ datasources:
     uid: scramblecoin-loki
     # Grafana expands ${ENV} in provisioning files at startup. Defaults to the
     # ACA internal hostname; overridable via the LOKI_URL env on the container.
-    url: ${LOKI_URL:-http://loki:3100}
+    url: ${LOKI_URL}
     isDefault: false
     editable: false

--- a/infra/grafana/provisioning-cloud/datasources/mssql.yaml
+++ b/infra/grafana/provisioning-cloud/datasources/mssql.yaml
@@ -1,0 +1,20 @@
+apiVersion: 1
+datasources:
+  - name: ScrambleCoin SQL Server
+    uid: scramblecoin-mssql
+    type: mssql
+    access: proxy
+    # Azure SQL FQDN + port, e.g. sql-scramblecoin.database.windows.net:1433.
+    # Grafana expands ${ENV} in provisioning files at startup.
+    url: ${AZURE_SQL_HOST}
+    user: ${AZURE_SQL_USER}
+    jsonData:
+      database: ${AZURE_SQL_DB}
+      # Azure SQL requires encrypted connections.
+      encrypt: 'true'
+      maxOpenConns: 5
+      maxIdleConns: 2
+    secureJsonData:
+      password: ${AZURE_SQL_PASSWORD}
+    isDefault: true
+    editable: false

--- a/infra/grafana/provisioning-cloud/datasources/prometheus.yaml
+++ b/infra/grafana/provisioning-cloud/datasources/prometheus.yaml
@@ -6,6 +6,6 @@ datasources:
     uid: scramblecoin-prometheus
     # Grafana expands ${ENV} in provisioning files at startup. Defaults to the
     # ACA internal hostname; overridable via the PROMETHEUS_URL env.
-    url: ${PROMETHEUS_URL:-http://prometheus:9090}
+    url: ${PROMETHEUS_URL}
     isDefault: false
     editable: false

--- a/infra/grafana/provisioning-cloud/datasources/prometheus.yaml
+++ b/infra/grafana/provisioning-cloud/datasources/prometheus.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+datasources:
+  - name: ScrambleCoin Prometheus
+    type: prometheus
+    access: proxy
+    uid: scramblecoin-prometheus
+    # Grafana expands ${ENV} in provisioning files at startup. Defaults to the
+    # ACA internal hostname; overridable via the PROMETHEUS_URL env.
+    url: ${PROMETHEUS_URL:-http://prometheus:9090}
+    isDefault: false
+    editable: false

--- a/infra/grafana/validate_provisioning.py
+++ b/infra/grafana/validate_provisioning.py
@@ -68,6 +68,24 @@ LOKI_DATASOURCE_URL = "http://loki:3100"
 PROMTAIL_PUSH_URL = "http://loki:3100/loki/api/v1/push"
 README_GAMEID_QUERY = '{job="scramblecoin-api"} |= "<GameId>"'
 
+# ---- Issue #132 (Azure Container Apps full-stack deploy) artifacts -----------
+ACA_BICEP = os.path.join(ROOT, "infra", "aca.bicep")
+ACA_PARAMS = os.path.join(ROOT, "infra", "aca.parameters.json")
+PROM_CLOUD_CONFIG = os.path.join(ROOT, "infra", "prometheus", "prometheus.cloud.yml")
+CLOUD_DATASOURCES_DIR = os.path.join(ROOT, "infra", "grafana", "provisioning-cloud", "datasources")
+CLOUD_LOKI_DS = os.path.join(CLOUD_DATASOURCES_DIR, "loki.yaml")
+CLOUD_PROM_DS = os.path.join(CLOUD_DATASOURCES_DIR, "prometheus.yaml")
+CLOUD_MSSQL_DS = os.path.join(CLOUD_DATASOURCES_DIR, "mssql.yaml")
+LOKI_DOCKERFILE = os.path.join(ROOT, "infra", "loki", "Dockerfile")
+PROM_DOCKERFILE = os.path.join(ROOT, "infra", "prometheus", "Dockerfile")
+GRAFANA_DOCKERFILE = os.path.join(ROOT, "infra", "grafana", "Dockerfile")
+WEB_DOCKERFILE = os.path.join(ROOT, "src", "ScrambleCoin.Web", "Dockerfile")
+DEPLOY_ACA_WORKFLOW = os.path.join(ROOT, ".github", "workflows", "deploy-aca.yml")
+ACA_VALIDATE_WORKFLOW = os.path.join(ROOT, ".github", "workflows", "aca-validate.yml")
+
+ACA_CONTAINER_APP_NAMES = ["loki", "prometheus", "grafana", "scramblecoin-api", "scramblecoin-web"]
+CLOUD_MSSQL_UID = "scramblecoin-mssql"
+
 _failures = []
 _checks = 0
 
@@ -456,6 +474,184 @@ def validate_issue_81():
               "paths filter includes 'infra/promtail/**'")
 
 
+def validate_issue_132():
+    """Assert the Azure Container Apps full-stack deploy artifacts (issue #132)."""
+    print("\n== Azure Container Apps deploy validation (issue #132) ==")
+
+    # ---- aca.bicep: resources + container apps --------------------------------
+    print("\ninfra/aca.bicep:")
+    bicep_text = ""
+    if check(os.path.isfile(ACA_BICEP), "aca.bicep exists"):
+        bicep_text = open(ACA_BICEP, "r", encoding="utf-8").read()
+        check("Microsoft.ContainerRegistry/registries" in bicep_text,
+              "aca.bicep declares an ACR (Microsoft.ContainerRegistry/registries)")
+        check("Microsoft.App/managedEnvironments" in bicep_text,
+              "aca.bicep declares a managed environment (Microsoft.App/managedEnvironments)")
+        check("Microsoft.App/containerApps" in bicep_text,
+              "aca.bicep declares container apps (Microsoft.App/containerApps)")
+        for app in ACA_CONTAINER_APP_NAMES:
+            check(f"name: '{app}'" in bicep_text,
+                  f"aca.bicep defines a container app named {app!r}")
+
+        # ---- Critical regression guard: port-less internal service URLs ------
+        # The review-fixed bug was internal URLs carrying the container port
+        # (ACA internal DNS resolves by app name, ingress maps the port).
+        check("'http://loki'" in bicep_text,
+              "aca.bicep uses port-less Loki URL ('http://loki')")
+        check("'http://prometheus'" in bicep_text,
+              "aca.bicep uses port-less Prometheus URL ('http://prometheus')")
+        check("http://loki:3100" not in bicep_text,
+              "aca.bicep does NOT use ported Loki URL ('http://loki:3100') [regression guard]")
+        check("http://prometheus:9090" not in bicep_text,
+              "aca.bicep does NOT use ported Prometheus URL ('http://prometheus:9090') [regression guard]")
+
+    # ---- aca.parameters.json: valid JSON --------------------------------------
+    print("\ninfra/aca.parameters.json:")
+    if check(os.path.isfile(ACA_PARAMS), "aca.parameters.json exists"):
+        try:
+            json.load(open(ACA_PARAMS, "r", encoding="utf-8"))
+            check(True, "aca.parameters.json is valid JSON")
+        except json.JSONDecodeError as exc:
+            check(False, f"aca.parameters.json is valid JSON ({exc})")
+
+    # ---- prometheus.cloud.yml: port-less api scrape target --------------------
+    print("\ninfra/prometheus/prometheus.cloud.yml:")
+    if check(os.path.isfile(PROM_CLOUD_CONFIG), "prometheus.cloud.yml exists"):
+        prom_doc = load_yaml(PROM_CLOUD_CONFIG)
+        prom_text = open(PROM_CLOUD_CONFIG, "r", encoding="utf-8").read()
+        if prom_doc is not None:
+            check(isinstance(prom_doc, dict) and "scrape_configs" in prom_doc,
+                  "prometheus.cloud.yml parses as YAML with 'scrape_configs'")
+            jobs = prom_doc.get("scrape_configs") or []
+            api_job = next((j for j in jobs if j.get("job_name") == "scramblecoin-api"), None)
+            check(api_job is not None,
+                  "prometheus.cloud.yml has a 'scramblecoin-api' scrape job")
+            if api_job is not None:
+                check(api_job.get("metrics_path") == "/metrics",
+                      f"api scrape job metrics_path is '/metrics' (got {api_job.get('metrics_path')!r})")
+                targets = []
+                for sc in (api_job.get("static_configs") or []):
+                    targets.extend(sc.get("targets") or [])
+                check("scramblecoin-api" in targets,
+                      f"api scrape target is port-less 'scramblecoin-api' (got {targets})")
+                check(not any(":" in t for t in targets),
+                      f"api scrape targets carry no port (got {targets})")
+        else:
+            check("job_name: scramblecoin-api" in prom_text,
+                  "prometheus.cloud.yml targets 'scramblecoin-api' (text check)")
+            check("metrics_path: /metrics" in prom_text,
+                  "prometheus.cloud.yml uses metrics_path /metrics (text check)")
+            check("'scramblecoin-api'" in prom_text or "scramblecoin-api']" in prom_text,
+                  "prometheus.cloud.yml scrape target present (text check)")
+
+    # ---- Cloud Grafana datasources -------------------------------------------
+    print("\ninfra/grafana/provisioning-cloud/datasources/:")
+
+    # loki.yaml
+    if check(os.path.isfile(CLOUD_LOKI_DS), "cloud loki.yaml exists"):
+        loki_text = open(CLOUD_LOKI_DS, "r", encoding="utf-8").read()
+        loki_doc = load_yaml(CLOUD_LOKI_DS)
+        if loki_doc is not None:
+            ds0 = (loki_doc.get("datasources") or [{}])[0]
+            check(ds0.get("type") == "loki",
+                  f"cloud loki datasource type is 'loki' (got {ds0.get('type')!r})")
+            check(ds0.get("url") == "${LOKI_URL}",
+                  f"cloud loki datasource url is '${{LOKI_URL}}' (got {ds0.get('url')!r})")
+        else:
+            check("type: loki" in loki_text, "cloud loki type is 'loki' (text check)")
+            check("${LOKI_URL}" in loki_text, "cloud loki url uses ${LOKI_URL} (text check)")
+
+    # prometheus.yaml
+    if check(os.path.isfile(CLOUD_PROM_DS), "cloud prometheus.yaml exists"):
+        prom_ds_text = open(CLOUD_PROM_DS, "r", encoding="utf-8").read()
+        prom_ds_doc = load_yaml(CLOUD_PROM_DS)
+        if prom_ds_doc is not None:
+            ds0 = (prom_ds_doc.get("datasources") or [{}])[0]
+            check(ds0.get("type") == "prometheus",
+                  f"cloud prometheus datasource type is 'prometheus' (got {ds0.get('type')!r})")
+            check(ds0.get("url") == "${PROMETHEUS_URL}",
+                  f"cloud prometheus datasource url is '${{PROMETHEUS_URL}}' (got {ds0.get('url')!r})")
+        else:
+            check("type: prometheus" in prom_ds_text, "cloud prometheus type is 'prometheus' (text check)")
+            check("${PROMETHEUS_URL}" in prom_ds_text, "cloud prometheus url uses ${PROMETHEUS_URL} (text check)")
+
+    # mssql.yaml
+    if check(os.path.isfile(CLOUD_MSSQL_DS), "cloud mssql.yaml exists"):
+        mssql_text = open(CLOUD_MSSQL_DS, "r", encoding="utf-8").read()
+        mssql_doc = load_yaml(CLOUD_MSSQL_DS)
+        if mssql_doc is not None:
+            ds0 = (mssql_doc.get("datasources") or [{}])[0]
+            check(ds0.get("type") == "mssql",
+                  f"cloud mssql datasource type is 'mssql' (got {ds0.get('type')!r})")
+            check(ds0.get("uid") == CLOUD_MSSQL_UID,
+                  f"cloud mssql datasource uid is {CLOUD_MSSQL_UID!r} (got {ds0.get('uid')!r})")
+            check(str(ds0.get("url", "")).startswith("${"),
+                  f"cloud mssql url is env-var-driven (got {ds0.get('url')!r})")
+            check(str(ds0.get("user", "")).startswith("${"),
+                  f"cloud mssql user is env-var-driven (got {ds0.get('user')!r})")
+            pw = ((ds0.get("secureJsonData") or {}).get("password"))
+            check(str(pw or "").startswith("${"),
+                  f"cloud mssql password is env-var-driven (got {pw!r})")
+            encrypt = ((ds0.get("jsonData") or {}).get("encrypt"))
+            check(str(encrypt) == "true",
+                  f"cloud mssql jsonData.encrypt is 'true' (got {encrypt!r})")
+        else:
+            check("type: mssql" in mssql_text, "cloud mssql type is 'mssql' (text check)")
+            check(f"uid: {CLOUD_MSSQL_UID}" in mssql_text, "cloud mssql uid (text check)")
+            check("${AZURE_SQL_HOST}" in mssql_text, "cloud mssql url uses ${AZURE_SQL_HOST} (text check)")
+            check("${AZURE_SQL_USER}" in mssql_text, "cloud mssql user uses ${AZURE_SQL_USER} (text check)")
+            check("${AZURE_SQL_PASSWORD}" in mssql_text, "cloud mssql password uses ${AZURE_SQL_PASSWORD} (text check)")
+            check("encrypt: 'true'" in mssql_text, "cloud mssql encrypt is 'true' (text check)")
+
+    # No hardcoded local hostnames in any cloud datasource.
+    cloud_ds_combined = ""
+    for p in (CLOUD_LOKI_DS, CLOUD_PROM_DS, CLOUD_MSSQL_DS):
+        if os.path.isfile(p):
+            cloud_ds_combined += open(p, "r", encoding="utf-8").read()
+    check("localhost" not in cloud_ds_combined,
+          "no hardcoded 'localhost' in cloud datasources")
+    check("scramblecoin-sqlserver" not in cloud_ds_combined,
+          "no hardcoded 'scramblecoin-sqlserver' hostname in cloud datasources")
+
+    # ---- Config-baking Dockerfiles -------------------------------------------
+    print("\nobservability + web Dockerfiles:")
+    check(os.path.isfile(LOKI_DOCKERFILE), "infra/loki/Dockerfile exists")
+    check(os.path.isfile(PROM_DOCKERFILE), "infra/prometheus/Dockerfile exists")
+    check(os.path.isfile(GRAFANA_DOCKERFILE), "infra/grafana/Dockerfile exists")
+    check(os.path.isfile(WEB_DOCKERFILE), "src/ScrambleCoin.Web/Dockerfile exists")
+
+    # ---- deploy-aca.yml workflow ---------------------------------------------
+    print("\n.github/workflows/deploy-aca.yml:")
+    if check(os.path.isfile(DEPLOY_ACA_WORKFLOW), "deploy-aca.yml exists"):
+        deploy_text = open(DEPLOY_ACA_WORKFLOW, "r", encoding="utf-8").read()
+        deploy_doc = load_yaml(DEPLOY_ACA_WORKFLOW)
+        if deploy_doc is not None:
+            # PyYAML parses the bare `on:` key as boolean True.
+            on_block = deploy_doc.get("on", deploy_doc.get(True))
+            check(isinstance(on_block, dict) and "workflow_dispatch" in on_block,
+                  "deploy-aca.yml is triggered by workflow_dispatch")
+        else:
+            check("workflow_dispatch:" in deploy_text,
+                  "deploy-aca.yml is triggered by workflow_dispatch (text check)")
+        check("az acr build" in deploy_text,
+              "deploy-aca.yml builds images via 'az acr build'")
+        check("dotnet ef database update" in deploy_text,
+              "deploy-aca.yml runs an EF Core migration step")
+
+    # ---- aca-validate.yml CI workflow ----------------------------------------
+    print("\n.github/workflows/aca-validate.yml:")
+    if check(os.path.isfile(ACA_VALIDATE_WORKFLOW), "aca-validate.yml exists"):
+        acaval_text = open(ACA_VALIDATE_WORKFLOW, "r", encoding="utf-8").read()
+        acaval_doc = load_yaml(ACA_VALIDATE_WORKFLOW)
+        check(acaval_doc is not None, "aca-validate.yml is valid YAML")
+        if acaval_doc is not None:
+            on_block = acaval_doc.get("on", acaval_doc.get(True))
+            check(isinstance(on_block, dict) and "pull_request" in on_block,
+                  "aca-validate.yml is triggered on pull_request")
+        check("az bicep build" in acaval_text,
+              "aca-validate.yml runs 'az bicep build'")
+
+
 def main():
     print("== tournament dashboard provisioning validation (issue #79) ==\n")
 
@@ -572,6 +768,9 @@ def main():
 
     # ---- Issue #81: Loki + Promtail log aggregation --------------------------
     validate_issue_81()
+
+    # ---- Issue #132: Azure Container Apps full-stack deploy ------------------
+    validate_issue_132()
 
     # ---- Summary -------------------------------------------------------------
     print("\n" + "=" * 60)

--- a/infra/loki/Dockerfile
+++ b/infra/loki/Dockerfile
@@ -1,0 +1,14 @@
+# Custom Loki image for Azure Container Apps.
+#
+# ACA cannot bind-mount host files, so observability services ship as custom
+# images. Loki's stock image already bundles a sensible single-instance config
+# at /etc/loki/local-config.yaml that writes to ephemeral local storage — which
+# is exactly what we want for a one-day event (data is lost on restart, per the
+# agreed design). We therefore keep the default ENTRYPOINT/config and only pin
+# the base image so the build/push pipeline is uniform with the other services.
+#
+# Build context: infra/loki
+#   docker build -f infra/loki/Dockerfile -t loki infra/loki
+FROM grafana/loki:latest
+
+EXPOSE 3100

--- a/infra/prometheus/Dockerfile
+++ b/infra/prometheus/Dockerfile
@@ -1,0 +1,14 @@
+# Custom Prometheus image for Azure Container Apps.
+#
+# ACA cannot bind-mount host files, so the cloud scrape config is baked into the
+# image. This config (prometheus.cloud.yml) targets the API at its ACA internal
+# hostname (scramblecoin-api:5001) instead of the docker-compose hostnames used
+# by the local infra/prometheus.yml (which is left untouched for local dev).
+#
+# Build context: infra/prometheus
+#   docker build -f infra/prometheus/Dockerfile -t prometheus infra/prometheus
+FROM prom/prometheus:latest
+
+COPY prometheus.cloud.yml /etc/prometheus/prometheus.yml
+
+EXPOSE 9090

--- a/infra/prometheus/prometheus.cloud.yml
+++ b/infra/prometheus/prometheus.cloud.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: scramblecoin-api
+    metrics_path: /metrics
+    static_configs:
+      # ACA internal service-to-service DNS resolves Container Apps by name.
+      # The API Container App is named "scramblecoin-api" and exposes its
+      # Prometheus metrics on its targetPort 5001.
+      - targets: ['scramblecoin-api:5001']
+        labels: { source: 'aca' }

--- a/infra/prometheus/prometheus.cloud.yml
+++ b/infra/prometheus/prometheus.cloud.yml
@@ -9,5 +9,5 @@ scrape_configs:
       # ACA internal service-to-service DNS resolves Container Apps by name.
       # The API Container App is named "scramblecoin-api" and exposes its
       # Prometheus metrics on its targetPort 5001.
-      - targets: ['scramblecoin-api:5001']
+      - targets: ['scramblecoin-api']
         labels: { source: 'aca' }

--- a/src/ScrambleCoin.Api/Program.cs
+++ b/src/ScrambleCoin.Api/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.OpenApi.Models;
 using Prometheus;
 using Serilog;
 using Serilog.Events;
+using Serilog.Sinks.Grafana.Loki;
 using ScrambleCoin.Application.BotRegistration;
 using ScrambleCoin.Application.Interfaces;
 using ScrambleCoin.Application.Services;
@@ -35,6 +36,20 @@ builder.Host.UseSerilog((context, services, configuration) =>
         configuration.WriteTo.ApplicationInsights(
             aiConnectionString,
             TelemetryConverter.Traces);
+    }
+
+    // Grafana Loki push sink — only active in the cloud (ACA) where Loki__Url is set.
+    // Local docker compose keeps using Promtail file-tailing (Loki__Url unset).
+    var lokiUrl = Environment.GetEnvironmentVariable("Loki__Url");
+    if (!string.IsNullOrWhiteSpace(lokiUrl))
+    {
+        configuration.WriteTo.GrafanaLoki(
+            lokiUrl,
+            labels: new[]
+            {
+                new Serilog.Sinks.Grafana.Loki.LokiLabel { Key = "app", Value = "scramblecoin-api" }
+            },
+            propertiesAsLabels: new[] { "level" });
     }
 });
 

--- a/src/ScrambleCoin.Api/ScrambleCoin.Api.csproj
+++ b/src/ScrambleCoin.Api/ScrambleCoin.Api.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.*" />
   </ItemGroup>
 

--- a/src/ScrambleCoin.Web/Dockerfile
+++ b/src/ScrambleCoin.Web/Dockerfile
@@ -1,0 +1,26 @@
+# Multi-stage build for ScrambleCoin.Web (Blazor Server).
+# Build context MUST be the repository root (it needs sibling projects).
+#   docker build -f src/ScrambleCoin.Web/Dockerfile -t scramblecoin-web .
+
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+# Restore first (better layer caching): copy the solution + all csproj files.
+COPY ScrambleCoin.sln ./
+COPY global.json ./
+COPY src/ScrambleCoin.Domain/ScrambleCoin.Domain.csproj src/ScrambleCoin.Domain/
+COPY src/ScrambleCoin.Application/ScrambleCoin.Application.csproj src/ScrambleCoin.Application/
+COPY src/ScrambleCoin.Infrastructure/ScrambleCoin.Infrastructure.csproj src/ScrambleCoin.Infrastructure/
+COPY src/ScrambleCoin.Web/ScrambleCoin.Web.csproj src/ScrambleCoin.Web/
+RUN dotnet restore src/ScrambleCoin.Web/ScrambleCoin.Web.csproj
+
+# Copy the rest of the source and publish.
+COPY . .
+RUN dotnet publish src/ScrambleCoin.Web/ScrambleCoin.Web.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish ./
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://+:8080
+ENTRYPOINT ["dotnet", "ScrambleCoin.Web.dll"]

--- a/src/ScrambleCoin.Web/Program.cs
+++ b/src/ScrambleCoin.Web/Program.cs
@@ -8,6 +8,7 @@ using ScrambleCoin.Infrastructure.Persistence;
 using ScrambleCoin.Web.Hubs;
 using Serilog;
 using Serilog.Events;
+using Serilog.Sinks.Grafana.Loki;
 
 // ── Serilog bootstrap logger (catches startup errors) ────────────────────────
 Log.Logger = new LoggerConfiguration()
@@ -37,6 +38,20 @@ try
                 path: "logs/scramblecoin-web-.log",
                 rollingInterval: RollingInterval.Day,
                 retainedFileCountLimit: 7);
+
+        // Grafana Loki push sink — only active in the cloud (ACA) where Loki__Url is set.
+        // Local docker compose keeps using Promtail file-tailing (Loki__Url unset).
+        var lokiUrl = Environment.GetEnvironmentVariable("Loki__Url");
+        if (!string.IsNullOrWhiteSpace(lokiUrl))
+        {
+            configuration.WriteTo.GrafanaLoki(
+                lokiUrl,
+                labels: new[]
+                {
+                    new Serilog.Sinks.Grafana.Loki.LokiLabel { Key = "app", Value = "scramblecoin-web" }
+                },
+                propertiesAsLabels: new[] { "level" });
+        }
     });
 
     // ── Blazor Server ─────────────────────────────────────────────────────────

--- a/src/ScrambleCoin.Web/ScrambleCoin.Web.csproj
+++ b/src/ScrambleCoin.Web/ScrambleCoin.Web.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.3.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
Closes #132. Deploys the **entire ScrambleCoin stack** (Blazor Web + bot API + Grafana + Loki + Prometheus) to **Azure Container Apps**, so the app is publicly reachable for the event with the observability dashboards running alongside it.

> **Stacked on #131** (Loki+Promtail, base `feature/issue-81-loki-promtail`). Merge #131 first, then this. Retarget to `milestone/logging` once #131 lands.

> **Note:** the actual `az` deploy is run by the maintainer — this PR delivers the IaC, deploy workflow, app changes, and runbook. All locally validated (`az bicep build`, `dotnet build`, validator); no live Azure deploy was performed from CI.

## Changes
- `infra/aca.bicep` (+`aca.parameters.json`): ACR, Log Analytics, a Container Apps Environment, and 5 Container Apps (`web`/`api`/`grafana` external HTTPS; `loki`/`prometheus` internal). Reuses the Azure SQL from `main.bicep`. Secrets wired as ACA `secrets` (`secretRef`), ACR pull via admin creds.
- `src/ScrambleCoin.Web/Dockerfile`: new multi-stage image (mirrors the API Dockerfile, listens on :8080).
- `infra/{loki,prometheus,grafana}/Dockerfile` + `infra/prometheus/prometheus.cloud.yml` + `infra/grafana/provisioning-cloud/**`: config baked into custom images (ACA can't bind-mount); cloud Grafana datasources are env-var-driven (Loki/Prometheus/Azure SQL).
- `src/ScrambleCoin.Api/Program.cs` + `src/ScrambleCoin.Web/Program.cs` (+ `Serilog.Sinks.Grafana.Loki` pkg): **conditional** Loki push sink, active only when `Loki__Url` is set — local docker-compose/Promtail (#81) is unchanged.
- `.github/workflows/deploy-aca.yml`: `workflow_dispatch` deploy — login → ensure ACR → `az acr build` ×5 → bicep deploy → EF migrations → echo URLs.
- `.github/workflows/aca-validate.yml`: PR validation (`az bicep build` + `dotnet build`).
- `infra/grafana/validate_provisioning.py`: extended with the #132 section (91 → **139 checks**), incl. a port-less-internal-URL regression guard.
- `infra/README.md`: appended the ACA deploy runbook.

## Key design decisions (confirmed with maintainer)
- ACA managed containers (not a VM); ACR admin auth; ephemeral Loki/Prometheus storage; Azure SQL reused.
- Cloud logs via the Loki Serilog sink (Promtail dropped in cloud only); internal ACA URLs are **port-less** (apps talk by name over port 80).
- API container runs `ASPNETCORE_ENVIRONMENT=Docker` so `/metrics` stays exposed for Prometheus.

## Testing
- Unit tests: 0 (infra/deploy-only; conditional sink is compile-checked by `aca-validate.yml`).
- Structural validation: infra validator **91 → 139 checks**, all green; `az bicep build` exit 0; both app projects build; local `docker compose config -q` still resolves.
- A manual **deploy** runbook is posted on #132 (requires an Azure subscription to execute).

## Review cycles
- Implementation: 1 cycle (fixed: port-less ACA internal URLs)
- Tests: 0 cycles

## Version bump
minor (labels: infra, feature)
